### PR TITLE
Add user progress persistence and leaderboard

### DIFF
--- a/learning-games/src/context/UserContext.tsx
+++ b/learning-games/src/context/UserContext.tsx
@@ -1,6 +1,10 @@
-import { createContext, useState } from 'react'
+import { createContext, useState, useCallback, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import type { UserData, UserContextType } from '../types/user'
+
+// All progress is stored under this key in localStorage so it persists across
+// sessions. Whenever the user object changes we throttle a save to this key.
+const STORAGE_KEY = 'strawberrytech_user'
 
 const defaultUser: UserData = {
   name: null,
@@ -16,41 +20,58 @@ export const UserContext = createContext<UserContextType>({
   setUser: () => {},
   setAge: () => {},
   setName: () => {},
-  addPoints: () => {},
+  setScore: () => {},
   addBadge: () => {},
 })
 
 export function UserProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<UserData>(defaultUser)
+  // Load any saved user progress from localStorage on first render
+  const [user, setUser] = useState<UserData>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    return saved ? { ...defaultUser, ...JSON.parse(saved) } : defaultUser
+  })
 
-  // Helper to set only the age field without overwriting other user data
-  const setAge = (age: number) => {
+
+  // Helper to set only the age field without overwriting other user data.
+  const setAge = useCallback((age: number) => {
     setUser((prev) => ({ ...prev, age }))
-  }
+  }, [])
 
-  const setName = (name: string) => {
+  const setName = useCallback((name: string) => {
     setUser((prev) => ({ ...prev, name }))
-  }
+  }, [])
 
-  // Increase the score for a specific game by the given amount
-  const addPoints = (game: string, points: number) => {
+  // Record the best score for a specific game
+  const setScore = useCallback((game: string, score: number) => {
     setUser((prev) => ({
       ...prev,
-      scores: { ...prev.scores, [game]: (prev.scores[game] ?? 0) + points },
+      scores: {
+        ...prev.scores,
+        [game]: Math.max(score, prev.scores[game] ?? 0),
+      },
     }))
-  }
+  }, [])
 
   // Award a badge for achievements or milestones
-  const addBadge = (badge: string) => {
+  const addBadge = useCallback((badge: string) => {
     setUser((prev) => ({
       ...prev,
-      badges: [...prev.badges, badge],
+      badges: prev.badges.includes(badge) ? prev.badges : [...prev.badges, badge],
     }))
-  }
+  }, [])
+
+  // Persist user progress to localStorage whenever it changes. The timeout acts
+  // like a simple debounce so rapid state updates don't spam localStorage.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+    }, 300)
+    return () => clearTimeout(handle)
+  }, [user])
 
   return (
     <UserContext.Provider
-      value={{ user, setUser, setAge, setName, addPoints, addBadge }}
+      value={{ user, setUser, setAge, setName, setScore, addBadge }}
     >
       {children}
     </UserContext.Provider>

--- a/learning-games/src/data/badges.ts
+++ b/learning-games/src/data/badges.ts
@@ -1,0 +1,24 @@
+export interface BadgeDefinition {
+  id: string
+  name: string
+  description: string
+}
+
+/** List of all possible badges and their criteria descriptions. */
+export const BADGES: BadgeDefinition[] = [
+  {
+    id: 'first-match3',
+    name: 'First Match-3 Complete',
+    description: 'Finish a Match-3 game once',
+  },
+  {
+    id: 'match-master',
+    name: 'Match-3 Master',
+    description: 'Score at least 100 points in Match-3',
+  },
+  {
+    id: 'quiz-whiz',
+    name: 'Quiz Whiz',
+    description: 'Get a perfect score on any quiz',
+  },
+]

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -1,3 +1,80 @@
+import { useContext } from 'react'
+import { Link } from 'react-router-dom'
+import { UserContext } from '../context/UserContext'
+import { BADGES } from '../data/badges'
+
+export interface ScoreEntry {
+  name: string
+  score: number
+}
+
+// Dummy leaderboards for each game. In a real multi-user app this data would
+// be fetched from a server.
+const DUMMY_SCORES: Record<string, ScoreEntry[]> = {
+  match3: [
+    { name: 'Alice', score: 240 },
+    { name: 'Bob', score: 180 },
+    { name: 'Charlie', score: 150 },
+  ],
+}
+
 export default function LeaderboardPage() {
-  return <h2>Leaderboard Coming Soon</h2>
+  const { user } = useContext(UserContext)
+
+  return (
+    <div>
+      <h2>Leaderboard</h2>
+      {/* Show top scores for Match-3 */}
+      <section>
+        <h3>Match-3 High Scores</h3>
+        <table style={{ margin: '0 auto' }}>
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th>Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {DUMMY_SCORES.match3
+              .concat({ name: user.name ?? 'You', score: user.scores['match3'] ?? 0 })
+              .sort((a, b) => b.score - a.score)
+              .slice(0, 5)
+              .map((entry) => (
+                <tr
+                  key={entry.name}
+                  style={{
+                    fontWeight:
+                      user.name && entry.name === user.name ? 'bold' : undefined,
+                  }}
+                >
+                  <td>{entry.name}</td>
+                  <td>{entry.score}</td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </section>
+
+      {/* Badges */}
+      <section style={{ marginTop: '2rem' }}>
+        <h3>Badges Earned</h3>
+        {user.badges.length === 0 && <p>No badges yet.</p>}
+        <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: '0.5rem' }}>
+          {user.badges.map((id) => {
+            const def = BADGES.find((b) => b.id === id)
+            return (
+              <li key={id} style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
+                <strong>{def?.name ?? id}</strong>
+                <div style={{ fontSize: '0.9em' }}>{def?.description}</div>
+              </li>
+            )
+          })}
+        </ul>
+      </section>
+
+      <p style={{ marginTop: '2rem' }}>
+        <Link to="/">Return Home</Link>
+      </p>
+    </div>
+  )
 }

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -35,7 +35,7 @@ const tips = [
  * show an age-based leadership tip.
  */
 export default function Match3Game() {
-  const { user, addPoints, addBadge } = useContext(UserContext)
+  const { user, setScore: saveScore, addBadge } = useContext(UserContext)
   const [grid, setGrid] = useState<(Tile | null)[]>(createGrid())
   const [selected, setSelected] = useState<number | null>(null)
   const [score, setScore] = useState(0)
@@ -126,17 +126,20 @@ export default function Match3Game() {
 
     const gained = matched.size * 10
     setScore((s) => s + gained)
-    addPoints('match3', gained)
     setGrid(working)
     if (ageTips && Math.random() < 0.3) {
       toast(ageTips[Math.floor(Math.random() * ageTips.length)])
     }
   }
 
-  // Award badge when game ends
+  // Award badges and store the best score when the game ends
   function endGame() {
-    if (score >= 100 && !user.badges.includes('Match Master')) {
-      addBadge('Match Master')
+    saveScore('match3', score)
+    if (score >= 100 && !user.badges.includes('match-master')) {
+      addBadge('match-master')
+    }
+    if (!user.badges.includes('first-match3')) {
+      addBadge('first-match3')
     }
     toast(`Game over! Final score: ${score}`)
   }

--- a/learning-games/src/types/user.ts
+++ b/learning-games/src/types/user.ts
@@ -19,10 +19,10 @@ export interface UserContextType {
    */
   setName: (name: string) => void
   /**
-   * Add points to the user's score record for a given game.
-   * Used by games to track progress across sessions.
+   * Set the score for a specific game. Implementations typically
+   * store the best/highest score seen so far.
    */
-  addPoints: (game: string, points: number) => void
+  setScore: (game: string, score: number) => void
   /**
    * Award a badge when the player reaches a milestone.
    */


### PR DESCRIPTION
## Summary
- persist user data in localStorage via `UserContext`
- define badge metadata and update Match3 game to award them
- implement a leaderboard page that shows high scores and badges
- track best scores with new `setScore` helper

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841813a7d20832f96d5453ee2cf94ce