### PR TITLE
Add scoring logic tests and ensure test script

### DIFF
--- a/learning-games/src/pages/__tests__/Match3Game.test.ts
+++ b/learning-games/src/pages/__tests__/Match3Game.test.ts
@@ -47,4 +47,13 @@ describe('checkMatches', () => {
     expect(result.gained).toBe(30)
     expect(result.grid.length).toBe(36)
   })
+
+  it('awards points for multiple matches', () => {
+    const grid = patternGrid()
+    grid[6] = { type: 'red', color: 'red', id: 999 }
+    grid[7] = { type: 'blue', color: 'blue', id: 1000 }
+    const result = checkMatches(grid, stubTileFactory())
+    expect(result.gained).toBe(60)
+    expect(result.grid.length).toBe(36)
+  })
 })


### PR DESCRIPTION
## Summary
- add a new test covering scoring with multiple matches in `Match3Game`
- verify `package.json` has the `test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68419b6740ec832fa86fdb216f0d0558