### PR TITLE
Add round indicator to QuizGame

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -79,6 +79,11 @@
   margin-bottom: 0.5rem;
 }
 
+.round-info {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
 .refresh-btn {
   background: transparent;
   border: none;

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -175,11 +175,12 @@ export default function QuizGame() {
           >
             🔄
           </button>
-        </div>
-        <ul className="statement-list">
-          {current.statements.map((s, i) => (
-            <li key={i}>
-              <button
+          </div>
+          <p className="round-info">Round {round + 1} / {ROUNDS.length}</p>
+          <ul className="statement-list">
+            {current.statements.map((s, i) => (
+              <li key={i}>
+                <button
                 className={`statement-btn ${choice === i ? 'selected' : ''}`}
                 onClick={() => handleSelect(i)}
                 disabled={choice !== null}


### PR DESCRIPTION
## Summary
- display current round above quiz statements
- style round info in quiz CSS

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6842d86a06b8832f93443301678b02ed