### PR TITLE
Add flavor challenge with animated emoji tiles

### DIFF
--- a/learning-games/package-lock.json
+++ b/learning-games/package-lock.json
@@ -8,6 +8,7 @@
       "name": "learning-games",
       "version": "0.0.0",
       "dependencies": {
+        "framer-motion": "^12.16.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.5.2",
@@ -2678,6 +2679,33 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.16.0.tgz",
+      "integrity": "sha512-xryrmD4jSBQrS2IkMdcTmiS4aSKckbS7kLDCuhUn9110SQKG1w3zlq1RTqCblewg+ZYe+m3sdtzQA6cRwo5g8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.16.0",
+        "motion-utils": "^12.12.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3023,6 +3051,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.16.0.tgz",
+      "integrity": "sha512-Z2nGwWrrdH4egLEtgYMCEN4V2qQt1qxlKy/uV7w691ztyA41Q5Rbn0KNGbsNVDZr9E8PD2IOQ3hSccRnB6xWzw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.12.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
+      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3670,6 +3713,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/learning-games/package.json
+++ b/learning-games/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "framer-motion": "^12.16.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",

--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -69,6 +69,14 @@
 .match3-container {
   max-width: 400px;
   margin: 0 auto;
+  background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.daily-challenge-banner {
+  margin-bottom: 0.5rem;
+  font-weight: bold;
 }
 
 .match3-grid {
@@ -81,13 +89,19 @@
 .match3-tile {
   width: 48px;
   height: 48px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   cursor: pointer;
+  user-select: none;
 }
 
 .match3-tile.selected {
   outline: 3px solid #0070f3;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* layout */

--- a/learning-games/src/pages/__tests__/Match3Game.test.ts
+++ b/learning-games/src/pages/__tests__/Match3Game.test.ts
@@ -42,7 +42,7 @@ describe('checkMatches', () => {
 
   it('clears matched tiles and reports gained score', () => {
     const grid = patternGrid()
-    grid[6] = { type: 'red', color: 'red', id: 999 }
+    grid[6] = { type: colors[0], color: colors[0], id: 999 }
     const result = checkMatches(grid, stubTileFactory())
     expect(result.gained).toBe(30)
     expect(result.grid.length).toBe(36)
@@ -50,8 +50,8 @@ describe('checkMatches', () => {
 
   it('awards points for multiple matches', () => {
     const grid = patternGrid()
-    grid[6] = { type: 'red', color: 'red', id: 999 }
-    grid[7] = { type: 'blue', color: 'blue', id: 1000 }
+    grid[6] = { type: colors[0], color: colors[0], id: 999 }
+    grid[7] = { type: colors[1], color: colors[1], id: 1000 }
     const result = checkMatches(grid, stubTileFactory())
     expect(result.gained).toBe(60)
     expect(result.grid.length).toBe(36)


### PR DESCRIPTION
## Summary
- introduce flavor-based tiles and challenge bonus
- animate tiles with Framer Motion
- add daily flavor banner and toasts for bonuses
- style match3 board with gradient and 3D emoji tiles
- update tests for new flavor tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68419f599c50832f8c7cb05d2523044e