### PR TITLE
Add vibrant Home page styling with animations

### DIFF
--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -1,0 +1,75 @@
+/* Vibrant styling for the Home page */
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.home {
+  animation: fadeIn 0.6s ease-out;
+}
+
+.hero {
+  background: linear-gradient(135deg, var(--color-purple), var(--color-orange));
+  background-size: 150% 150%;
+  animation: gradientMove 8s ease infinite;
+  color: #fff;
+  padding: 3rem 1rem;
+  border-radius: 12px;
+  margin-bottom: 2rem;
+}
+
+@keyframes gradientMove {
+  0% {
+    background-position: 0 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+
+.hero button {
+  background: var(--color-lime);
+  color: #000;
+}
+
+.hero button:hover {
+  background: #fff;
+  color: var(--color-purple);
+}
+
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.game-card {
+  background: radial-gradient(circle at top left, #ffffff, #f3f3f3);
+  border: none;
+  border-radius: 10px;
+  padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.game-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
+}
+

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { UserContext } from '../context/UserContext'
+import './Home.css'
 
 /**
  * Home page listing available games.


### PR DESCRIPTION
## Summary
- create `Home.css` with gradients and hover effects
- import `Home.css` in `Home.tsx`
- include page load fade-in and card hover animation

## Testing
- `npm install`
- `npm run lint`
- `npm run dev` *(stopped after launch)*

------
https://chatgpt.com/codex/tasks/task_e_68418f343f60832fadb0bd4f6cacb299