### PR TITLE
Fix AgeInputForm blank input handling

### DIFF
--- a/learning-games/src/pages/AgeInputForm.tsx
+++ b/learning-games/src/pages/AgeInputForm.tsx
@@ -37,7 +37,10 @@ export default function AgeInputForm() {
         min={12}
         max={18}
         value={age}
-        onChange={(e) => setAgeState(Number(e.target.value))}
+        onChange={(e) => {
+          const { value } = e.target
+          setAgeState(value === '' ? '' : Number(value))
+        }}
         required
       />
       <button type="submit">Save Age</button>


### PR DESCRIPTION
## Summary
- support empty value in age input

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684183fa65e4832f80e491e7928484b5