### PR TITLE
Add refresh button to quiz

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -68,3 +68,21 @@
 .chatbox-input input {
   flex: 1;
 }
+
+.statement-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.refresh-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+.refresh-btn:hover {
+  color: var(--color-purple);
+}

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -77,6 +77,12 @@ export default function QuizGame() {
     setChoice(idx)
   }
 
+  function refreshRound() {
+    setChoice(null)
+    const next = Math.floor(Math.random() * ROUNDS.length)
+    setRound(next)
+  }
+
   function nextRound() {
     setChoice(null)
     setRound((r) => (r + 1) % ROUNDS.length)
@@ -85,7 +91,16 @@ export default function QuizGame() {
   return (
     <div className="truth-game">
       <div className="statements">
-        <h2>3 Truths and a Lie</h2>
+        <div className="statement-header">
+          <h2>3 Truths and a Lie</h2>
+          <button
+            className="refresh-btn"
+            onClick={refreshRound}
+            aria-label="New statements"
+          >
+            🔄
+          </button>
+        </div>
         <ul className="statement-list">
           {current.statements.map((s, i) => (
             <li key={i}>


### PR DESCRIPTION
## Summary
- add a refresh button in the quiz game to load a new statement set
- style refresh icon

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842364c5770832fbfca6a120afaa986