### PR TITLE
Enable name collection and any age

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StrawberryTech Learning Games
 
-StrawberryTech is a collection of small web games built with **React**, **TypeScript** and **Vite**. Each game adapts content based on the player's age (12‑18) which is stored locally so progress persists between sessions.
+StrawberryTech is a collection of small web games built with **React**, **TypeScript** and **Vite**. Each game adapts content based on the player's age, which is stored locally so progress persists between sessions.
 
 ## Mini Games
 
@@ -11,7 +11,7 @@ Swap adjacent tiles to make rows or columns of three using a simple drag‑and�
 A short quiz where you spot the single AI hallucination hidden among two truthful statements.
 
 ## Age‑Adaptive Features
-- Players enter an age between **12–18** on first visit.
+- Players enter their age and name on first visit.
 - Games read the stored age to tweak difficulty and show tailored tips.
 - High scores and earned badges persist using `localStorage`.
 

--- a/learning-games/src/pages/AgeInputForm.tsx
+++ b/learning-games/src/pages/AgeInputForm.tsx
@@ -15,8 +15,9 @@ export default function AgeInputForm({
   onSaved?: () => void
   allowEdit?: boolean
 }) {
-  const { user, setAge } = useContext(UserContext)
+  const { user, setAge, setName } = useContext(UserContext)
   const [age, setAgeState] = useState<number | ''>(user.age ?? '')
+  const [name, setNameState] = useState(user.name ?? '')
   const navigate = useNavigate()
 
   // If age already exists and editing isn't allowed, redirect away
@@ -27,27 +28,34 @@ export default function AgeInputForm({
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
     const ageNumber = Number(age)
-    if (ageNumber >= 12 && ageNumber <= 18) {
+    if (!Number.isNaN(ageNumber) && ageNumber > 0) {
       setAge(ageNumber)
+      if (name) setName(name)
       if (onSaved) {
         onSaved()
       } else {
         navigate('/')
       }
     } else {
-      alert('Age must be between 12 and 18')
+      alert('Please enter a valid age')
     }
   }
 
   return (
     <div className="age-form">
       <form onSubmit={handleSubmit}>
+        <label htmlFor="name">Enter your name:</label>
+        <input
+          id="name"
+          type="text"
+          value={name}
+          onChange={(e) => setNameState(e.target.value)}
+          required
+        />
         <label htmlFor="age">Enter your age:</label>
         <input
           id="age"
           type="number"
-          min={12}
-          max={18}
           value={age}
           onChange={(e) => {
             const { value } = e.target
@@ -55,7 +63,7 @@ export default function AgeInputForm({
           }}
           required
         />
-        <button type="submit">Save Age</button>
+        <button type="submit">Save</button>
       </form>
     </div>
   )


### PR DESCRIPTION
## Summary
- allow any positive age and capture player's name in age form
- update docs to mention both name and age collection

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f54b4d30832f96e18e10b629f669