### PR TITLE
Fix JSON parsing in UserProvider

### DIFF
--- a/learning-games/src/context/UserProvider.tsx
+++ b/learning-games/src/context/UserProvider.tsx
@@ -12,7 +12,15 @@ export function UserProvider({ children }: { children: ReactNode }) {
   // Load any saved user progress from localStorage on first render
   const [user, setUser] = useState<UserData>(() => {
     const saved = localStorage.getItem(STORAGE_KEY)
-    return saved ? { ...defaultUser, ...JSON.parse(saved) } : defaultUser
+    if (saved) {
+      try {
+        return { ...defaultUser, ...JSON.parse(saved) }
+      } catch (err) {
+        console.error('Failed to parse saved user data', err)
+        return defaultUser
+      }
+    }
+    return defaultUser
   })
 
 


### PR DESCRIPTION
## Summary
- handle invalid JSON when loading user data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68418a7168ec832fa4929332e94e30d9