### PR TITLE
Update games to persist scores

### DIFF
--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -166,10 +166,11 @@ export function checkMatches(
   return { grid: working, gained, matchedTypes: Array.from(matchedTypes) };
 }
 
-function ToneMatchGame({ onComplete }: { onComplete: () => void }) {
+function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) {
   const [selected, setSelected] = useState<Tone | null>(null);
   const [used, setUsed] = useState<Set<Tone>>(new Set());
   const [quizAnswer, setQuizAnswer] = useState<Tone | null>(null);
+  const [score, setScore] = useState(0);
 
   function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {
     e.dataTransfer.setData("text/plain", tone);
@@ -178,9 +179,10 @@ function ToneMatchGame({ onComplete }: { onComplete: () => void }) {
   function handleDrop(e: React.DragEvent<HTMLSpanElement>) {
     e.preventDefault();
     const tone = e.dataTransfer.getData("text/plain") as Tone;
-    if (tones.includes(tone)) {
+    if (tones.includes(tone) && !used.has(tone)) {
       setSelected(tone);
       setUsed(new Set(used).add(tone));
+      setScore((s) => s + 20);
     }
   }
 
@@ -191,9 +193,9 @@ function ToneMatchGame({ onComplete }: { onComplete: () => void }) {
 
   useEffect(() => {
     if (used.size === tones.length) {
-      onComplete();
+      onComplete(score);
     }
-  }, [used, onComplete]);
+  }, [used, onComplete, score]);
 
   return (
     <div className="dragdrop-game">
@@ -274,7 +276,7 @@ function ToneMatchGame({ onComplete }: { onComplete: () => void }) {
  * show an age-based leadership tip.
  */
 export default function Match3Game() {
-  const { user, addBadge } = useContext(UserContext)
+  const { user, addBadge, setScore } = useContext(UserContext)
   const navigate = useNavigate()
   const [sidebarQuote] = useState(
     () => quotes[Math.floor(Math.random() * quotes.length)],
@@ -284,8 +286,13 @@ export default function Match3Game() {
       tips[Math.floor(Math.random() * tips.length)],
   )
 
-  function handleComplete() {
+  function handleComplete(score: number) {
     const earned: string[] = [];
+    setScore('tone', score)
+    if (score >= 100 && !user.badges.includes('match-master')) {
+      addBadge('match-master')
+      earned.push('match-master')
+    }
     if (!user.badges.includes("first-match3")) {
       addBadge("first-match3");
       earned.push("first-match3");

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useContext } from 'react'
 import { motion } from 'framer-motion'
 import { toast } from 'react-hot-toast'
 import { Link } from 'react-router-dom'
+import { UserContext } from '../context/UserContext'
 import './QuizGame.css'
 import InstructionBanner from '../components/ui/InstructionBanner'
 
@@ -128,8 +129,11 @@ function ChatBox() {
 }
 
 export default function QuizGame() {
+  const { user, setScore, addBadge } = useContext(UserContext)
   const [round, setRound] = useState(0)
   const [choice, setChoice] = useState<number | null>(null)
+  const [score, setScoreState] = useState(0)
+  const [played, setPlayed] = useState(0)
 
   const current = ROUNDS[round]
   const correct = choice === current.lieIndex
@@ -146,6 +150,23 @@ export default function QuizGame() {
   }
 
   function nextRound() {
+    const wasCorrect = correct
+    const newScore = wasCorrect ? score + 1 : score
+    setScoreState(newScore)
+    setPlayed(p => p + 1)
+    setScore('quiz', newScore)
+
+    if (played + 1 === ROUNDS.length) {
+      if (newScore === ROUNDS.length && !user.badges.includes('quiz-whiz')) {
+        addBadge('quiz-whiz')
+      }
+      toast.success(`You scored ${newScore} out of ${ROUNDS.length}`)
+      setScoreState(0)
+      setPlayed(0)
+      setChoice(null)
+      setRound(0)
+      return
+    }
     setChoice(null)
     setRound((r) => (r + 1) % ROUNDS.length)
   }


### PR DESCRIPTION
## Summary
- track tone puzzle score and update player data
- store quiz scores each round and award a badge for perfection

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684325f46548832f9e9a27e5e8001f6b