### PR TITLE
Fix reveal animations and layout for quiz page

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -54,6 +54,7 @@
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  grid-column: span 2;
 }
 
 .chatbox-history {
@@ -111,7 +112,7 @@
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   text-align: left;
-  margin: 0 auto 1rem;
+  margin-bottom: 1rem;
 }
 
 @media (max-width: 600px) {
@@ -120,5 +121,6 @@
   }
   .quiz-sidebar {
     max-width: none;
+    margin-top: 1rem;
   }
 }

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import './QuizGame.css'
 
@@ -146,10 +146,24 @@ export default function QuizGame() {
     setRound((r) => (r + 1) % ROUNDS.length)
   }
 
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible')
+          obs.unobserve(entry.target)
+        }
+      })
+    }, { threshold: 0.1 })
+
+    document.querySelectorAll('.reveal').forEach((el) => observer.observe(el))
+
+    return () => observer.disconnect()
+  }, [])
+
   return (
     <div className="quiz-page">
       <ChallengeBanner />
-      <WhyItMatters />
       <div className="truth-game">
         <div className="statements">
           <div className="statement-header">
@@ -186,6 +200,7 @@ export default function QuizGame() {
           </>
         )}
         </div>
+        <WhyItMatters />
         <ChatBox />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- center new quiz elements and observe scroll for reveal animations
- span the chatbox across columns and tweak sidebar

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684246c080c8832f926f4d1c51c09304