### PR TITLE
Fix build error and swap Home images

### DIFF
--- a/learning-games/package-lock.json
+++ b/learning-games/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^22.15.29",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -1141,6 +1142,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",

--- a/learning-games/package.json
+++ b/learning-games/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -42,8 +42,8 @@ export default function Home() {
       <section className="hero reveal">
         <h1>Fun Learning Awaits!</h1>
         <img
-          src="https://cdnjs.cloudflare.com/ajax/libs/openmoji/15.1.0/color/svg/1F353.svg"
-          alt="Strawberry mascot"
+          src="https://images.unsplash.com/photo-1675731118661-15dc54c11130?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400"
+          alt="Strawberry"
           className="hero-img"
         />
         <p className="tagline">Play engaging games and sharpen your skills.</p>
@@ -61,15 +61,15 @@ export default function Home() {
       <div className="game-grid reveal">
         <Link className="game-card" to="/games/match3">
           <img
-            src="https://cdnjs.cloudflare.com/ajax/libs/openmoji/15.1.0/color/svg/1F9E9.svg"
-            alt="Puzzle"
+            src="https://plus.unsplash.com/premium_photo-1723662084148-2cd2357705ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400"
+            alt="Puzzle pieces"
             className="game-icon"
           />
           <span>Match-3 Puzzle</span>
         </Link>
         <Link className="game-card" to="/games/quiz">
           <img
-            src="https://cdnjs.cloudflare.com/ajax/libs/openmoji/15.1.0/color/svg/2753.svg"
+            src="https://plus.unsplash.com/premium_photo-1678048604398-f42dda6997bd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400"
             alt="Question mark"
             className="game-icon"
           />

--- a/learning-games/src/types/canvas-confetti.d.ts
+++ b/learning-games/src/types/canvas-confetti.d.ts
@@ -1,0 +1,1 @@
+declare module 'canvas-confetti';


### PR DESCRIPTION
## Summary
- replace OpenMoji assets on Home with royalty-free images from Unsplash
- install `@types/canvas-confetti` and add a declaration file

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684304c722fc832fa187c17c2884b4b3