### PR TITLE
Improve quiz layout and add challenge banner

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -1,7 +1,9 @@
 .truth-game {
+  width: 100%;
   display: grid;
   grid-template-columns: 1fr 260px;
   gap: 1rem;
+  justify-content: center;
   align-items: start;
 }
 
@@ -85,4 +87,38 @@
 
 .refresh-btn:hover {
   color: var(--color-purple);
+}
+
+.quiz-page {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.challenge-banner {
+  background: linear-gradient(135deg, var(--color-orange), var(--color-purple));
+  color: #fff;
+  font-weight: bold;
+  padding: 0.5rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.quiz-sidebar {
+  max-width: 240px;
+  background: #fff;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  text-align: left;
+  margin: 0 auto 1rem;
+}
+
+@media (max-width: 600px) {
+  .truth-game {
+    grid-template-columns: 1fr;
+  }
+  .quiz-sidebar {
+    max-width: none;
+  }
 }

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { motion } from 'framer-motion'
 import './QuizGame.css'
 
 interface StatementSet {
@@ -33,9 +34,35 @@ const ROUNDS: StatementSet[] = [
   },
 ]
 
+const QUOTE = 'Always verify surprising claims.'
+const TIP = 'Tip: ask for sources when something sounds off.'
+
 interface ChatMessage {
   role: 'user' | 'assistant'
   content: string
+}
+
+function ChallengeBanner() {
+  return (
+    <motion.div
+      className="challenge-banner reveal"
+      animate={{ scale: [1, 1.1, 1] }}
+      transition={{ repeat: Infinity, duration: 2 }}
+    >
+      Super Hard Challenge! Spot the liar 🕵️
+    </motion.div>
+  )
+}
+
+function WhyItMatters() {
+  return (
+    <aside className="quiz-sidebar reveal">
+      <h3>Why It Matters</h3>
+      <p>Hallucinations happen when an AI confidently states something untrue.</p>
+      <blockquote className="sidebar-quote">{QUOTE}</blockquote>
+      <p className="sidebar-tip">{TIP}</p>
+    </aside>
+  )
 }
 
 function ChatBox() {
@@ -120,13 +147,16 @@ export default function QuizGame() {
   }
 
   return (
-    <div className="truth-game">
-      <div className="statements">
-        <div className="statement-header">
-          <h2>3 Truths and a Lie</h2>
-          <button
-            className="refresh-btn"
-            onClick={refreshRound}
+    <div className="quiz-page">
+      <ChallengeBanner />
+      <WhyItMatters />
+      <div className="truth-game">
+        <div className="statements">
+          <div className="statement-header">
+            <h2>3 Truths and a Lie</h2>
+            <button
+              className="refresh-btn"
+              onClick={refreshRound}
             aria-label="New statements"
           >
             🔄
@@ -155,8 +185,9 @@ export default function QuizGame() {
             <button onClick={nextRound}>Next Round</button>
           </>
         )}
+        </div>
+        <ChatBox />
       </div>
-      <ChatBox />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- restyle `QuizGame` with a banner and sidebar
- add CSS for responsive quiz layout

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684242b6eb7c832fb0c9fdff9ee696b1