### PR TITLE
Improve Match3 to tone drag format

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -67,7 +67,8 @@
 
 /* Match-3 styles */
 .match3-container {
-  max-width: 400px;
+  width: 100%;
+  max-width: 420px;
   margin: 0 auto;
   background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
   padding: 1rem;
@@ -76,13 +77,15 @@
 
 
 .match3-wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
   gap: 1rem;
   justify-content: center;
+  align-items: start;
 }
 
 .match3-sidebar {
-  max-width: 200px;
+  max-width: 240px;
   background: #fff;
   padding: 1rem;
   border-radius: 8px;
@@ -119,6 +122,35 @@
 .match3-tile.selected {
   outline: 3px solid #0070f3;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.sidebar-quote {
+  margin-top: 1rem;
+  font-style: italic;
+}
+
+.badge-rewards {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.badge-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 1.4rem;
+}
+
+@media (max-width: 600px) {
+  .match3-wrapper {
+    grid-template-columns: 1fr;
+  }
+  .match3-sidebar,
+  .match3-container {
+    max-width: none;
+  }
 }
 
 /* layout */
@@ -200,5 +232,38 @@
 
 .match3-modal button {
   margin-top: 1rem;
+}
+
+.drag-container {
+  display: flex;
+  gap: 1rem;
+  margin: 1rem 0;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.drag-word {
+  padding: 0.5rem 1rem;
+  background: var(--color-lime);
+  color: #000;
+  border-radius: 4px;
+  cursor: grab;
+  user-select: none;
+}
+
+.drop-zones {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.drop-zone {
+  width: 60px;
+  height: 60px;
+  border: 2px dashed #ccc;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
 }
 

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -1,60 +1,72 @@
-import { useContext, useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
+import { useContext, useState, useEffect } from "react";
+import { motion } from "framer-motion";
 
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from "react-router-dom";
 
-import { UserContext } from '../context/UserContext'
-import { toast } from 'react-hot-toast'
+import { UserContext } from "../context/UserContext";
+import { BADGES } from "../data/badges";
 
 /** Tile element used in the grid */
 export interface Tile {
-  type: string
-  color: string
-  emoji?: string
-  id: number
+  type: string;
+  color: string;
+  emoji?: string;
+  id: number;
 }
 
 export interface Flavor {
-  name: string
-  emoji: string
-  color: string
+  name: string;
+  emoji: string;
+  color: string;
 }
 
 export const flavors: Flavor[] = [
-  { name: 'spicy', emoji: '🌶️', color: '#ff4500' },
-  { name: 'zesty', emoji: '🍋', color: '#ffd700' },
-  { name: 'calm', emoji: '🪴', color: '#3cb371' },
-  { name: 'fresh', emoji: '🍃', color: '#8fbc8f' },
-]
+  { name: "spicy", emoji: "🌶️", color: "#ff4500" },
+  { name: "zesty", emoji: "🍋", color: "#ffd700" },
+  { name: "calm", emoji: "🪴", color: "#3cb371" },
+  { name: "fresh", emoji: "🍃", color: "#8fbc8f" },
+];
 
-export const colors = flavors.map((f) => f.name)
-let tileId = 0
+export const colors = flavors.map((f) => f.name);
+let tileId = 0;
 
 /** Create a random tile with a unique id */
 export function createTile(): Tile {
-  const flavor = flavors[Math.floor(Math.random() * flavors.length)]
+  const flavor = flavors[Math.floor(Math.random() * flavors.length)];
   return {
     type: flavor.name,
     color: flavor.color,
     emoji: flavor.emoji,
     id: tileId++,
-  }
+  };
 }
 
 /** Generate the initial 6x6 grid */
 export function createGrid(): (Tile | null)[] {
-  return Array.from({ length: 36 }, () => createTile())
+  return Array.from({ length: 36 }, () => createTile());
 }
 
 const tips = [
-  { range: [12, 14], tips: ['Great start! Keep learning leadership basics.'] },
-  { range: [15, 18], tips: ['Remember: teamwork makes the dream work!'] },
-]
+  { range: [12, 14], tips: ["Great start! Keep learning leadership basics."] },
+  { range: [15, 18], tips: ["Remember: teamwork makes the dream work!"] },
+];
+
+const quotes = [
+  "Prompting is like seasoning \u2013 a single word changes the flavor.",
+  "Swap words wisely and watch your message sparkle!",
+];
+
+const toneWords = [
+  { word: "fiery", flavor: "spicy" },
+  { word: "zippy", flavor: "zesty" },
+  { word: "soothing", flavor: "calm" },
+  { word: "crisp", flavor: "fresh" },
+];
 
 export interface MatchResult {
-  grid: (Tile | null)[]
-  gained: number
-  matchedTypes: string[]
+  grid: (Tile | null)[];
+  gained: number;
+  matchedTypes: string[];
 }
 
 /**
@@ -64,19 +76,26 @@ export interface MatchResult {
  */
 export function checkMatches(
   current: (Tile | null)[],
-  create: () => Tile = createTile
+  create: () => Tile = createTile,
 ): MatchResult {
-  const matched = new Set<number>()
-  const matchedTypes = new Set<string>()
+  const matched = new Set<number>();
+  const matchedTypes = new Set<string>();
 
   // rows
   for (let r = 0; r < 6; r++) {
     for (let c = 0; c < 4; c++) {
-      const idx = r * 6 + c
-      const t = current[idx]
-      if (t && current[idx + 1]?.type === t.type && current[idx + 2]?.type === t.type) {
-        matched.add(idx).add(idx + 1).add(idx + 2)
-        if (t) matchedTypes.add(t.type)
+      const idx = r * 6 + c;
+      const t = current[idx];
+      if (
+        t &&
+        current[idx + 1]?.type === t.type &&
+        current[idx + 2]?.type === t.type
+      ) {
+        matched
+          .add(idx)
+          .add(idx + 1)
+          .add(idx + 2);
+        if (t) matchedTypes.add(t.type);
       }
     }
   }
@@ -84,34 +103,103 @@ export function checkMatches(
   // columns
   for (let c = 0; c < 6; c++) {
     for (let r = 0; r < 4; r++) {
-      const idx = r * 6 + c
-      const t = current[idx]
-      if (t && current[idx + 6]?.type === t.type && current[idx + 12]?.type === t.type) {
-        matched.add(idx).add(idx + 6).add(idx + 12)
-        if (t) matchedTypes.add(t.type)
+      const idx = r * 6 + c;
+      const t = current[idx];
+      if (
+        t &&
+        current[idx + 6]?.type === t.type &&
+        current[idx + 12]?.type === t.type
+      ) {
+        matched
+          .add(idx)
+          .add(idx + 6)
+          .add(idx + 12);
+        if (t) matchedTypes.add(t.type);
       }
     }
   }
 
-  if (matched.size === 0) return { grid: current, gained: 0, matchedTypes: [] }
+  if (matched.size === 0) return { grid: current, gained: 0, matchedTypes: [] };
 
-  const working = [...current]
-  matched.forEach((i) => (working[i] = null))
+  const working = [...current];
+  matched.forEach((i) => (working[i] = null));
 
   for (let c = 0; c < 6; c++) {
     for (let r = 5; r >= 0; r--) {
-      const idx = r * 6 + c
+      const idx = r * 6 + c;
       if (working[idx] === null) {
         for (let k = r; k > 0; k--) {
-          working[k * 6 + c] = working[(k - 1) * 6 + c]
+          working[k * 6 + c] = working[(k - 1) * 6 + c];
         }
-        working[c] = create()
+        working[c] = create();
       }
     }
   }
 
-  const gained = matched.size * 10
-  return { grid: working, gained, matchedTypes: Array.from(matchedTypes) }
+  const gained = matched.size * 10;
+  return { grid: working, gained, matchedTypes: Array.from(matchedTypes) };
+}
+
+function ToneMatchGame({ onComplete }: { onComplete: () => void }) {
+  const [completed, setCompleted] = useState<string[]>([]);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  function handleDrop(flavor: string, word: string) {
+    const correct = toneWords.find((t) => t.word === word)?.flavor === flavor;
+    setFeedback(correct ? `Nice! ${word} is ${flavor}.` : `Try again!`);
+    if (correct && !completed.includes(word)) {
+      setCompleted((c) => [...c, word]);
+    }
+  }
+
+  useEffect(() => {
+    if (completed.length === toneWords.length) {
+      onComplete();
+    }
+  }, [completed, onComplete]);
+
+  return (
+    <div>
+      <h3>Drag the words to match the emoji</h3>
+      <div className="drag-container">
+        <div className="drag-words">
+          {toneWords
+            .filter((w) => !completed.includes(w.word))
+            .map((w) => (
+              <div
+                key={w.word}
+                className="drag-word"
+                draggable
+                onDragStart={(e) =>
+                  e.dataTransfer.setData("text/plain", w.word)
+                }
+              >
+                {w.word}
+              </div>
+            ))}
+        </div>
+        <div className="drop-zones">
+          {flavors.map((f) => (
+            <div
+              key={f.name}
+              className="drop-zone"
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => {
+                e.preventDefault();
+                const word = e.dataTransfer.getData("text/plain");
+                handleDrop(f.name, word);
+              }}
+            >
+              <span role="img" aria-label={f.name}>
+                {f.emoji}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {feedback && <p>{feedback}</p>}
+    </div>
+  );
 }
 
 /**
@@ -120,142 +208,65 @@ export function checkMatches(
  * show an age-based leadership tip.
  */
 export default function Match3Game() {
-  const { user, setScore: saveScore, addBadge } = useContext(UserContext)
-  const [grid, setGrid] = useState<(Tile | null)[]>(createGrid())
-  const [selected, setSelected] = useState<number | null>(null)
-  const [score, setScore] = useState(0)
-  const [moves, setMoves] = useState(20)
-  const [challenge] = useState<Flavor>(
-    () => flavors[Math.floor(Math.random() * flavors.length)]
-  )
+  const { user, addBadge } = useContext(UserContext);
+  const navigate = useNavigate();
+  const [sidebarQuote] = useState(
+    () => quotes[Math.floor(Math.random() * quotes.length)],
+  );
+  const [newBadges, setNewBadges] = useState<string[]>([]);
+  const [showEndModal, setShowEndModal] = useState(false);
 
-  const navigate = useNavigate()
-  const [showInstructions, setShowInstructions] = useState(true)
-  const [showEndModal, setShowEndModal] = useState(false)
-
-
-  // Return tips list for the current age
-  const ageTips = tips.find((t) =>
-    user.age ? user.age >= t.range[0] && user.age <= t.range[1] : false
-  )?.tips
-
-  /** Swap two tiles if they are adjacent */
-  function handleClick(index: number) {
-    if (moves <= 0) return
-    if (selected === null) {
-      setSelected(index)
-      return
+  function handleComplete() {
+    const earned: string[] = [];
+    if (!user.badges.includes("first-match3")) {
+      addBadge("first-match3");
+      earned.push("first-match3");
     }
-    const diff = Math.abs(selected - index)
-    const adjacent = [1, 6].includes(diff) && !(selected % 6 === 5 && index % 6 === 0)
-    if (!adjacent) {
-      setSelected(null)
-      return
-    }
-    const newGrid = [...grid]
-    ;[newGrid[selected], newGrid[index]] = [newGrid[index], newGrid[selected]]
-    setGrid(newGrid)
-    setSelected(null)
-    setMoves((m) => m - 1)
-    applyMatches(newGrid)
+    setNewBadges(earned);
+    setShowEndModal(true);
   }
-
-  /**
-   * Find matches of 3+ identical tiles and handle scoring/dropping logic.
-   * Tiles that are cleared are replaced by the tile above them; new tiles fill
-   * the top row.
-   */
-  function applyMatches(current: (Tile | null)[]) {
-    const result = checkMatches(current)
-    if (result.gained === 0) return
-    let gained = result.gained
-    if (result.matchedTypes.includes(challenge.name)) {
-      gained += 20
-      toast(`Tone tip! Matched the ${challenge.name} flavor!`)
-    }
-    setScore((s) => s + gained)
-    setGrid(result.grid)
-    if (ageTips && Math.random() < 0.3) {
-      toast(ageTips[Math.floor(Math.random() * ageTips.length)])
-    }
-  }
-
-  // Award badges and store the best score when the game ends
-  function endGame() {
-    saveScore('match3', score)
-    if (score >= 100 && !user.badges.includes('match-master')) {
-      addBadge('match-master')
-    }
-    if (!user.badges.includes('first-match3')) {
-      addBadge('first-match3')
-    }
-    toast(`Game over! Final score: ${score}`)
-    setShowEndModal(true)
-  }
-
-  useEffect(() => {
-    if (moves === 0) {
-      endGame()
-    }
-  }, [moves])
 
   return (
-
     <div className="match3-wrapper">
       <div className="match3-container">
-        <div className="daily-challenge-banner">
-          Daily Flavor Challenge: {challenge.emoji} {challenge.name}
-        </div>
-        <h2>Match-3 Puzzle</h2>
-        <p>Moves Left: {moves}</p>
-        <div className="match3-grid">
-          {grid.map((tile, i) => (
-            <motion.div
-              key={tile?.id ?? i}
-              onClick={() => handleClick(i)}
-              className={`match3-tile ${selected === i ? 'selected' : ''}`}
-              style={{ background: tile?.color || 'transparent' }}
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              {tile?.emoji}
-            </motion.div>
-          ))}
-        </div>
-        <p>Score: {score}</p>
-
+        <ToneMatchGame onComplete={handleComplete} />
       </div>
       <aside className="match3-sidebar">
-        <h3>How to Play</h3>
-        <ul>
-          <li>Swap tiles to create lines of three matching emojis.</li>
-          <li>Match the daily flavor for a 20 point bonus.</li>
-          <li>Earn as many points as you can in 20 moves.</li>
-        </ul>
+        <h3>Why Tone Matters</h3>
+        <p>Drag the adjectives to the emoji that best matches their vibe.</p>
+        <blockquote className="sidebar-quote">{sidebarQuote}</blockquote>
       </aside>
-
-      {showInstructions && (
-        <div className="match3-modal-overlay">
-          <div className="match3-modal">
-            <h3>Welcome!</h3>
-            <p>
-              Swap adjacent tiles to match three or more. Focus on {challenge.emoji}{' '}
-              {challenge.name} for bonus points.
-            </p>
-            <button onClick={() => setShowInstructions(false)}>Start</button>
-          </div>
-        </div>
-      )}
 
       {showEndModal && (
         <div className="match3-modal-overlay">
           <div className="match3-modal">
-            <h3>Game Over</h3>
-            <p>Your score: {score}</p>
+            <h3>Great job!</h3>
+            <p>You matched all the words.</p>
+            {newBadges.length > 0 && (
+              <div className="badge-rewards">
+                {newBadges.map((id) => {
+                  const badge = BADGES.find((b) => b.id === id);
+                  return (
+                    <motion.div
+                      key={id}
+                      className="badge-icon"
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ type: "spring", stiffness: 260 }}
+                    >
+                      <span role="img" aria-label="badge">
+                        🏅
+                      </span>
+                      <div>{badge?.name ?? id}</div>
+                    </motion.div>
+                  );
+                })}
+              </div>
+            )}
             <button
               onClick={() => {
-                setShowEndModal(false)
-                navigate('/games/quiz')
+                setShowEndModal(false);
+                navigate("/games/quiz");
               }}
             >
               Next Game
@@ -264,5 +275,5 @@ export default function Match3Game() {
         </div>
       )}
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- convert Match3 to a tone-word drag-and-drop challenge
- show responsive sidebar with tone tips and quote
- animate newly earned badges in completion modal

## Testing
- `npm test --prefix learning-games` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b49dacc4832f928775d33a8fa5d3