### PR TITLE
Fix light theme readability

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -58,6 +58,7 @@
   align-items: center;
   gap: 0.5rem;
   background: #fff;
+  color: #000;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s ease, border-color 0.2s ease;
 }
@@ -93,6 +94,7 @@
 .match3-sidebar {
   max-width: 240px;
   background: #fff;
+  color: #000;
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);

--- a/learning-games/src/components/ui/card.tsx
+++ b/learning-games/src/components/ui/card.tsx
@@ -22,6 +22,7 @@ const Card: React.FC<CardProps> = ({
         border: '1px solid #eee',
         borderRadius: '8px',
         background: '#fff',
+        color: '#000',
         boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
         ...style,
       }}

--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -7,6 +7,7 @@
 
 .statements {
   background: #fff;
+  color: #000;
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
@@ -26,6 +27,7 @@
   border: 1px solid #ccc;
   border-radius: 6px;
   background: #f8f8f8;
+  color: #000;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- ensure text is dark on light surfaces
- tweak quiz and match3 styles
- update Card component style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842359fc5b8832f8ac231f1f2b733a7