### PR TITLE
Integrate progress hub routing

### DIFF
--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -329,7 +329,7 @@ export default function Match3Game() {
       </div>
       <RobotChat />
       <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-        <Link to="/">Return Home</Link>
+        <Link to="/leaderboard">Return to Progress</Link>
       </p>
     </div>
   );

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -238,7 +238,7 @@ export default function QuizGame() {
         </div>
         <ChatBox />
         <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-          <Link to="/">Return Home</Link>
+          <Link to="/leaderboard">Return to Progress</Link>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- direct players back to the progress hub from Match3 and Quiz games

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68432a5932f8832f8cfe66a613bdce3d