### PR TITLE
Fix Match3 sidebar layout

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -92,6 +92,7 @@
   padding: 1rem;
   border-radius: 8px;
   grid-column: 2;
+  grid-row: 1;
 }
 
 .match3-page {
@@ -118,6 +119,7 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   text-align: left;
   grid-column: 1;
+  grid-row: 1;
 }
 
 


### PR DESCRIPTION
## Summary
- align Match3 sidebar with the puzzle grid by pinning both grid items to the first row

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6843106ad074832f82dda770bdd61cc2