### PR TITLE
Enhance home UI with hero and vibrant palette

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -50,10 +50,15 @@
 
 .game-card {
   padding: 1rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-purple);
   border-radius: 8px;
   text-decoration: none;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
 .progress-summary {
@@ -83,5 +88,61 @@
 
 .match3-tile.selected {
   outline: 3px solid #0070f3;
+}
+
+/* layout */
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--color-purple);
+  padding: 0.5rem 1rem;
+  color: #fff;
+}
+
+.navbar ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar a {
+  color: #fff;
+}
+
+.navbar a:hover {
+  color: var(--color-lime);
+}
+
+.hero {
+  background: var(--color-orange);
+  color: #fff;
+  padding: 2rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+}
+
+.hero button {
+  background: var(--color-purple);
+  color: #fff;
+  border: none;
+}
+
+.hero button:hover {
+  background: var(--color-lime);
+}
+
+.game-icon {
+  font-size: 2rem;
+}
+
+.footer {
+  background: var(--color-purple);
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+  margin-top: 2rem;
 }
 

--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
 import AgeInputForm from './pages/AgeInputForm'
 import SplashPage from './pages/SplashPage'
@@ -7,20 +7,14 @@ import QuizGame from './pages/QuizGame'
 import DragDropGame from './pages/DragDropGame'
 import LeaderboardPage from './pages/LeaderboardPage'
 import { Toaster } from 'react-hot-toast'
+import NavBar from './components/layout/NavBar'
+import Footer from './components/layout/Footer'
 import './App.css'
 
 function App() {
   return (
     <Router>
-      <nav>
-        <ul>
-          <li><Link to="/">Home</Link></li>
-          <li><Link to="/games/match3">Match-3</Link></li>
-          <li><Link to="/games/quiz">Quiz</Link></li>
-        <li><Link to="/games/dragdrop">Drag & Drop</Link></li>
-        <li><Link to="/leaderboard">Leaderboard</Link></li>
-      </ul>
-      </nav>
+      <NavBar />
       <Routes>
         <Route path="/age" element={<AgeInputForm />} />
         <Route path="/welcome" element={<SplashPage />} />
@@ -32,6 +26,7 @@ function App() {
       </Routes>
       {/* Verification comment: routes render correctly with context */}
       <Toaster />
+      <Footer />
     </Router>
   )
 }

--- a/learning-games/src/components/layout/Footer.tsx
+++ b/learning-games/src/components/layout/Footer.tsx
@@ -1,0 +1,6 @@
+export default function Footer() {
+  const year = new Date().getFullYear()
+  return (
+    <footer className="footer">&copy; {year} StrawberryTech</footer>
+  )
+}

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom'
+
+export default function NavBar() {
+  return (
+    <nav className="navbar">
+      <div className="brand">StrawberryTech</div>
+      <ul>
+        <li><Link to="/">Home</Link></li>
+        <li><Link to="/games/match3">Match-3</Link></li>
+        <li><Link to="/games/quiz">Quiz</Link></li>
+        <li><Link to="/games/dragdrop">Drag & Drop</Link></li>
+        <li><Link to="/leaderboard">Leaderboard</Link></li>
+      </ul>
+    </nav>
+  )
+}

--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -3,6 +3,10 @@
   line-height: 1.5;
   font-weight: 400;
 
+  --color-purple: #9f29fd;
+  --color-orange: #ff6b00;
+  --color-lime: #a3e635;
+
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
@@ -15,11 +19,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-purple);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-orange);
 }
 
 body {
@@ -42,16 +46,17 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-purple);
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: var(--color-orange);
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 4px auto var(--color-lime);
 }
 
 @media (prefers-color-scheme: light) {
@@ -60,9 +65,9 @@ button:focus-visible {
     background-color: #ffffff;
   }
   a:hover {
-    color: #747bff;
+    color: var(--color-lime);
   }
   button {
-    background-color: #f9f9f9;
+    background-color: var(--color-purple);
   }
 }

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -21,6 +21,13 @@ export default function Home() {
 
   return (
     <div className="home">
+      {/* hero section */}
+      <section className="hero">
+        <h1>Fun Learning Awaits!</h1>
+        <p className="tagline">Play engaging games and sharpen your skills.</p>
+        <button onClick={() => navigate('/games/match3')}>Play Now</button>
+      </section>
+
       {/* greeting */}
       {user.age && (
         <h2>
@@ -30,9 +37,18 @@ export default function Home() {
 
       {/* game list */}
       <div className="game-grid">
-        <Link className="game-card" to="/games/match3">Match-3 Puzzle</Link>
-        <Link className="game-card" to="/games/quiz">Quiz Game</Link>
-        <Link className="game-card" to="/games/dragdrop">Drag & Drop Game</Link>
+        <Link className="game-card" to="/games/match3">
+          <span className="game-icon">🧩</span>
+          <span>Match-3 Puzzle</span>
+        </Link>
+        <Link className="game-card" to="/games/quiz">
+          <span className="game-icon">❓</span>
+          <span>Quiz Game</span>
+        </Link>
+        <Link className="game-card" to="/games/dragdrop">
+          <span className="game-icon">🎯</span>
+          <span>Drag & Drop Game</span>
+        </Link>
       </div>
 
       {/* navigation */}


### PR DESCRIPTION
## Summary
- apply global purple, orange and lime palette
- add navigation bar and footer components
- build hero section on home page with call to action
- redesign game grid as icon cards

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684188c9e1b8832fae153dc57ed31a5f