### PR TITLE
Add accessible labels for emoji

### DIFF
--- a/learning-games/src/components/RobotChat.tsx
+++ b/learning-games/src/components/RobotChat.tsx
@@ -57,7 +57,7 @@ export default function RobotChat() {
         animate={{ y: [0, -10, 0] }}
         transition={{ repeat: Infinity, duration: 2 }}
       >
-        {'\u{1F916}'}
+        <span role="img" aria-label="robot">🤖</span>
       </motion.div>
       {open && (
         <div className="chat-modal-overlay" onClick={() => setOpen(false)}>
@@ -68,9 +68,14 @@ export default function RobotChat() {
             <h3>Practice</h3>
             <div className="chat-history">
               {messages.map((m, i) => (
-                <p key={i} className={`chat-message ${m.role}`}>{
-                  m.role === 'user' ? '🧑 ' : '🤖 '
-                }{m.content}</p>
+                <p key={i} className={`chat-message ${m.role}`}>
+                  {m.role === 'user' ? (
+                    <span role="img" aria-label="person">🧑</span>
+                  ) : (
+                    <span role="img" aria-label="robot">🤖</span>
+                  )}{' '}
+                  {m.content}
+                </p>
               ))}
             </div>
             <form className="chat-input" onSubmit={sendMessage}>

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -55,11 +55,15 @@ export default function Home() {
       {/* game list */}
       <div className="game-grid reveal">
         <Link className="game-card" to="/games/match3">
-          <span className="game-icon">🧩</span>
+          <span className="game-icon">
+            <span role="img" aria-label="puzzle piece">🧩</span>
+          </span>
           <span>Match-3 Puzzle</span>
         </Link>
         <Link className="game-card" to="/games/quiz">
-          <span className="game-icon">❓</span>
+          <span className="game-icon">
+            <span role="img" aria-label="question mark">❓</span>
+          </span>
           <span>Quiz Game</span>
         </Link>
       </div>

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -173,7 +173,7 @@ export default function QuizGame() {
               onClick={refreshRound}
             aria-label="New statements"
           >
-            🔄
+            <span role="img" aria-label="refresh">🔄</span>
           </button>
         </div>
         <ul className="statement-list">
@@ -192,9 +192,17 @@ export default function QuizGame() {
         {choice !== null && (
           <>
             <p className="feedback">
-              {correct
-                ? '✅ Correct! You spotted the hallucination.'
-                : '❌ Incorrect. That one is true.'}
+              {correct ? (
+                <>
+                  <span role="img" aria-label="check mark">✅</span>{' '}
+                  Correct! You spotted the hallucination.
+                </>
+              ) : (
+                <>
+                  <span role="img" aria-label="cross mark">❌</span>{' '}
+                  Incorrect. That one is true.
+                </>
+              )}
             </p>
             <button onClick={nextRound}>Next Round</button>
           </>

--- a/learning-games/src/pages/SplashPage.tsx
+++ b/learning-games/src/pages/SplashPage.tsx
@@ -30,7 +30,10 @@ export default function SplashPage() {
   return (
     <div className="splash-container">
       <div className="overlay">
-        <h1>Welcome to StrawberryTech! 🍓</h1>
+        <h1>
+          Welcome to StrawberryTech!
+          <span role="img" aria-label="strawberry">🍓</span>
+        </h1>
         <p>Play while you learn.</p>
         <form onSubmit={handleSubmit} className="start-form">
           <input


### PR DESCRIPTION
## Summary
- wrap emoji in span elements with aria-labels
- update RobotChat, Home, SplashPage and QuizGame screens

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6842d87576d8832f928044b47ae6c222