### PR TITLE
Fix chat modal close button positioning

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -395,6 +395,7 @@
   max-width: 400px;
   max-height: 80vh;
   overflow-y: auto;
+  position: relative;
 }
 
 .chat-history {


### PR DESCRIPTION
## Summary
- ensure `.chat-modal` is relatively positioned so the close button anchors in the corner

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68422d1afb30832fb729f01ce60b3f00