### PR TITLE
Implement splash page and user name

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import Home from './pages/Home'
 import AgeInputForm from './pages/AgeInputForm'
+import SplashPage from './pages/SplashPage'
 import Match3Game from './pages/Match3Game'
 import QuizGame from './pages/QuizGame'
 import DragDropGame from './pages/DragDropGame'
@@ -12,7 +13,7 @@ function App() {
     <Router>
       <nav>
         <ul>
-          <li><Link to="/">Home</Link></li>
+          <li><Link to="/home">Home</Link></li>
           <li><Link to="/games/match3">Match-3</Link></li>
           <li><Link to="/games/quiz">Quiz</Link></li>
         <li><Link to="/games/dragdrop">Drag & Drop</Link></li>
@@ -21,7 +22,8 @@ function App() {
       </nav>
       <Routes>
         <Route path="/age" element={<AgeInputForm />} />
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<SplashPage />} />
+        <Route path="/home" element={<Home />} />
         <Route path="/games/match3" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />
         <Route path="/games/dragdrop" element={<DragDropGame />} />

--- a/learning-games/src/components/ui/card.tsx
+++ b/learning-games/src/components/ui/card.tsx
@@ -3,11 +3,22 @@ import React from 'react';
 export interface CardProps {
   children: React.ReactNode;
   className?: string;
+  onClick?: () => void;
 }
 
-const Card: React.FC<CardProps> = ({ children, className = '' }) => {
+const Card: React.FC<CardProps> = ({ children, className = '', onClick }) => {
   return (
-    <div className={`card ${className}`} style={{ padding: '1rem', border: '1px solid #eee', borderRadius: '8px', background: '#fff', boxShadow: '0 2px 8px rgba(0,0,0,0.05)' }}>
+    <div
+      className={`card ${className}`}
+      onClick={onClick}
+      style={{
+        padding: '1rem',
+        border: '1px solid #eee',
+        borderRadius: '8px',
+        background: '#fff',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+      }}
+    >
       {children}
     </div>
   );

--- a/learning-games/src/context/UserContext.tsx
+++ b/learning-games/src/context/UserContext.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import type { UserData, UserContextType } from '../types/user'
 
 const defaultUser: UserData = {
+  name: null,
   age: null,
   scores: {},
   badges: [],
@@ -14,6 +15,7 @@ export const UserContext = createContext<UserContextType>({
   user: defaultUser,
   setUser: () => {},
   setAge: () => {},
+  setName: () => {},
 })
 
 export function UserProvider({ children }: { children: ReactNode }) {
@@ -24,8 +26,12 @@ export function UserProvider({ children }: { children: ReactNode }) {
     setUser((prev) => ({ ...prev, age }))
   }
 
+  const setName = (name: string) => {
+    setUser((prev) => ({ ...prev, name }))
+  }
+
   return (
-    <UserContext.Provider value={{ user, setUser, setAge }}>
+    <UserContext.Provider value={{ user, setUser, setAge, setName }}>
       {children}
     </UserContext.Provider>
   )

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -22,7 +22,11 @@ export default function Home() {
   return (
     <div className="home">
       {/* greeting */}
-      {user.age && <h2>Welcome! Age group: {user.age}</h2>}
+      {user.age && (
+        <h2>
+          Welcome{user.name ? `, ${user.name}` : ''}! Age group: {user.age}
+        </h2>
+      )}
 
       {/* game list */}
       <div className="game-grid">

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
+import { useState } from 'react'
+import { Card, CardContent } from '../components/ui/card'
 import { toast } from 'react-hot-toast';
 
 const toneFlavors = [
@@ -9,13 +9,21 @@ const toneFlavors = [
   { type: 'zesty', label: 'lively', emoji: '🍋', points: 7 }
 ];
 
-const generateTile = (id) => {
+interface Tile {
+  type: string
+  label: string
+  emoji: string
+  points: number
+  id: number
+}
+
+const generateTile = (id: number): Tile => {
   const flavor = toneFlavors[Math.floor(Math.random() * toneFlavors.length)];
   return { ...flavor, id };
 };
 
-const generateGrid = () => {
-  const grid = [];
+const generateGrid = (): Tile[] => {
+  const grid: Tile[] = [];
   for (let i = 0; i < 36; i++) {
     grid.push(generateTile(i));
   }
@@ -23,11 +31,11 @@ const generateGrid = () => {
 };
 
 const Match3PromptTuner = () => {
-  const [grid, setGrid] = useState(generateGrid());
-  const [selected, setSelected] = useState(null);
+  const [grid, setGrid] = useState<Tile[]>(generateGrid());
+  const [selected, setSelected] = useState<number | null>(null);
   const [score, setScore] = useState(0);
 
-  const handleClick = (index) => {
+  const handleClick = (index: number) => {
     if (selected === null) {
       setSelected(index);
     } else {
@@ -45,8 +53,8 @@ const Match3PromptTuner = () => {
     }
   };
 
-  const checkMatches = (grid) => {
-    let matchedIndices = new Set();
+  const checkMatches = (grid: Tile[]) => {
+    const matchedIndices = new Set<number>();
 
     // Check rows
     for (let i = 0; i < 36; i += 6) {

--- a/learning-games/src/pages/SplashPage.css
+++ b/learning-games/src/pages/SplashPage.css
@@ -1,0 +1,31 @@
+.splash-container {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  color: #fff;
+  text-align: center;
+}
+
+.bg-video {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: brightness(0.6);
+}
+
+.overlay {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.start-form input {
+  margin: 0.5rem;
+  padding: 0.5rem;
+}
+
+.start-form button {
+  margin-top: 1rem;
+}

--- a/learning-games/src/pages/SplashPage.tsx
+++ b/learning-games/src/pages/SplashPage.tsx
@@ -1,0 +1,59 @@
+import { useContext, useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { UserContext } from '../context/UserContext'
+import './SplashPage.css'
+
+export default function SplashPage() {
+  const { user, setUser } = useContext(UserContext)
+  const [name, setName] = useState(user.name ?? '')
+  const [age, setAge] = useState<number | ''>(user.age ?? '')
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (user.age) {
+      navigate('/games/match3')
+    }
+  }, [user.age, navigate])
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const ageNum = Number(age)
+    if (ageNum < 12 || ageNum > 18) {
+      alert('Age must be between 12 and 18')
+      return
+    }
+    setUser({ ...user, name, age: ageNum })
+    navigate('/games/match3')
+  }
+
+  return (
+    <div className="splash-container">
+      <video autoPlay loop muted className="bg-video">
+        <source src="/welcome.mp4" type="video/mp4" />
+      </video>
+      <div className="overlay">
+        <h1>Welcome to StrawberryTech! 🍓</h1>
+        <p>Play while you learn.</p>
+        <form onSubmit={handleSubmit} className="start-form">
+          <input
+            type="text"
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            type="number"
+            min={12}
+            max={18}
+            placeholder="Age"
+            value={age}
+            onChange={(e) => setAge(Number(e.target.value))}
+            required
+          />
+          <button type="submit">Start Playing</button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/learning-games/src/types/user.ts
+++ b/learning-games/src/types/user.ts
@@ -1,4 +1,6 @@
 export interface UserData {
+  /** User's name for personalized greetings */
+  name: string | null
   age: number | null
   scores: Record<string, number>
   badges: string[]
@@ -12,4 +14,8 @@ export interface UserContextType {
    * content difficulty and themes.
    */
   setAge: (age: number) => void
+  /**
+   * Update only the name field of the user.
+   */
+  setName: (name: string) => void
 }


### PR DESCRIPTION
## Summary
- add `SplashPage` capturing name and age with video background
- route `/` to `SplashPage`
- support storing user name in context
- update `Home` greeting and card component
- type and import fixes for match-3 game

## Testing
- `npm run build`
- `npm run lint`
- `npm run dev` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce0b548c832f936db2e67ef51e84