### PR TITLE
Implement drag-drop tone exercise

### DIFF
--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -1,0 +1,55 @@
+.dragdrop-game {
+  padding: 1rem;
+}
+
+.sentence {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.drop-area {
+  display: inline-block;
+  min-width: 80px;
+  margin: 0 4px;
+  padding: 0.25rem 0.5rem;
+  border: 2px dashed var(--color-purple);
+  border-radius: 4px;
+  text-align: center;
+}
+
+.word-bank {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.word {
+  padding: 0.4rem 0.6rem;
+  background: var(--color-orange);
+  color: #fff;
+  border-radius: 6px;
+  cursor: grab;
+  user-select: none;
+}
+
+.response {
+  margin-top: 1rem;
+  background: #f3f3f3;
+  color: #000;
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+.quiz {
+  margin-top: 2rem;
+}
+
+.options button {
+  margin: 0.25rem;
+}
+
+.feedback {
+  margin-top: 1rem;
+  font-weight: bold;
+}

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -1,3 +1,116 @@
+import { useState } from 'react'
+import './DragDropGame.css'
+
+const tones = [
+  'Polite',
+  'Casual',
+  'Emotional',
+  'Angry',
+  'Urgent',
+  'Compelling',
+  'Persuasive',
+] as const
+
+type Tone = (typeof tones)[number]
+
+const examples: Record<Tone, string> = {
+  Polite:
+    "Hey, I'm sorry but something came up and I need to cancel. Hope we can reschedule soon!",
+  Casual:
+    "Yo, gotta bail on our plans—something popped up. Let's hang later!",
+  Emotional:
+    "I hate to do this but I really can't make it tonight. I'm disappointed and hope you understand.",
+  Angry:
+    "Look, I'm cancelling. Too much going on and I'm frustrated.",
+  Urgent:
+    "I'm so sorry but I have to cancel right away because of an emergency.",
+  Compelling:
+    "I have to cancel because I got an important commitment I can't miss. Thanks for understanding!",
+  Persuasive:
+    "Would you mind if we postponed? I think meeting later will be much better for both of us.",
+}
+
 export default function DragDropGame() {
-  return <h2>Drag & Drop Game Coming Soon</h2>
+  const [selected, setSelected] = useState<Tone | null>(null)
+  const [used, setUsed] = useState<Set<Tone>>(new Set())
+  const [quizAnswer, setQuizAnswer] = useState<Tone | null>(null)
+
+  function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {
+    e.dataTransfer.setData('text/plain', tone)
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLSpanElement>) {
+    e.preventDefault()
+    const tone = e.dataTransfer.getData('text/plain') as Tone
+    if (tones.includes(tone)) {
+      setSelected(tone)
+      setUsed(new Set(used).add(tone))
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLSpanElement>) {
+    e.preventDefault()
+  }
+
+  return (
+    <div className="dragdrop-game">
+      <h2>Drag a tone into the blank</h2>
+      <p className="sentence">
+        Write a
+        <span
+          className="drop-area"
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+        >
+          {selected ? ` ${selected} ` : ' ____ '}
+        </span>
+        short text to cancel my plans with a friend.
+      </p>
+      <div className="word-bank">
+        {tones.map((tone) => (
+          <div
+            key={tone}
+            draggable
+            onDragStart={(e) => handleDragStart(e, tone)}
+            className="word"
+          >
+            {tone}
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <div className="response">
+          <h3>AI Response</h3>
+          <p>{examples[selected]}</p>
+        </div>
+      )}
+      {used.size === tones.length && (
+        <div className="quiz">
+          <h3>Quick test</h3>
+          <p>
+            What tone should you use when writing a message to your boss that you
+            will be out of work sick today?
+          </p>
+          <div className="options">
+            {tones.map((tone) => (
+              <button
+                key={tone}
+                onClick={() => setQuizAnswer(tone)}
+                disabled={!!quizAnswer}
+              >
+                {tone}
+              </button>
+            ))}
+          </div>
+          {quizAnswer && (
+            <p className="feedback">
+              {quizAnswer === 'Polite'
+                ? 'Correct! A polite tone is best for informing your boss.'
+                : 'Not quite. A polite tone is usually most appropriate.'}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- implement DragDropGame with drag-and-drop tone practice and a quiz
- style new page

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6841db267414832f82f7d73ad959d66c