### PR TITLE
Add course overview section

### DIFF
--- a/learning-games/src/components/CourseOverview.tsx
+++ b/learning-games/src/components/CourseOverview.tsx
@@ -1,0 +1,37 @@
+import { useContext } from 'react'
+import { Link } from 'react-router-dom'
+import { UserContext } from '../context/UserContext'
+import COURSES from '../data/courses'
+import Card from './ui/card'
+
+export default function CourseOverview() {
+  const { user } = useContext(UserContext)
+  return (
+    <div className="course-grid">
+      {COURSES.map((course) => {
+        const progress = Math.min(user.scores[course.id] ?? 0, 100)
+        const content = (
+          <Card className="course-card">
+            {course.meme && (
+              <img
+                src={course.meme}
+                alt={`${course.title} meme`}
+                style={{ width: '100%', borderRadius: '4px' }}
+              />
+            )}
+            <h3>{course.title}</h3>
+            <p>{course.description}</p>
+            <progress value={progress} max={100} style={{ width: '100%', height: '1rem' }} />
+          </Card>
+        )
+        return course.path ? (
+          <Link key={course.id} to={course.path} className="course-card-link">
+            {content}
+          </Link>
+        ) : (
+          <div key={course.id}>{content}</div>
+        )
+      })}
+    </div>
+  )
+}

--- a/learning-games/src/data/courses.ts
+++ b/learning-games/src/data/courses.ts
@@ -1,0 +1,27 @@
+export interface CourseMeta {
+  id: string
+  title: string
+  description: string
+  path: string
+  meme?: string
+}
+
+/** Basic metadata for each available course */
+export const COURSES: CourseMeta[] = [
+  {
+    id: 'tone',
+    title: 'Tone Puzzle',
+    description: 'Swap adjectives to explore how tone changes a message.',
+    path: '/games/tone',
+    meme: 'https://i.imgflip.com/1bhf.jpg',
+  },
+  {
+    id: 'quiz',
+    title: 'Hallucinations Quiz',
+    description: 'Spot the AI hallucination hidden among the facts.',
+    path: '/games/quiz',
+    meme: 'https://i.imgflip.com/30b1gx.jpg',
+  },
+]
+
+export default COURSES

--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -135,3 +135,10 @@
 }
 
 
+
+.course-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { UserContext } from '../context/UserContext'
+import CourseOverview from '../components/CourseOverview'
 import './Home.css'
 
 /**
@@ -61,6 +62,8 @@ export default function Home() {
         <p className="tagline">Play engaging games and sharpen your skills.</p>
         <button onClick={() => navigate('/games/tone')}>Play Now</button>
       </section>
+
+      <CourseOverview />
 
       {/* greeting */}
       {user.age && (


### PR DESCRIPTION
## Summary
- create course metadata and overview component
- display course overview on the home page
- add responsive grid styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684331b19bfc832f92b45afeead1ebfd