### PR TITLE
Add game instructions banner

### DIFF
--- a/learning-games/src/components/ui/InstructionBanner.css
+++ b/learning-games/src/components/ui/InstructionBanner.css
@@ -1,0 +1,24 @@
+.instruction-banner {
+  background: #f1f5f9;
+  color: #000;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  position: relative;
+  margin-bottom: 1rem;
+  text-align: left;
+}
+
+.banner-close {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.instruction-content {
+  padding-right: 1.5rem;
+}

--- a/learning-games/src/components/ui/InstructionBanner.tsx
+++ b/learning-games/src/components/ui/InstructionBanner.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import './InstructionBanner.css'
+
+export interface InstructionBannerProps {
+  children: React.ReactNode
+}
+
+export default function InstructionBanner({ children }: InstructionBannerProps) {
+  const [visible, setVisible] = useState(true)
+  if (!visible) return null
+  return (
+    <div className="instruction-banner">
+      <button
+        className="banner-close"
+        aria-label="Close instructions"
+        onClick={() => setVisible(false)}
+      >
+        \u2715
+      </button>
+      <div className="instruction-content">{children}</div>
+    </div>
+  )
+}

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 
 import { UserContext } from "../context/UserContext";
 import RobotChat from "../components/RobotChat";
+import InstructionBanner from "../components/ui/InstructionBanner";
 
 /** Tile element used in the grid */
 export interface Tile {
@@ -288,6 +289,10 @@ export default function Match3Game() {
 
   return (
     <div className="match3-wrapper">
+      <InstructionBanner>
+        Drag each tone word into the blank. After trying them all, answer the
+        quick quiz!
+      </InstructionBanner>
       <div className="match3-container">
         <ToneMatchGame onComplete={handleComplete} />
       </div>

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import './QuizGame.css'
+import InstructionBanner from '../components/ui/InstructionBanner'
 
 interface StatementSet {
   statements: string[]
@@ -164,6 +165,10 @@ export default function QuizGame() {
   return (
     <div className="quiz-page">
       <ChallengeBanner />
+      <InstructionBanner>
+        Choose the statement you believe is false. Use the refresh button for
+        new statements and click on an option to answer.
+      </InstructionBanner>
       <div className="truth-game">
         <div className="statements">
           <div className="statement-header">


### PR DESCRIPTION
## Summary
- add `InstructionBanner` component with CSS
- show banner at start of Match3Game
- show banner at start of QuizGame

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842d865e8b4832faefd89a8321bb8ea