### PR TITLE
Remove broken SplashPage video

### DIFF
--- a/learning-games/src/pages/SplashPage.css
+++ b/learning-games/src/pages/SplashPage.css
@@ -5,14 +5,7 @@
   overflow: hidden;
   color: #fff;
   text-align: center;
-}
-
-.bg-video {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: brightness(0.6);
+  background: linear-gradient(to bottom right, #ff4d80, #ff9966);
 }
 
 .overlay {

--- a/learning-games/src/pages/SplashPage.tsx
+++ b/learning-games/src/pages/SplashPage.tsx
@@ -29,9 +29,6 @@ export default function SplashPage() {
 
   return (
     <div className="splash-container">
-      <video autoPlay loop muted className="bg-video">
-        <source src="/welcome.mp4" type="video/mp4" />
-      </video>
       <div className="overlay">
         <h1>Welcome to StrawberryTech! 🍓</h1>
         <p>Play while you learn.</p>


### PR DESCRIPTION
## Summary
- remove broken `welcome.mp4` video element
- clean up unused `.bg-video` style and add gradient background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68419b5f759c832f88aee576418ccf91