### PR TITLE
Implement 3 Truths and a Lie game

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -1,0 +1,68 @@
+.truth-game {
+  display: grid;
+  grid-template-columns: 1fr 260px;
+  gap: 1rem;
+  align-items: start;
+}
+
+.statements {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.statement-list {
+  list-style: none;
+  padding: 0;
+}
+
+.statement-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #f8f8f8;
+  cursor: pointer;
+}
+
+.statement-btn:hover {
+  background: #ececec;
+}
+
+.statement-btn.selected {
+  background: var(--color-purple);
+  color: #fff;
+  border-color: var(--color-purple);
+}
+
+.feedback {
+  font-weight: bold;
+  margin-top: 1rem;
+}
+
+.chatbox {
+  background: #fff;
+  color: #000;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.chatbox-history {
+  max-height: 240px;
+  overflow-y: auto;
+  margin-bottom: 0.5rem;
+}
+
+.chatbox-input {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.chatbox-input input {
+  flex: 1;
+}

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,3 +1,116 @@
+import { useState } from 'react'
+import './QuizGame.css'
+
+interface StatementSet {
+  statements: string[]
+  lieIndex: number
+}
+
+const ROUNDS: StatementSet[] = [
+  {
+    statements: [
+      'Bananas are berries.',
+      'Venus is hotter than Mercury.',
+      'Goldfish have a memory span of only three seconds.',
+    ],
+    lieIndex: 2,
+  },
+  {
+    statements: [
+      'Adult humans have 206 bones.',
+      'The Amazon River is the longest river in the world.',
+      'The Eiffel Tower can be 15 cm taller during the summer.',
+    ],
+    lieIndex: 1,
+  },
+  {
+    statements: [
+      'Honey never spoils.',
+      'Mount Everest is the highest mountain above sea level.',
+      'Humans can breathe and swallow at the same time.',
+    ],
+    lieIndex: 2,
+  },
+]
+
+function ChatBox() {
+  const [input, setInput] = useState('')
+  const [history, setHistory] = useState<string[]>([])
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const q = input.trim()
+    if (!q) return
+    setHistory((prev) => [...prev, q])
+    setInput('')
+  }
+
+  return (
+    <div className="chatbox">
+      <h3>Ask the Assistant</h3>
+      <div className="chatbox-history">
+        {history.map((msg, i) => (
+          <p key={i}>You: {msg}</p>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="chatbox-input">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a question..."
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  )
+}
+
 export default function QuizGame() {
-  return <h2>Quiz Game Coming Soon</h2>
+  const [round, setRound] = useState(0)
+  const [choice, setChoice] = useState<number | null>(null)
+
+  const current = ROUNDS[round]
+  const correct = choice === current.lieIndex
+
+  function handleSelect(idx: number) {
+    if (choice !== null) return
+    setChoice(idx)
+  }
+
+  function nextRound() {
+    setChoice(null)
+    setRound((r) => (r + 1) % ROUNDS.length)
+  }
+
+  return (
+    <div className="truth-game">
+      <div className="statements">
+        <h2>3 Truths and a Lie</h2>
+        <ul className="statement-list">
+          {current.statements.map((s, i) => (
+            <li key={i}>
+              <button
+                className={`statement-btn ${choice === i ? 'selected' : ''}`}
+                onClick={() => handleSelect(i)}
+                disabled={choice !== null}
+              >
+                {s}
+              </button>
+            </li>
+          ))}
+        </ul>
+        {choice !== null && (
+          <>
+            <p className="feedback">
+              {correct
+                ? '✅ Correct! You spotted the hallucination.'
+                : '❌ Incorrect. That one is true.'}
+            </p>
+            <button onClick={nextRound}>Next Round</button>
+          </>
+        )}
+      </div>
+      <ChatBox />
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- replace placeholder QuizGame with new "3 Truths and a Lie" game
- allow picking the fabricated statement with feedback and round cycling
- add a simple chat box for verifying facts during play
- style the new game page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842331ec6c8832f8ce7e2a7a9c4c16b