### PR TITLE
Improve tone matching mini-game UI

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -79,8 +79,7 @@
 .match3-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 240px;
-
+  grid-template-columns: 1fr 260px;
   gap: 1rem;
   justify-content: center;
   align-items: start;
@@ -131,6 +130,12 @@
   font-style: italic;
 }
 
+.sidebar-tip {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
 .badge-rewards {
   display: flex;
   gap: 0.5rem;
@@ -143,6 +148,19 @@
   flex-direction: column;
   align-items: center;
   font-size: 1.4rem;
+  animation: pop 0.6s ease;
+}
+
+@keyframes pop {
+  0% {
+    transform: scale(0);
+  }
+  80% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 @media (max-width: 600px) {
@@ -242,11 +260,10 @@
 }
 
 .drag-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1rem;
   margin: 1rem 0;
-  flex-wrap: wrap;
-  justify-content: center;
 }
 
 .drag-word {
@@ -258,9 +275,17 @@
   user-select: none;
 }
 
-.drop-zones {
-  display: flex;
+.drag-words {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
   gap: 0.5rem;
+}
+
+.drop-zones {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  gap: 0.5rem;
+  justify-items: center;
 }
 
 .drop-zone {

--- a/learning-games/src/data/badges.ts
+++ b/learning-games/src/data/badges.ts
@@ -21,4 +21,9 @@ export const BADGES: BadgeDefinition[] = [
     name: 'Quiz Whiz',
     description: 'Get a perfect score on any quiz',
   },
+  {
+    id: 'tone-whiz',
+    name: 'Tone Tactician',
+    description: 'Matched every tone correctly in the mini-game',
+  },
 ]

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -54,6 +54,11 @@ const quotes = [
   "Swap words wisely and watch your message sparkle!",
 ];
 
+const tips = [
+  "Tip: Swap one adjective to completely change the vibe.",
+  "Use synonyms to experiment with different tones!",
+];
+
 const toneWords = [
 
 
@@ -280,11 +285,15 @@ function ToneMatchGame({ onComplete }: { onComplete: () => void }) {
  * show an age-based leadership tip.
  */
 export default function Match3Game() {
-  const { user, addBadge } = useContext(UserContext);
-  const navigate = useNavigate();
+  const { user, addBadge } = useContext(UserContext)
+  const navigate = useNavigate()
   const [sidebarQuote] = useState(
     () => quotes[Math.floor(Math.random() * quotes.length)],
-  );
+  )
+  const [sidebarTip] = useState(
+    () =>
+      tips[Math.floor(Math.random() * tips.length)],
+  )
   const [newBadges, setNewBadges] = useState<string[]>([]);
   const [showEndModal, setShowEndModal] = useState(false);
 
@@ -293,6 +302,10 @@ export default function Match3Game() {
     if (!user.badges.includes("first-match3")) {
       addBadge("first-match3");
       earned.push("first-match3");
+    }
+    if (!user.badges.includes("tone-whiz")) {
+      addBadge("tone-whiz");
+      earned.push("tone-whiz");
     }
     setNewBadges(earned);
     setShowEndModal(true);
@@ -307,6 +320,7 @@ export default function Match3Game() {
         <h3>Why Tone Matters</h3>
         <p>Drag the adjectives to the face that best matches their vibe.</p>
         <blockquote className="sidebar-quote">{sidebarQuote}</blockquote>
+        <p className="sidebar-tip">{sidebarTip}</p>
       </aside>
 
       {showEndModal && (
@@ -314,6 +328,7 @@ export default function Match3Game() {
           <div className="match3-modal">
             <h3>Great job!</h3>
             <p>You matched all the words.</p>
+            <p>You've earned the Tone Tactician badge!</p>
             <div className="flashcard">
               <strong>Why Tone Matters</strong>
               <p>Changing one adjective = a whole new vibe. Tone tells the AI how to speak, not just what to say.</p>
@@ -326,8 +341,8 @@ export default function Match3Game() {
                     <motion.div
                       key={id}
                       className="badge-icon"
-                      initial={{ scale: 0 }}
-                      animate={{ scale: 1 }}
+                      initial={{ scale: 0, rotate: 0 }}
+                      animate={{ scale: 1, rotate: 360 }}
                       transition={{ type: "spring", stiffness: 260 }}
                     >
                       <span role="img" aria-label="badge">


### PR DESCRIPTION
## Summary
- refine match3 wrapper grid layout
- animate badge pop-in for completion modal
- add random sidebar tip and tone badge reward
- align drag/drop UI using CSS grid

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841e846f860832f9c865872bf228144