### PR TITLE
Fix typos and redesign contrast toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ StrawberryTech is a collection of small web games built with **React**, **TypeSc
 ### Tone Puzzle
 Swap adjectives to explore how word choice affects tone. Matches award points and may show leadership tips that vary by age group. Scores and badges are saved for later.
 
-### Hulluscinations
+### Hallucinations
 A short quiz where you spot the single AI hallucination hidden among two truthful statements.
 
 ## Age‑Adaptive Features

--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -226,6 +226,13 @@
   margin-right: 1rem;
   background: #fff;
   color: var(--color-brand);
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .navbar ul {

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -31,7 +31,7 @@ export default function NavBar() {
           <Link to="/games/tone">Tone</Link>
         </li>
         <li>
-          <Link to="/games/quiz">Hulluscinations</Link>
+          <Link to="/games/quiz">Hallucinations</Link>
         </li>
         <li>
           <Link to="/leaderboard">Leaderboard</Link>

--- a/learning-games/src/components/layout/ThemeToggle.tsx
+++ b/learning-games/src/components/layout/ThemeToggle.tsx
@@ -11,9 +11,9 @@ export default function ThemeToggle() {
     <button
       className="theme-toggle"
       aria-label="Toggle high contrast mode"
-      onClick={() => setEnabled((v) => !v)}
+      onClick={() => setEnabled(v => !v)}
     >
-      {enabled ? 'Default' : 'High Contrast'}
+      <span aria-hidden="true">{enabled ? '🔲' : '🔳'}</span>
     </button>
   )
 }

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -73,7 +73,7 @@ export default function Home() {
             alt="Question mark"
             className="game-icon"
           />
-          <span>Hulluscinations</span>
+          <span>Hallucinations</span>
         </Link>
       </div>
 

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -178,7 +178,7 @@ export default function QuizGame() {
         <WhyItMatters />
         <div className="statements">
           <div className="statement-header">
-            <h2>Hulluscinations</h2>
+            <h2>Hallucinations</h2>
             <button
               className="refresh-btn"
               onClick={refreshRound}


### PR DESCRIPTION
## Summary
- correct misspellings of "Hallucinations" across the project
- replace the text-based high contrast button with a small icon toggle
- shrink the toggle size in the CSS

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684319afaf58832fb1b903dc360a964b