### PR TITLE
Integrate progress sidebar

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -128,6 +128,15 @@
   align-items: start;
 }
 
+.leaderboard-wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+  justify-content: center;
+  align-items: start;
+}
+
 .match3-sidebar {
   max-width: 240px;
   background: #fff;
@@ -211,6 +220,10 @@
 
 @media (max-width: 600px) {
   .match3-wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .leaderboard-wrapper {
     grid-template-columns: 1fr;
   }
 

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -34,7 +34,7 @@ export default function NavBar() {
           <Link to="/games/quiz">Hallucinations</Link>
         </li>
         <li>
-          <Link to="/leaderboard">Leaderboard</Link>
+          <Link to="/leaderboard">Progress</Link>
         </li>
         <li>
           <Link to="/help">Help</Link>

--- a/learning-games/src/pages/AgeInputForm.tsx
+++ b/learning-games/src/pages/AgeInputForm.tsx
@@ -22,7 +22,7 @@ export default function AgeInputForm({
 
   // If age already exists and editing isn't allowed, redirect away
   useEffect(() => {
-    if (user.age && !allowEdit) navigate('/')
+    if (user.age && !allowEdit) navigate('/leaderboard')
   }, [user.age, navigate, allowEdit])
 
   function handleSubmit(e: FormEvent) {
@@ -34,7 +34,7 @@ export default function AgeInputForm({
       if (onSaved) {
         onSaved()
       } else {
-        navigate('/')
+        navigate('/leaderboard')
       }
     } else {
       alert('Please enter a valid age')
@@ -66,7 +66,7 @@ export default function AgeInputForm({
         <button type="submit">Save</button>
       </form>
       <p style={{ marginTop: '1rem' }}>
-        <Link to="/">Return Home</Link>
+        <Link to="/leaderboard">Return to Progress</Link>
       </p>
     </div>
   )

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -79,7 +79,7 @@ export default function Home() {
 
       {/* navigation */}
       <p className="reveal">
-        <Link to="/leaderboard">View Leaderboard</Link>
+        <Link to="/leaderboard">View Progress</Link>
       </p>
 
       {/* progress summary */}

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { Link } from 'react-router-dom'
 import { UserContext } from '../context/UserContext'
-import { BADGES } from '../data/badges'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
 
 export interface ScoreEntry {
   name: string
@@ -22,8 +22,10 @@ export default function LeaderboardPage() {
   const { user } = useContext(UserContext)
 
   return (
-    <div>
-      <h2>Leaderboard</h2>
+    <div className="leaderboard-wrapper">
+      <ProgressSidebar />
+      <div>
+        <h2>Leaderboard</h2>
       {/* Show top scores for Tone */}
       <section>
         <h3>Tone High Scores</h3>
@@ -55,26 +57,10 @@ export default function LeaderboardPage() {
         </table>
       </section>
 
-      {/* Badges */}
-      <section style={{ marginTop: '2rem' }}>
-        <h3>Badges Earned</h3>
-        {user.badges.length === 0 && <p>No badges yet.</p>}
-        <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: '0.5rem' }}>
-          {user.badges.map((id) => {
-            const def = BADGES.find((b) => b.id === id)
-            return (
-              <li key={id} style={{ border: '1px solid #ccc', padding: '0.5rem' }}>
-                <strong>{def?.name ?? id}</strong>
-                <div style={{ fontSize: '0.9em' }}>{def?.description}</div>
-              </li>
-            )
-          })}
-        </ul>
-      </section>
-
       <p style={{ marginTop: '2rem' }}>
         <Link to="/">Return Home</Link>
       </p>
+      </div>
     </div>
   )
 }

--- a/learning-games/src/pages/ProfilePage.tsx
+++ b/learning-games/src/pages/ProfilePage.tsx
@@ -11,7 +11,7 @@ export default function ProfilePage() {
   function handleSaveName(e: React.FormEvent) {
     e.preventDefault()
     setName(name)
-    navigate('/')
+    navigate('/leaderboard')
   }
 
   return (
@@ -28,9 +28,9 @@ export default function ProfilePage() {
         />
         <button type="submit" style={{ marginLeft: '0.5rem' }}>Save Name</button>
       </form>
-      <AgeInputForm allowEdit onSaved={() => navigate('/')} />
+      <AgeInputForm allowEdit onSaved={() => navigate('/leaderboard')} />
       <p style={{ marginTop: '1rem' }}>
-        <Link to="/">Return Home</Link>
+        <Link to="/leaderboard">Return to Progress</Link>
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
- show ProgressSidebar on LeaderboardPage
- drop duplicate badge list from leaderboard
- direct age/profile forms back to leaderboard
- reword nav link to "Progress"
- allow home page to link to Progress hub

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843276040e8832f8c184a4950d081ba