### PR TITLE
Remove urgent tone from match game

### DIFF
--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -22,7 +22,6 @@ export interface Flavor {
 
 export const flavors: Flavor[] = [
 
-  { name: "urgent", emoji: "😠", color: "#ff4500" },
   { name: "friendly", emoji: "😀", color: "#ffd700" },
   { name: "professional", emoji: "😐", color: "#3cb371" },
   { name: "casual", emoji: "😎", color: "#8fbc8f" },
@@ -61,8 +60,6 @@ const tips = [
 
 const toneWords = [
 
-
-  { word: "urgent", flavor: "spicy" },
   { word: "critical", flavor: "spicy" },
   { word: "friendly", flavor: "zesty" },
   { word: "cheerful", flavor: "zesty" },

--- a/learning-games/src/pages/__tests__/Match3Game.test.ts
+++ b/learning-games/src/pages/__tests__/Match3Game.test.ts
@@ -27,7 +27,7 @@ describe('createGrid', () => {
 function patternGrid(): Tile[] {
   const grid: Tile[] = []
   for (let i = 0; i < 36; i++) {
-    grid.push({ type: colors[i % 4], color: colors[i % 4], id: i })
+    grid.push({ type: colors[i % colors.length], color: colors[i % colors.length], id: i })
   }
   return grid
 }


### PR DESCRIPTION
## Summary
- remove the `urgent` option from the flavour list
- update tone words list
- adjust test helper to use dynamic color count

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421761b308832fb8fb374d5af6fd4a