### PR TITLE
Enable responsive layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Node **18+** is recommended. Major dependencies include React 19, React Router 7
 - `npm run test` runs the Vitest unit tests.
 - `npm run build` creates a production build in `dist/`.
 
+### Running Tests
+
+Before executing the test suite make sure dependencies are installed:
+
+```bash
+cd learning-games
+npm install
+npm test
+```
+
+Without installing the packages first the `vitest` command used by
+`npm test` will not be available and the tests will fail.
+
 ## Environment Variables
 RobotChat uses the OpenAI API. Create a `.env` file inside `learning-games` containing:
 

--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -1,6 +1,6 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 2rem;
   text-align: center;
 }
@@ -52,6 +52,12 @@
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
   margin-top: 1rem;
+}
+
+@media (max-width: 480px) {
+  .game-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .game-card {
@@ -242,6 +248,12 @@
   margin-bottom: 2rem;
   position: relative;
   overflow: hidden;
+}
+
+@media (max-width: 480px) {
+  .hero {
+    padding: 1.5rem 1rem;
+  }
 }
 
 @keyframes gradientShift {

--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -20,6 +20,10 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 a {
   font-weight: 500;
   color: var(--color-purple);
@@ -31,10 +35,9 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  padding: 0 1rem;
 }
 
 h1 {

--- a/learning-games/src/pages/AgeInputForm.css
+++ b/learning-games/src/pages/AgeInputForm.css
@@ -15,6 +15,17 @@
   color: #fff;
 }
 
+@media (max-width: 480px) {
+  .age-form form {
+    width: 100%;
+    margin: 0 1rem;
+    padding: 1rem;
+  }
+  .age-form input {
+    max-width: none;
+  }
+}
+
 @keyframes ageGradient {
   0% {
     background-position: 0 50%;

--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -70,3 +70,12 @@
   margin-top: 1rem;
   font-style: italic;
 }
+
+@media (max-width: 480px) {
+  .dragdrop-game {
+    padding: 0.5rem;
+  }
+  .sentence {
+    font-size: 1rem;
+  }
+}

--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -46,4 +46,10 @@
   gap: 1.5rem;
 }
 
+@media (max-width: 480px) {
+  .game-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 

--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -95,6 +95,12 @@
   margin: 0 auto;
 }
 
+@media (max-width: 480px) {
+  .quiz-page {
+    margin: 0 1rem;
+  }
+}
+
 .challenge-banner {
   background: linear-gradient(135deg, var(--color-orange), var(--color-purple));
   color: #fff;

--- a/learning-games/src/pages/SplashPage.css
+++ b/learning-games/src/pages/SplashPage.css
@@ -22,3 +22,13 @@
 .start-form button {
   margin-top: 1rem;
 }
+
+@media (max-width: 480px) {
+  .overlay {
+    padding: 0 1rem;
+  }
+  .start-form input {
+    width: 100%;
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure layout isn't stuck centered on large screens by letting `#root` span full width
- drop global body centering styles
- add mobile responsive rules across pages
- set global box-sizing and body padding
- document how to install dependencies and run tests

## Testing
- `npm test --silent` (passes)
- `npm run lint --silent` (passes with warnings)


------
https://chatgpt.com/codex/tasks/task_e_6842d5fe83b4832fa020e443e4192ae6