### PR TITLE
Improve endgame trigger in match3

### DIFF
--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useState, useEffect } from 'react'
 import Card, { CardContent } from '../components/ui/card'
 import { UserContext } from '../context/UserContext'
 import { toast } from 'react-hot-toast'
@@ -144,9 +144,11 @@ export default function Match3Game() {
     toast(`Game over! Final score: ${score}`)
   }
 
-  if (moves === 0) {
-    endGame()
-  }
+  useEffect(() => {
+    if (moves === 0) {
+      endGame()
+    }
+  }, [moves])
 
   return (
     <div className="match3-container">


### PR DESCRIPTION
## Summary
- use `useEffect` in Match3Game to trigger end of game when moves reach 0

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841858f241c832f9002c6dad36ac7d8