### PR TITLE
Add age input flow and home page

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -40,3 +40,22 @@
 .read-the-docs {
   color: #888;
 }
+
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.game-card {
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  text-decoration: none;
+  display: block;
+}
+
+.progress-summary {
+  margin-top: 1rem;
+}

--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import Home from './pages/Home'
+import AgeInputForm from './pages/AgeInputForm'
 import Match3Game from './pages/Match3Game'
 import QuizGame from './pages/QuizGame'
 import DragDropGame from './pages/DragDropGame'
@@ -14,11 +15,12 @@ function App() {
           <li><Link to="/">Home</Link></li>
           <li><Link to="/games/match3">Match-3</Link></li>
           <li><Link to="/games/quiz">Quiz</Link></li>
-          <li><Link to="/games/dragdrop">Drag & Drop</Link></li>
-          <li><Link to="/leaderboard">Leaderboard</Link></li>
-        </ul>
+        <li><Link to="/games/dragdrop">Drag & Drop</Link></li>
+        <li><Link to="/leaderboard">Leaderboard</Link></li>
+      </ul>
       </nav>
       <Routes>
+        <Route path="/age" element={<AgeInputForm />} />
         <Route path="/" element={<Home />} />
         <Route path="/games/match3" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />

--- a/learning-games/src/context/UserContext.tsx
+++ b/learning-games/src/context/UserContext.tsx
@@ -8,16 +8,24 @@ const defaultUser: UserData = {
   badges: [],
 }
 
+// UserContext stores the entire profile including age. The age value lets
+// games adjust difficulty and content for the appropriate age group.
 export const UserContext = createContext<UserContextType>({
   user: defaultUser,
   setUser: () => {},
+  setAge: () => {},
 })
 
 export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<UserData>(defaultUser)
 
+  // Helper to set only the age field without overwriting other user data
+  const setAge = (age: number) => {
+    setUser((prev) => ({ ...prev, age }))
+  }
+
   return (
-    <UserContext.Provider value={{ user, setUser }}>
+    <UserContext.Provider value={{ user, setUser, setAge }}>
       {children}
     </UserContext.Provider>
   )

--- a/learning-games/src/pages/AgeInputForm.tsx
+++ b/learning-games/src/pages/AgeInputForm.tsx
@@ -1,0 +1,46 @@
+import { useContext, useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { UserContext } from '../context/UserContext'
+
+/**
+ * Form for collecting the user's age. Age is stored in context
+ * and later used to customize game content by age group.
+ */
+export default function AgeInputForm() {
+  const { user, setAge } = useContext(UserContext)
+  const [age, setAgeState] = useState<number | ''>(user.age ?? '')
+  const navigate = useNavigate()
+
+  // If age already exists, go straight to the game selection page
+  useEffect(() => {
+    if (user.age) navigate('/')
+  }, [user.age, navigate])
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const ageNumber = Number(age)
+    if (ageNumber >= 12 && ageNumber <= 18) {
+      setAge(ageNumber)
+      navigate('/')
+    } else {
+      alert('Age must be between 12 and 18')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label htmlFor="age">Enter your age:</label>
+      <input
+        id="age"
+        type="number"
+        min={12}
+        max={18}
+        value={age}
+        onChange={(e) => setAgeState(Number(e.target.value))}
+        required
+      />
+      <button type="submit">Save Age</button>
+    </form>
+  )
+}

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -1,3 +1,48 @@
+import { useContext, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { UserContext } from '../context/UserContext'
+
+/**
+ * Home page listing available games.
+ * If the user's age isn't known we send them to the age input form first.
+ */
 export default function Home() {
-  return <h2>Home Page</h2>
+  const { user } = useContext(UserContext)
+  const navigate = useNavigate()
+
+  // Redirect to the age form if age hasn't been provided yet
+  useEffect(() => {
+    if (user.age === null) {
+      navigate('/age')
+    }
+  }, [user.age, navigate])
+
+  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+
+  return (
+    <div className="home">
+      {/* greeting */}
+      {user.age && <h2>Welcome! Age group: {user.age}</h2>}
+
+      {/* game list */}
+      <div className="game-grid">
+        <Link className="game-card" to="/games/match3">Match-3 Puzzle</Link>
+        <Link className="game-card" to="/games/quiz">Quiz Game</Link>
+        <Link className="game-card" to="/games/dragdrop">Drag & Drop Game</Link>
+      </div>
+
+      {/* navigation */}
+      <p>
+        <Link to="/leaderboard">View Leaderboard</Link>
+      </p>
+
+      {/* progress summary */}
+      {totalPoints > 0 && (
+        <div className="progress-summary">
+          <p>Total Points: {totalPoints}</p>
+          <p>Badges Earned: {user.badges.length}</p>
+        </div>
+      )}
+    </div>
+  )
 }

--- a/learning-games/src/types/user.ts
+++ b/learning-games/src/types/user.ts
@@ -7,4 +7,9 @@ export interface UserData {
 export interface UserContextType {
   user: UserData
   setUser: (user: UserData) => void
+  /**
+   * Update only the age field of the user. Games read this to tailor
+   * content difficulty and themes.
+   */
+  setAge: (age: number) => void
 }


### PR DESCRIPTION
## Summary
- extend `UserContext` with `setAge`
- add an age entry form component
- implement redirected Home page with game list and progress summary
- style game cards and progress section
- wire `/age` route in router

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840b6b84ee0832fa3e38ae63798b613