### PR TITLE
Add community forum page with basic moderation

### DIFF
--- a/learning-games/package-lock.json
+++ b/learning-games/package-lock.json
@@ -17,6 +17,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/react": "^16.3.0",
         "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^22.15.29",
         "@types/react": "^19.1.2",
@@ -66,6 +68,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/core": {
       "version": "7.27.4",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
@@ -95,21 +112,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core/node_modules/@babel/compat-data": {
@@ -370,6 +372,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1024,6 +1036,61 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
@@ -1652,6 +1719,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -1670,6 +1747,16 @@
       "version": "2.0.1",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1945,6 +2032,23 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3030,6 +3134,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -3283,6 +3397,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -3347,6 +3489,13 @@
         "react": ">=16",
         "react-dom": ">=16"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/learning-games/package.json
+++ b/learning-games/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.3.0",
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.2",

--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -5,6 +5,7 @@ import SplashPage from './pages/SplashPage'
 import Match3Game from './pages/Match3Game'
 import QuizGame from './pages/QuizGame'
 import LeaderboardPage from './pages/LeaderboardPage'
+import CommunityPage from './pages/CommunityPage'
 import ProfilePage from './pages/ProfilePage'
 import HelpPage from './pages/HelpPage'
 import PrivacyPage from './pages/PrivacyPage'
@@ -26,6 +27,7 @@ function App() {
         <Route path="/games/tone" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
+        <Route path="/community" element={<CommunityPage />} />
         <Route path="/help" element={<HelpPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />

--- a/learning-games/src/components/Post.tsx
+++ b/learning-games/src/components/Post.tsx
@@ -1,0 +1,27 @@
+import Card from './ui/card'
+
+export interface PostData {
+  id: number
+  title: string
+  image: string
+  flagged?: boolean
+}
+
+export interface PostProps {
+  post: PostData
+  onFlag: (id: number) => void
+}
+
+export default function Post({ post, onFlag }: PostProps) {
+  return (
+    <Card className="post" style={{ marginBottom: '1rem' }}>
+      <h4>{post.title}</h4>
+      <img src={post.image} alt={post.title} style={{ width: '100%', borderRadius: '4px' }} />
+      <div style={{ marginTop: '0.5rem' }}>
+        <button onClick={() => onFlag(post.id)} disabled={post.flagged}>
+          {post.flagged ? 'Flagged' : 'Report'}
+        </button>
+      </div>
+    </Card>
+  )
+}

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -47,6 +47,11 @@ export default function NavBar() {
         </li>
         <li>
           <Tooltip message="Hover here for a surprise!">
+            <Link to="/community">Community</Link>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
             <Link to="/help">Help</Link>
           </Tooltip>
         </li>

--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import Post, { PostData } from '../components/Post'
+
+const initialPosts: PostData[] = [
+  {
+    id: 1,
+    title: 'Welcome Meme',
+    image:
+      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmM2cG9tbDNmYzIybHM4aGd1aXBhbHFhb3M1eTUwczdtdGN1eDBydCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oEduSbSGpGaRX2Vri/giphy.gif',
+  },
+  {
+    id: 2,
+    title: 'Coding Time',
+    image:
+      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdG1sbmFzeG8zazI4dGIxeHF6NmZ2dXg5YWNra2k1bzJiZTZjdHA1biZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l4FGuhL4U2WyjdkaY/giphy.gif',
+  },
+]
+
+export default function CommunityPage() {
+  const [posts, setPosts] = useState(initialPosts)
+
+  function flagPost(id: number) {
+    setPosts((prev) => prev.map((p) => (p.id === id ? { ...p, flagged: true } : p)))
+  }
+
+  return (
+    <div className="community-page">
+      <h2>Community</h2>
+      {posts.map((p) => (
+        <Post key={p.id} post={p} onFlag={flagPost} />
+      ))}
+      <p style={{ marginTop: '2rem' }}>
+        <Link to="/">Return Home</Link>
+      </p>
+    </div>
+  )
+}

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -61,6 +61,9 @@ export default function Home() {
         />
         <p className="tagline">Play engaging games and sharpen your skills.</p>
         <button onClick={() => navigate('/games/tone')}>Play Now</button>
+        <button onClick={() => navigate('/community')} style={{ marginLeft: '1rem' }}>
+          Community
+        </button>
       </section>
 
       <CourseOverview />

--- a/learning-games/src/pages/__tests__/CommunityPage.test.tsx
+++ b/learning-games/src/pages/__tests__/CommunityPage.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Post, { PostData } from '../../components/Post'
+import CommunityPage from '../CommunityPage'
+
+afterEach(() => cleanup())
+
+describe('Post component', () => {
+  it('calls onFlag when report clicked', () => {
+    const data: PostData = { id: 1, title: 't', image: 'img' }
+    const onFlag = vi.fn()
+    const { getByRole } = render(<Post post={data} onFlag={onFlag} />)
+    fireEvent.click(getByRole('button'))
+    expect(onFlag).toHaveBeenCalledWith(1)
+  })
+})
+
+describe('CommunityPage', () => {
+  it('flags a post on report', async () => {
+    const { getAllByRole } = render(
+      <MemoryRouter>
+        <CommunityPage />
+      </MemoryRouter>
+    )
+    const buttons = getAllByRole('button', { name: /report/i })
+    fireEvent.click(buttons[0])
+    await waitFor(() => {
+      expect(getAllByRole('button')[0].textContent).toBe('Flagged')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- create `CommunityPage` with simple threads and moderation
- add `Post` component with flagging UI
- link community page from NavBar and Home hero
- expose `/community` route in router
- add tests for the new page and component
- include testing-library for React component tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843338f955c832fa1a5148a66129448