### PR TITLE
Improve Quiz instructions and styling

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -8,11 +8,12 @@
 }
 
 .statements {
-  background: #fff;
-  color: var(--color-text-dark);
+  background: linear-gradient(135deg, var(--color-purple-dark), var(--color-blue));
+  color: #fff;
   padding: 1rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  margin-bottom: 1rem;
 }
 
 .statement-list {
@@ -25,22 +26,24 @@
   width: 100%;
   text-align: left;
   margin-bottom: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.6rem 0.75rem;
   border: 1px solid #ccc;
   border-radius: 6px;
-  background: #f8f8f8;
+  background: #fdfdfd;
   color: var(--color-text-dark);
   cursor: pointer;
+  transition: transform 0.15s, background-color 0.15s;
 }
 
 .statement-btn:hover {
   background: #ececec;
+  transform: scale(1.03);
 }
 
 .statement-btn.selected {
-  background: var(--color-purple);
+  background: var(--color-orange);
   color: #fff;
-  border-color: var(--color-purple);
+  border-color: var(--color-orange);
 }
 
 .feedback {
@@ -104,6 +107,9 @@
   .quiz-page {
     margin: 0 1rem;
   }
+  .statement-btn {
+    font-size: 0.9rem;
+  }
 }
 
 .challenge-banner {
@@ -132,6 +138,5 @@
   }
   .quiz-sidebar {
     max-width: none;
-    margin-top: 1rem;
   }
 }

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -51,7 +51,7 @@ function ChallengeBanner() {
       animate={{ scale: [1, 1.1, 1] }}
       transition={{ repeat: Infinity, duration: 2 }}
     >
-      Super Hard Challenge! Spot the liar 🕵️
+      Ultimate Challenge: find the AI's lie! 🕵️
     </motion.div>
   )
 }
@@ -60,7 +60,7 @@ function WhyItMatters() {
   return (
     <aside className="quiz-sidebar reveal">
       <h3>Why It Matters</h3>
-      <p>Hallucinations happen when an AI confidently states something untrue.</p>
+      <p>AI hallucinations occur when the system confidently states something untrue.</p>
       <blockquote className="sidebar-quote">{QUOTE}</blockquote>
       <p className="sidebar-tip">{TIP}</p>
     </aside>
@@ -168,9 +168,10 @@ export default function QuizGame() {
     <div className="quiz-page">
       <ChallengeBanner />
       <InstructionBanner>
-        Choose the statement you believe is false. Use the refresh button for
-        new statements and click on an option to answer.
+        Find the one false statement—the AI hallucination. Tap the refresh icon
+        for new prompts and then select your answer.
       </InstructionBanner>
+      <WhyItMatters />
       <div className="truth-game">
         <div className="statements">
           <div className="statement-header">
@@ -208,7 +209,6 @@ export default function QuizGame() {
           </>
         )}
         </div>
-        <WhyItMatters />
         <ChatBox />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refine quiz instructions to focus on finding the AI hallucination
- move the learning card above the game section
- style quiz buttons and card with colorful gradients
- tweak mobile layout for better readability

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842dd7d2448832fbd6d499e166ebdbe