### PR TITLE
Improve mobile layout for Match3

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -204,7 +204,7 @@
   }
 
   .match3-sidebar {
-    margin-top: 1rem;
+    margin-top: 0;
   }
 
 }

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -310,15 +310,15 @@ export default function Match3Game() {
         Match adjectives to explore how tone changes the meaning of a message.
       </InstructionBanner>
       <div className="match3-wrapper">
-        <div className="match3-container">
-          <ToneMatchGame onComplete={handleComplete} />
-        </div>
         <aside className="match3-sidebar">
           <h3>Why Tone Matters</h3>
           <p>Drag the adjectives into the blank to try different tones.</p>
           <blockquote className="sidebar-quote">{sidebarQuote}</blockquote>
           <p className="sidebar-tip">{sidebarTip}</p>
         </aside>
+        <div className="match3-container">
+          <ToneMatchGame onComplete={handleComplete} />
+        </div>
       </div>
       <RobotChat />
       <p style={{ marginTop: '1rem', textAlign: 'center' }}>


### PR DESCRIPTION
## Summary
- reorder the Match3 sidebar to appear before the game
- tweak mobile CSS so the sidebar sits just under the banner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68431d64ef58832f9b9383fd13d00536