### PR TITLE
Improve Match3 layout and badge visuals

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -67,7 +67,8 @@
 
 /* Match-3 styles */
 .match3-container {
-  max-width: 400px;
+  width: 100%;
+  max-width: 420px;
   margin: 0 auto;
   background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
   padding: 1rem;
@@ -76,13 +77,15 @@
 
 
 .match3-wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
   gap: 1rem;
   justify-content: center;
+  align-items: start;
 }
 
 .match3-sidebar {
-  max-width: 200px;
+  max-width: 240px;
   background: #fff;
   padding: 1rem;
   border-radius: 8px;
@@ -119,6 +122,35 @@
 .match3-tile.selected {
   outline: 3px solid #0070f3;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.sidebar-quote {
+  margin-top: 1rem;
+  font-style: italic;
+}
+
+.badge-rewards {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.badge-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 1.4rem;
+}
+
+@media (max-width: 600px) {
+  .match3-wrapper {
+    grid-template-columns: 1fr;
+  }
+  .match3-sidebar,
+  .match3-container {
+    max-width: none;
+  }
 }
 
 /* layout */

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { UserContext } from '../context/UserContext'
 import { toast } from 'react-hot-toast'
+import { BADGES } from '../data/badges'
 
 /** Tile element used in the grid */
 export interface Tile {
@@ -49,6 +50,11 @@ export function createGrid(): (Tile | null)[] {
 const tips = [
   { range: [12, 14], tips: ['Great start! Keep learning leadership basics.'] },
   { range: [15, 18], tips: ['Remember: teamwork makes the dream work!'] },
+]
+
+const quotes = [
+  'Prompting is like seasoning \u2013 a single word changes the flavor.',
+  'Swap words wisely and watch your message sparkle!',
 ]
 
 export interface MatchResult {
@@ -129,6 +135,11 @@ export default function Match3Game() {
     () => flavors[Math.floor(Math.random() * flavors.length)]
   )
 
+  const [sidebarQuote] = useState(
+    () => quotes[Math.floor(Math.random() * quotes.length)]
+  )
+  const [newBadges, setNewBadges] = useState<string[]>([])
+
   const navigate = useNavigate()
   const [showInstructions, setShowInstructions] = useState(true)
   const [showEndModal, setShowEndModal] = useState(false)
@@ -183,12 +194,16 @@ export default function Match3Game() {
   // Award badges and store the best score when the game ends
   function endGame() {
     saveScore('match3', score)
+    const earned: string[] = []
     if (score >= 100 && !user.badges.includes('match-master')) {
+      earned.push('match-master')
       addBadge('match-master')
     }
     if (!user.badges.includes('first-match3')) {
+      earned.push('first-match3')
       addBadge('first-match3')
     }
+    setNewBadges(earned)
     toast(`Game over! Final score: ${score}`)
     setShowEndModal(true)
   }
@@ -232,6 +247,7 @@ export default function Match3Game() {
           <li>Match the daily flavor for a 20 point bonus.</li>
           <li>Earn as many points as you can in 20 moves.</li>
         </ul>
+        <blockquote className="sidebar-quote">{sidebarQuote}</blockquote>
       </aside>
 
       {showInstructions && (
@@ -252,6 +268,25 @@ export default function Match3Game() {
           <div className="match3-modal">
             <h3>Game Over</h3>
             <p>Your score: {score}</p>
+            {newBadges.length > 0 && (
+              <div className="badge-rewards">
+                {newBadges.map((id) => {
+                  const badge = BADGES.find((b) => b.id === id)
+                  return (
+                    <motion.div
+                      key={id}
+                      className="badge-icon"
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ type: 'spring', stiffness: 260 }}
+                    >
+                      <span role="img" aria-label="badge">🏅</span>
+                      <div>{badge?.name ?? id}</div>
+                    </motion.div>
+                  )
+                })}
+              </div>
+            )}
             <button
               onClick={() => {
                 setShowEndModal(false)


### PR DESCRIPTION
## Summary
- update Match3 game UI with quote sidebar and badge animation
- make layout responsive with CSS grid
- show newly earned badges in game over modal

## Testing
- `npm test --prefix learning-games`

------
https://chatgpt.com/codex/tasks/task_e_6841b49dacc4832f928775d33a8fa5d3