### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -5,6 +5,12 @@
   text-align: center;
 }
 
+@media (max-width: 600px) {
+  #root {
+    padding: 1rem;
+  }
+}
+
 .logo {
   height: 6em;
   padding: 1.5em;
@@ -215,6 +221,15 @@
 
 .navbar a:hover {
   color: var(--color-lime);
+}
+
+.menu-toggle {
+  display: none;
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
 }
 
 .hero {
@@ -443,5 +458,24 @@
   background: #f1f5f9;
   color: #000;
   border-color: #cbd5e1;
+}
+
+@media (max-width: 600px) {
+  .menu-toggle {
+    display: block;
+  }
+  .navbar ul {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    flex-direction: column;
+    background: var(--color-purple);
+    padding: 1rem;
+    display: none;
+  }
+  .navbar ul.open {
+    display: flex;
+  }
 }
 

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -1,14 +1,32 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 
 export default function NavBar() {
+  const [open, setOpen] = useState(false)
+
   return (
     <nav className="navbar">
       <div className="brand">StrawberryTech</div>
-      <ul>
-        <li><Link to="/">Home</Link></li>
-        <li><Link to="/games/match3">Match-3</Link></li>
-        <li><Link to="/games/quiz">Quiz</Link></li>
-        <li><Link to="/leaderboard">Leaderboard</Link></li>
+      <button
+        className="menu-toggle"
+        aria-label="Toggle navigation"
+        onClick={() => setOpen(o => !o)}
+      >
+        ☰
+      </button>
+      <ul className={open ? 'open' : undefined} onClick={() => setOpen(false)}>
+        <li>
+          <Link to="/">Home</Link>
+        </li>
+        <li>
+          <Link to="/games/match3">Match-3</Link>
+        </li>
+        <li>
+          <Link to="/games/quiz">Quiz</Link>
+        </li>
+        <li>
+          <Link to="/leaderboard">Leaderboard</Link>
+        </li>
       </ul>
     </nav>
   )


### PR DESCRIPTION
## Summary
- tweak global padding for small screens
- add responsive nav menu with hamburger toggle

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6842d3a511d8832f910ef9899ba567b9