### PR TITLE
Add ProgressSidebar to quiz page

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -137,11 +137,16 @@
   grid-column: 1;
 }
 
+.progress-sidebar {
+  grid-column: 1;
+}
+
 @media (max-width: 600px) {
   .truth-game {
     grid-template-columns: 1fr;
   }
-  .quiz-sidebar {
+  .quiz-sidebar,
+  .progress-sidebar {
     max-width: none;
     grid-column: auto;
   }

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useContext } from 'react'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
 import { motion } from 'framer-motion'
 import { toast } from 'react-hot-toast'
 import { Link } from 'react-router-dom'
@@ -196,6 +197,7 @@ export default function QuizGame() {
         for new prompts and then select your answer.
       </InstructionBanner>
       <div className="truth-game">
+        <ProgressSidebar />
         <WhyItMatters />
         <div className="statements">
           <div className="statement-header">


### PR DESCRIPTION
## Summary
- include `ProgressSidebar` on the quiz game page
- keep the sidebar in the grid with responsive layout adjustments

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68432c8af8e0832fa0b16f570f1baf44