### PR TITLE
Improve homepage visuals and UX

### DIFF
--- a/learning-games/index.html
+++ b/learning-games/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>StrawberryTech Learning Games</title>
   </head>

--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -50,15 +50,20 @@
 
 .game-card {
   padding: 1rem;
-  border: 1px solid var(--color-purple);
-  border-radius: 8px;
+  border: 2px solid transparent;
+  border-radius: 10px;
   text-decoration: none;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
   background: #fff;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+.game-card:hover {
+  transform: scale(1.05);
+  border-color: var(--color-purple);
 }
 
 .progress-summary {
@@ -180,12 +185,16 @@
 
 /* layout */
 .navbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background: var(--color-purple);
   padding: 0.5rem 1rem;
   color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .navbar ul {
@@ -194,10 +203,12 @@
   gap: 1rem;
   margin: 0;
   padding: 0;
+  font-size: 1.1rem;
 }
 
 .navbar a {
   color: #fff;
+  transition: color 0.3s ease;
 }
 
 .navbar a:hover {
@@ -205,25 +216,43 @@
 }
 
 .hero {
-  background: var(--color-orange);
+  background: linear-gradient(135deg, var(--color-blue), var(--color-purple-dark));
+  background-size: 200% 200%;
+  animation: gradientShift 15s ease infinite;
   color: #fff;
   padding: 2rem 1rem;
   border-radius: 8px;
   margin-bottom: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+@keyframes gradientShift {
+  0% {
+    background-position: 0 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
 }
 
 .hero button {
   background: var(--color-purple);
   color: #fff;
   border: none;
+  transition: transform 0.2s ease, background-color 0.3s ease;
 }
 
 .hero button:hover {
   background: var(--color-lime);
+  transform: scale(1.05);
 }
 
 .game-icon {
-  font-size: 2rem;
+  font-size: 3rem;
 }
 
 .footer {
@@ -232,6 +261,17 @@
   padding: 1rem;
   text-align: center;
   margin-top: 2rem;
+  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.2);
+}
+.footer-links {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+.footer-links a {
+  color: #fff;
+}
+.footer-links a:hover {
+  color: var(--color-lime);
 }
 
 .match3-modal-overlay {

--- a/learning-games/src/components/layout/Footer.tsx
+++ b/learning-games/src/components/layout/Footer.tsx
@@ -1,6 +1,13 @@
 export default function Footer() {
   const year = new Date().getFullYear()
   return (
-    <footer className="footer">&copy; {year} StrawberryTech</footer>
+    <footer className="footer">
+      <div>&copy; {year} StrawberryTech</div>
+      <div className="footer-links">
+        <a href="#">Privacy Policy</a> |{' '}
+        <a href="#">Terms of Service</a> |{' '}
+        <a href="#">Contact</a>
+      </div>
+    </footer>
   )
 }

--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -1,11 +1,13 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Poppins', 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   --color-purple: #9f29fd;
   --color-orange: #ff6b00;
   --color-lime: #a3e635;
+  --color-blue: #1e3a8a;
+  --color-purple-dark: #6d28d9;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
@@ -57,6 +59,16 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto var(--color-lime);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+.reveal.visible {
+  opacity: 1;
+  transform: none;
 }
 
 @media (prefers-color-scheme: light) {

--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -13,39 +13,32 @@
 
 .home {
   animation: fadeIn 0.6s ease-out;
+  position: relative;
 }
 
-.hero {
-  background: linear-gradient(135deg, var(--color-purple), var(--color-orange));
-  background-size: 150% 150%;
-  animation: gradientMove 8s ease infinite;
-  color: #fff;
-  padding: 3rem 1rem;
-  border-radius: 12px;
-  margin-bottom: 2rem;
+.home::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.15) 1px, transparent 1px);
+  background-size: 60px 60px;
+  animation: floatBackground 20s linear infinite;
+  pointer-events: none;
+  z-index: -1;
 }
 
-@keyframes gradientMove {
-  0% {
-    background-position: 0 50%;
+@keyframes floatBackground {
+  from {
+    transform: translateY(0);
   }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0 50%;
+  to {
+    transform: translateY(-60px);
   }
 }
 
-.hero button {
-  background: var(--color-lime);
-  color: #000;
-}
-
-.hero button:hover {
-  background: #fff;
-  color: var(--color-purple);
-}
 
 .game-grid {
   display: grid;
@@ -53,23 +46,4 @@
   gap: 1.5rem;
 }
 
-.game-card {
-  background: radial-gradient(circle at top left, #ffffff, #f3f3f3);
-  border: none;
-  border-radius: 10px;
-  padding: 1rem;
-  text-decoration: none;
-  color: inherit;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.game-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
-}
 

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -18,12 +18,28 @@ export default function Home() {
     }
   }, [user.age, navigate])
 
+  // Apply reveal animation when elements scroll into view
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible')
+          }
+        })
+      },
+      { threshold: 0.1 }
+    )
+    document.querySelectorAll('.reveal').forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [])
+
   const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
 
   return (
     <div className="home">
       {/* hero section */}
-      <section className="hero">
+      <section className="hero reveal">
         <h1>Fun Learning Awaits!</h1>
         <p className="tagline">Play engaging games and sharpen your skills.</p>
         <button onClick={() => navigate('/games/match3')}>Play Now</button>
@@ -31,13 +47,13 @@ export default function Home() {
 
       {/* greeting */}
       {user.age && (
-        <h2>
+        <h2 className="reveal">
           Welcome{user.name ? `, ${user.name}` : ''}! Age group: {user.age}
         </h2>
       )}
 
       {/* game list */}
-      <div className="game-grid">
+      <div className="game-grid reveal">
         <Link className="game-card" to="/games/match3">
           <span className="game-icon">🧩</span>
           <span>Match-3 Puzzle</span>
@@ -49,13 +65,13 @@ export default function Home() {
       </div>
 
       {/* navigation */}
-      <p>
+      <p className="reveal">
         <Link to="/leaderboard">View Leaderboard</Link>
       </p>
 
       {/* progress summary */}
       {totalPoints > 0 && (
-        <div className="progress-summary">
+        <div className="progress-summary reveal">
           <p>Total Points: {totalPoints}</p>
           <p>Badges Earned: {user.badges.length}</p>
         </div>


### PR DESCRIPTION
## Summary
- load **Poppins** font in the HTML entrypoint
- style NavBar to be sticky with smooth link transitions
- give the hero section an animated blue‑purple gradient
- enlarge the play button on hover
- redesign game cards with scale and border effects
- add footer links with drop shadow styling
- animate sections into view with IntersectionObserver
- add gentle floating background shapes

## Testing
- `npm run lint` *(fails: '@eslint/js' module missing)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68421ec2a258832f8b188e48053c333f