### PR TITLE
Update game names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ StrawberryTech is a collection of small web games built with **React**, **TypeSc
 
 ## Mini Games
 
-### Match‑3 Puzzle
-Swap adjacent tiles to make rows or columns of three using a simple drag‑and‑drop mechanic. Matches award points and may show leadership tips that vary by age group. Scores and badges are saved for later.
+### Tone Puzzle
+Swap adjectives to explore how word choice affects tone. Matches award points and may show leadership tips that vary by age group. Scores and badges are saved for later.
 
-### Two Truths and a Lie
+### Hulluscinations
 A short quiz where you spot the single AI hallucination hidden among two truthful statements.
 
 ## Age‑Adaptive Features

--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
         <Route path="/age" element={<AgeInputForm />} />
         <Route path="/welcome" element={<SplashPage />} />
         <Route path="/" element={<Home />} />
-        <Route path="/games/match3" element={<Match3Game />} />
+        <Route path="/games/tone" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/help" element={<HelpPage />} />

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -26,10 +26,10 @@ export default function NavBar() {
           <Link to="/">Home</Link>
         </li>
         <li>
-          <Link to="/games/match3">Match-3</Link>
+          <Link to="/games/tone">Tone</Link>
         </li>
         <li>
-          <Link to="/games/quiz">Two Truths and a Lie</Link>
+          <Link to="/games/quiz">Hulluscinations</Link>
         </li>
         <li>
           <Link to="/leaderboard">Leaderboard</Link>

--- a/learning-games/src/data/badges.ts
+++ b/learning-games/src/data/badges.ts
@@ -8,13 +8,13 @@ export interface BadgeDefinition {
 export const BADGES: BadgeDefinition[] = [
   {
     id: 'first-match3',
-    name: 'First Match-3 Complete',
-    description: 'Finish a Match-3 game once',
+    name: 'First Tone Game Complete',
+    description: 'Finish a Tone game once',
   },
   {
     id: 'match-master',
-    name: 'Match-3 Master',
-    description: 'Score at least 100 points in Match-3',
+    name: 'Tone Master',
+    description: 'Score at least 100 points in Tone',
   },
   {
     id: 'quiz-whiz',

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -47,7 +47,7 @@ export default function Home() {
           className="hero-img"
         />
         <p className="tagline">Play engaging games and sharpen your skills.</p>
-        <button onClick={() => navigate('/games/match3')}>Play Now</button>
+        <button onClick={() => navigate('/games/tone')}>Play Now</button>
       </section>
 
       {/* greeting */}
@@ -59,13 +59,13 @@ export default function Home() {
 
       {/* game list */}
       <div className="game-grid reveal">
-        <Link className="game-card" to="/games/match3">
+        <Link className="game-card" to="/games/tone">
           <img
             src="https://plus.unsplash.com/premium_photo-1723662084148-2cd2357705ba?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&q=80&w=400"
             alt="Puzzle pieces"
             className="game-icon"
           />
-          <span>Match-3 Puzzle</span>
+          <span>Tone Puzzle</span>
         </Link>
         <Link className="game-card" to="/games/quiz">
           <img
@@ -73,7 +73,7 @@ export default function Home() {
             alt="Question mark"
             className="game-icon"
           />
-          <span>Two Truths and a Lie</span>
+          <span>Hulluscinations</span>
         </Link>
       </div>
 

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -11,7 +11,7 @@ export interface ScoreEntry {
 // Dummy leaderboards for each game. In a real multi-user app this data would
 // be fetched from a server.
 const DUMMY_SCORES: Record<string, ScoreEntry[]> = {
-  match3: [
+  tone: [
     { name: 'Alice', score: 240 },
     { name: 'Bob', score: 180 },
     { name: 'Charlie', score: 150 },
@@ -24,9 +24,9 @@ export default function LeaderboardPage() {
   return (
     <div>
       <h2>Leaderboard</h2>
-      {/* Show top scores for Match-3 */}
+      {/* Show top scores for Tone */}
       <section>
-        <h3>Match-3 High Scores</h3>
+        <h3>Tone High Scores</h3>
         <table style={{ margin: '0 auto' }}>
           <thead>
             <tr>
@@ -35,8 +35,8 @@ export default function LeaderboardPage() {
             </tr>
           </thead>
           <tbody>
-            {DUMMY_SCORES.match3
-              .concat({ name: user.name ?? 'You', score: user.scores['match3'] ?? 0 })
+            {DUMMY_SCORES.tone
+              .concat({ name: user.name ?? 'You', score: user.scores['tone'] ?? 0 })
               .sort((a, b) => b.score - a.score)
               .slice(0, 5)
               .map((entry) => (

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -177,7 +177,7 @@ export default function QuizGame() {
         <WhyItMatters />
         <div className="statements">
           <div className="statement-header">
-            <h2>Two Truths and a Lie</h2>
+            <h2>Hulluscinations</h2>
             <button
               className="refresh-btn"
               onClick={refreshRound}

--- a/learning-games/src/pages/SplashPage.tsx
+++ b/learning-games/src/pages/SplashPage.tsx
@@ -12,7 +12,7 @@ export default function SplashPage() {
 
   useEffect(() => {
     if (user.age) {
-      navigate('/games/match3')
+      navigate('/games/tone')
     }
   }, [user.age, navigate])
 
@@ -24,7 +24,7 @@ export default function SplashPage() {
       return
     }
     setUser({ ...user, name, age: ageNum })
-    navigate('/games/match3')
+    navigate('/games/tone')
   }
 
   return (


### PR DESCRIPTION
## Summary
- rename Match3 to Tone throughout nav and pages
- rename Two Truths and a Lie references to Hulluscinations
- update badges and leaderboard for new names
- adjust README docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684312d95e80832fae6bd035116fa3d9