### PR TITLE
Add celebratory progress sidebar

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -97,7 +97,7 @@
 
 .progress-sidebar progress {
   width: 100%;
-  height: 1rem;
+  height: 1.5rem;
   accent-color: #ffd700;
 }
 

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -1,4 +1,5 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useRef } from 'react'
+import confetti from 'canvas-confetti'
 import { Link } from 'react-router-dom'
 import { UserContext } from '../../context/UserContext'
 import { DUMMY_SCORES } from '../../pages/LeaderboardPage'
@@ -6,6 +7,15 @@ import { DUMMY_SCORES } from '../../pages/LeaderboardPage'
 export default function ProgressSidebar() {
   const { user } = useContext(UserContext)
   const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const GOAL_POINTS = 100
+  const celebrated = useRef(false)
+
+  useEffect(() => {
+    if (totalPoints >= GOAL_POINTS && !celebrated.current) {
+      confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } })
+      celebrated.current = true
+    }
+  }, [totalPoints])
   const leaderboard = DUMMY_SCORES.tone
     .concat({ name: user.name ?? 'You', score: user.scores['tone'] ?? 0 })
     .sort((a, b) => b.score - a.score)
@@ -14,8 +24,9 @@ export default function ProgressSidebar() {
   return (
     <aside className="progress-sidebar">
       <h3>Your Progress</h3>
-      <p>Total Points: {totalPoints}</p>
-      <progress value={totalPoints} max={100} />
+      <p aria-live="polite" aria-atomic="true">Total Points: {totalPoints}</p>
+      <progress value={totalPoints} max={GOAL_POINTS} />
+      <p aria-live="polite" aria-atomic="true">Badges Earned: {user.badges.length}</p>
       <div className="badge-icons" style={{ marginTop: '0.5rem' }}>
         {user.badges.map((b) => (
           <span key={b}>🏅</span>


### PR DESCRIPTION
## Summary
- enlarge sidebar progress bar display
- show badge count and make progress updates accessible
- trigger confetti when goal reached

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684331baa9e0832f9b89f4c5ba0cb1cb