### PR TITLE
Add ProgressSidebar component

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -84,6 +84,23 @@
   text-align: center;
 }
 
+.progress-sidebar {
+  max-width: 240px;
+  background: #fff;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  text-align: left;
+  margin-bottom: 1rem;
+}
+
+.progress-sidebar progress {
+  width: 100%;
+  height: 1rem;
+  accent-color: #ffd700;
+}
+
 /* Match-3 styles */
 .match3-container {
   width: 100%;
@@ -205,6 +222,10 @@
 
   .match3-sidebar {
     margin-top: 0;
+  }
+
+  .progress-sidebar {
+    max-width: none;
   }
 
 }

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -1,0 +1,38 @@
+import { useContext } from 'react'
+import { Link } from 'react-router-dom'
+import { UserContext } from '../../context/UserContext'
+import { DUMMY_SCORES } from '../../pages/LeaderboardPage'
+
+export default function ProgressSidebar() {
+  const { user } = useContext(UserContext)
+  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const leaderboard = DUMMY_SCORES.tone
+    .concat({ name: user.name ?? 'You', score: user.scores['tone'] ?? 0 })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+
+  return (
+    <aside className="progress-sidebar">
+      <h3>Your Progress</h3>
+      <p>Total Points: {totalPoints}</p>
+      <progress value={totalPoints} max={100} />
+      <div className="badge-icons" style={{ marginTop: '0.5rem' }}>
+        {user.badges.map((b) => (
+          <span key={b}>🏅</span>
+        ))}
+        {user.badges.length === 0 && <span>No badges yet.</span>}
+      </div>
+      <h4 style={{ marginTop: '1rem' }}>Top Scores</h4>
+      <ol style={{ paddingLeft: '1.2rem' }}>
+        {leaderboard.map((entry) => (
+          <li key={entry.name} style={{ fontWeight: entry.name === (user.name ?? 'You') ? 'bold' : undefined }}>
+            {entry.name}: {entry.score}
+          </li>
+        ))}
+      </ol>
+      <p style={{ marginTop: '0.5rem' }}>
+        <Link to="/leaderboard">View full leaderboard</Link>
+      </p>
+    </aside>
+  )
+}

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -10,7 +10,7 @@ export interface ScoreEntry {
 
 // Dummy leaderboards for each game. In a real multi-user app this data would
 // be fetched from a server.
-const DUMMY_SCORES: Record<string, ScoreEntry[]> = {
+export const DUMMY_SCORES: Record<string, ScoreEntry[]> = {
   tone: [
     { name: 'Alice', score: 240 },
     { name: 'Bob', score: 180 },


### PR DESCRIPTION
## Summary
- show total points, badges, and leaderboard snippet in new `ProgressSidebar`
- export `DUMMY_SCORES` for reuse
- style `.progress-sidebar` responsively in `App.css`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843241d5858832f8768ee2e8d924c87