### PR TITLE
Fix react-refresh warning by isolating UserContext

### DIFF
--- a/learning-games/src/context/UserContext.ts
+++ b/learning-games/src/context/UserContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react'
+import type { UserData, UserContextType } from '../types/user'
+
+export const defaultUser: UserData = {
+  name: null,
+  age: null,
+  scores: {},
+  badges: [],
+}
+
+export const UserContext = createContext<UserContextType>({
+  user: defaultUser,
+  setUser: () => {},
+  setAge: () => {},
+  setName: () => {},
+  setScore: () => {},
+  addBadge: () => {},
+})

--- a/learning-games/src/context/UserProvider.tsx
+++ b/learning-games/src/context/UserProvider.tsx
@@ -1,28 +1,12 @@
-import { createContext, useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import type { ReactNode } from 'react'
-import type { UserData, UserContextType } from '../types/user'
+import type { UserData } from '../types/user'
+import { UserContext, defaultUser } from './UserContext'
 
 // All progress is stored under this key in localStorage so it persists across
 // sessions. Whenever the user object changes we throttle a save to this key.
 const STORAGE_KEY = 'strawberrytech_user'
 
-const defaultUser: UserData = {
-  name: null,
-  age: null,
-  scores: {},
-  badges: [],
-}
-
-// UserContext stores the entire profile including age. The age value lets
-// games adjust difficulty and content for the appropriate age group.
-export const UserContext = createContext<UserContextType>({
-  user: defaultUser,
-  setUser: () => {},
-  setAge: () => {},
-  setName: () => {},
-  setScore: () => {},
-  addBadge: () => {},
-})
 
 export function UserProvider({ children }: { children: ReactNode }) {
   // Load any saved user progress from localStorage on first render

--- a/learning-games/src/main.tsx
+++ b/learning-games/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './index.css'
-import { UserProvider } from './context/UserContext'
+import { UserProvider } from './context/UserProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- split `UserContext` initialization into its own module
- move provider component to `UserProvider.tsx`
- update references to `UserProvider`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841879c2528832fa5e3d0017944c5b3