### PR TITLE
Add profile page with editing

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -5,6 +5,7 @@ import SplashPage from './pages/SplashPage'
 import Match3Game from './pages/Match3Game'
 import QuizGame from './pages/QuizGame'
 import LeaderboardPage from './pages/LeaderboardPage'
+import ProfilePage from './pages/ProfilePage'
 import { Toaster } from 'react-hot-toast'
 import NavBar from './components/layout/NavBar'
 import Footer from './components/layout/Footer'
@@ -21,6 +22,7 @@ function App() {
         <Route path="/games/match3" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
+        <Route path="/profile" element={<ProfilePage />} />
       </Routes>
       {/* Verification comment: routes render correctly with context */}
       <Toaster />

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -27,6 +27,9 @@ export default function NavBar() {
         <li>
           <Link to="/leaderboard">Leaderboard</Link>
         </li>
+        <li>
+          <Link to="/profile">Profile</Link>
+        </li>
       </ul>
     </nav>
   )

--- a/learning-games/src/pages/AgeInputForm.tsx
+++ b/learning-games/src/pages/AgeInputForm.tsx
@@ -8,22 +8,32 @@ import './AgeInputForm.css'
  * Form for collecting the user's age. Age is stored in context
  * and later used to customize game content by age group.
  */
-export default function AgeInputForm() {
+export default function AgeInputForm({
+  onSaved,
+  allowEdit = false,
+}: {
+  onSaved?: () => void
+  allowEdit?: boolean
+}) {
   const { user, setAge } = useContext(UserContext)
   const [age, setAgeState] = useState<number | ''>(user.age ?? '')
   const navigate = useNavigate()
 
-  // If age already exists, go straight to the game selection page
+  // If age already exists and editing isn't allowed, redirect away
   useEffect(() => {
-    if (user.age) navigate('/')
-  }, [user.age, navigate])
+    if (user.age && !allowEdit) navigate('/')
+  }, [user.age, navigate, allowEdit])
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
     const ageNumber = Number(age)
     if (ageNumber >= 12 && ageNumber <= 18) {
       setAge(ageNumber)
-      navigate('/')
+      if (onSaved) {
+        onSaved()
+      } else {
+        navigate('/')
+      }
     } else {
       alert('Age must be between 12 and 18')
     }

--- a/learning-games/src/pages/ProfilePage.tsx
+++ b/learning-games/src/pages/ProfilePage.tsx
@@ -1,0 +1,34 @@
+import { useContext, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import AgeInputForm from './AgeInputForm'
+import { UserContext } from '../context/UserContext'
+
+export default function ProfilePage() {
+  const { user, setName } = useContext(UserContext)
+  const [name, setNameState] = useState(user.name ?? '')
+  const navigate = useNavigate()
+
+  function handleSaveName(e: React.FormEvent) {
+    e.preventDefault()
+    setName(name)
+    navigate('/')
+  }
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h2>Edit Profile</h2>
+      <form onSubmit={handleSaveName} style={{ marginBottom: '1rem' }}>
+        <label htmlFor="name">Name:</label>
+        <input
+          id="name"
+          type="text"
+          value={name}
+          onChange={(e) => setNameState(e.target.value)}
+          style={{ marginLeft: '0.5rem' }}
+        />
+        <button type="submit" style={{ marginLeft: '0.5rem' }}>Save Name</button>
+      </form>
+      <AgeInputForm allowEdit onSaved={() => navigate('/')} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- enhance `NavBar` with a profile link
- allow editing existing age in `AgeInputForm`
- create a `ProfilePage` for updating name and age
- register the profile route in `App`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842d85f8460832fb54c69c793f4c28a