### PR TITLE
Refine hero and start button design

### DIFF
--- a/learning-games/index.html
+++ b/learning-games/index.html
@@ -17,6 +17,10 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>StrawberryTech Learning Games</title>
   </head>

--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -81,6 +81,7 @@
 
 .progress-summary {
   margin-top: 1rem;
+  text-align: center;
 }
 
 /* Match-3 styles */

--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -52,10 +52,20 @@
   display: block;
 }
 
+.hero-title {
+  font-family: 'Fredoka One', cursive;
+  font-size: 28px;
+  color: #ff6347;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
 .progress-summary progress {
-  width: 100%;
+  width: 80%;
   height: 1rem;
-  accent-color: var(--color-lime);
+  accent-color: #ffd700;
+  display: block;
+  margin: 0 auto;
 }
 
 .badge-icons {

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -40,7 +40,7 @@ export default function Home() {
     <div className="home">
       {/* hero section */}
       <section className="hero reveal">
-        <h1>Fun Learning Awaits!</h1>
+        <h1 className="hero-title">Embark on a Fruity Learning Adventure!</h1>
         <img
           src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
           alt="Strawberry logo"

--- a/learning-games/src/pages/SplashPage.css
+++ b/learning-games/src/pages/SplashPage.css
@@ -23,6 +23,33 @@
   margin-top: 1rem;
 }
 
+.start-btn {
+  font-family: 'Roboto', sans-serif;
+  font-weight: bold;
+  font-size: 16px;
+  background: #32cd32;
+  min-width: 44px;
+  min-height: 44px;
+  transition: background-color 0.3s ease;
+}
+
+.start-btn:hover {
+  background: #228b22;
+}
+
+.start-btn:active {
+  animation: bounce 0.3s;
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
 @media (max-width: 480px) {
   .overlay {
     padding: 0 1rem;

--- a/learning-games/src/pages/SplashPage.tsx
+++ b/learning-games/src/pages/SplashPage.tsx
@@ -48,7 +48,7 @@ export default function SplashPage() {
             onChange={(e) => setAge(Number(e.target.value))}
             required
           />
-          <button type="submit">Start Playing</button>
+          <button type="submit" className="start-btn">Begin Your Journey</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update hero text to a fun headline
- load Fredoka One font
- style hero title
- tweak progress bar color
- rename splash button and style it with bounce animation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843109fd390832fa90e99b6c69f0077