### PR TITLE
Add sticky NavBar with tooltip hover

### DIFF
--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import ThemeToggle from './ThemeToggle'
+import Tooltip from '../ui/Tooltip'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
 
   return (
-    <nav className="navbar">
+    <nav className="navbar" style={{ position: 'sticky', top: 0 }}>
       <div className="brand">
         <img
           src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
@@ -25,22 +26,34 @@ export default function NavBar() {
       </button>
       <ul className={open ? 'open' : undefined} onClick={() => setOpen(false)}>
         <li>
-          <Link to="/">Home</Link>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/">Home</Link>
+          </Tooltip>
         </li>
         <li>
-          <Link to="/games/tone">Tone</Link>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/games/tone">Tone</Link>
+          </Tooltip>
         </li>
         <li>
-          <Link to="/games/quiz">Hallucinations</Link>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/games/quiz">Hallucinations</Link>
+          </Tooltip>
         </li>
         <li>
-          <Link to="/leaderboard">Progress</Link>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/leaderboard">Progress</Link>
+          </Tooltip>
         </li>
         <li>
-          <Link to="/help">Help</Link>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/help">Help</Link>
+          </Tooltip>
         </li>
         <li>
-          <Link to="/profile">Profile</Link>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/profile">Profile</Link>
+          </Tooltip>
         </li>
       </ul>
     </nav>

--- a/learning-games/src/components/ui/Tooltip.css
+++ b/learning-games/src/components/ui/Tooltip.css
@@ -1,0 +1,20 @@
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  pointer-events: none;
+  opacity: 0.9;
+  z-index: 1000;
+}

--- a/learning-games/src/components/ui/Tooltip.tsx
+++ b/learning-games/src/components/ui/Tooltip.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import './Tooltip.css'
+
+export interface TooltipProps {
+  message: string
+  children: React.ReactNode
+}
+
+export default function Tooltip({ message, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <span
+      className="tooltip-wrapper"
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocus={() => setVisible(true)}
+      onBlur={() => setVisible(false)}
+    >
+      {children}
+      {visible && <span className="tooltip">{message}</span>}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
- make NavBar sticky via inline style
- wrap navigation links with new Tooltip component
- implement simple Tooltip UI with hover/focus handling
- add tooltip styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843306981f0832fa640569fd3d2d030