### PR TITLE
Add sidebar grid layout to drag-drop game

### DIFF
--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -2,6 +2,20 @@
   padding: 1rem;
 }
 
+.dragdrop-page {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.dragdrop-wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+  justify-content: center;
+  align-items: start;
+}
+
 .sentence {
   font-size: 1.2rem;
   margin-bottom: 1rem;
@@ -77,5 +91,15 @@
   }
   .sentence {
     font-size: 1rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .dragdrop-wrapper {
+    grid-template-columns: 1fr;
+  }
+  .progress-sidebar {
+    max-width: none;
+    grid-column: auto;
   }
 }

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
 import './DragDropGame.css'
 
 const tones = [
@@ -60,31 +61,34 @@ export default function DragDropGame() {
   }
 
   return (
-    <div className="dragdrop-game">
-      <h2>Drag a tone into the blank</h2>
-      <p className="sentence">
-        Write a
-        <span
-          className="drop-area"
-          onDrop={handleDrop}
-          onDragOver={handleDragOver}
-        >
-          {selected ? ` ${selected} ` : ' ____ '}
-        </span>
-        short text to my manager calling out of work sick today.
-      </p>
-      <div className="word-bank">
-        {tones.map((tone) => (
-          <div
-            key={tone}
-            draggable
-            onDragStart={(e) => handleDragStart(e, tone)}
-            className="word"
+    <div className="dragdrop-page">
+      <div className="dragdrop-wrapper">
+        <ProgressSidebar />
+        <div className="dragdrop-game">
+          <h2>Drag a tone into the blank</h2>
+          <p className="sentence">
+          Write a
+          <span
+            className="drop-area"
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
           >
-            {tone}
+            {selected ? ` ${selected} ` : ' ____ '}
+          </span>
+          short text to my manager calling out of work sick today.
+          </p>
+          <div className="word-bank">
+            {tones.map((tone) => (
+              <div
+                key={tone}
+                draggable
+                onDragStart={(e) => handleDragStart(e, tone)}
+                className="word"
+              >
+                {tone}
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
       {selected && (
         <div className="response">
           <h3>AI Response</h3>
@@ -133,6 +137,8 @@ export default function DragDropGame() {
           )}
         </div>
       )}
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- adjust DragDropGame layout to use a new `dragdrop-wrapper` grid
- include `ProgressSidebar` in the left column
- collapse layout to a single column under 600px screens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6843277a6670832fb773e2942ee26381