### PR TITLE
Rename quiz game and fix close buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ StrawberryTech is a collection of small web games built with **React**, **TypeSc
 ### Match‑3 Puzzle
 Swap adjacent tiles to make rows or columns of three using a simple drag‑and‑drop mechanic. Matches award points and may show leadership tips that vary by age group. Scores and badges are saved for later.
 
-### Quiz Game
-A short multiple‑choice quiz (implementation in progress) that will scale question difficulty according to the player's age.
+### Two Truths and a Lie
+A short quiz where you spot the single AI hallucination hidden among two truthful statements.
 
 ## Age‑Adaptive Features
 - Players enter an age between **12–18** on first visit.

--- a/learning-games/src/components/RobotChat.tsx
+++ b/learning-games/src/components/RobotChat.tsx
@@ -77,7 +77,7 @@ export default function RobotChat() {
         <div className="chat-modal-overlay" onClick={() => setOpen(false)}>
           <div className="chat-modal" onClick={e => e.stopPropagation()}>
             <button className="chat-close" onClick={() => setOpen(false)}>
-              \u2715
+              X
             </button>
             <h3>Practice</h3>
             <div className="chat-history">

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -22,7 +22,7 @@ export default function NavBar() {
           <Link to="/games/match3">Match-3</Link>
         </li>
         <li>
-          <Link to="/games/quiz">Quiz</Link>
+          <Link to="/games/quiz">Two Truths and a Lie</Link>
         </li>
         <li>
           <Link to="/leaderboard">Leaderboard</Link>

--- a/learning-games/src/components/ui/InstructionBanner.tsx
+++ b/learning-games/src/components/ui/InstructionBanner.tsx
@@ -15,7 +15,7 @@ export default function InstructionBanner({ children }: InstructionBannerProps) 
         aria-label="Close instructions"
         onClick={() => setVisible(false)}
       >
-        \u2715
+        X
       </button>
       <div className="instruction-content">{children}</div>
     </div>

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -60,7 +60,7 @@ export default function Home() {
         </Link>
         <Link className="game-card" to="/games/quiz">
           <span className="game-icon">❓</span>
-          <span>Quiz Game</span>
+          <span>Two Truths and a Lie</span>
         </Link>
       </div>
 

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -175,7 +175,7 @@ export default function QuizGame() {
       <div className="truth-game">
         <div className="statements">
           <div className="statement-header">
-            <h2>3 Truths and a Lie</h2>
+            <h2>Two Truths and a Lie</h2>
             <button
               className="refresh-btn"
               onClick={refreshRound}


### PR DESCRIPTION
## Summary
- rename the quiz to **Two Truths and a Lie** across the UI and docs
- use a simple `X` character for closing RobotChat and InstructionBanner

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842e45290bc832fbc30f6a6f63383de