### PR TITLE
Handle API unreachable with toast

### DIFF
--- a/learning-games/src/components/RobotChat.tsx
+++ b/learning-games/src/components/RobotChat.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
+import { toast } from 'react-hot-toast'
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -45,7 +46,11 @@ export default function RobotChat() {
       }
     } catch (err) {
       console.error(err)
-      setMessages(prev => [...prev, { role: 'assistant', content: 'Failed to get response.' }])
+      toast.error('Unable to reach the API. Check your network or .env key.')
+      setMessages(prev => [
+        ...prev,
+        { role: 'assistant', content: 'Failed to get response.' },
+      ])
     }
   }
 

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
+import { toast } from 'react-hot-toast'
 import './QuizGame.css'
 
 interface StatementSet {
@@ -96,6 +97,7 @@ function ChatBox() {
       }
     } catch (err) {
       console.error(err)
+      toast.error('Unable to reach the API. Check your network or .env key.')
       setMessages(prev => [
         ...prev,
         { role: 'assistant', content: 'Failed to get response.' },


### PR DESCRIPTION
## Summary
- show a toast error if the OpenAI API can't be reached in RobotChat
- show a toast error if the OpenAI API can't be reached in QuizGame

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d8839734832f80c7f31cea9093b3