### PR TITLE
Add role and label to RobotChat icon

### DIFF
--- a/learning-games/src/components/RobotChat.tsx
+++ b/learning-games/src/components/RobotChat.tsx
@@ -56,6 +56,15 @@ export default function RobotChat() {
         onClick={() => setOpen(true)}
         animate={{ y: [0, -10, 0] }}
         transition={{ repeat: Infinity, duration: 2 }}
+        role="button"
+        aria-label="Open practice chat"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setOpen(true)
+          }
+        }}
       >
         {'\u{1F916}'}
       </motion.div>


### PR DESCRIPTION
## Summary
- mark RobotChat icon as a button and provide aria label
- make icon keyboard focusable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d8725228832f9b3dabecc46f4d04