### PR TITLE
Remove broken intro and tweak course cards

### DIFF
--- a/learning-games/src/components/CourseOverview.tsx
+++ b/learning-games/src/components/CourseOverview.tsx
@@ -11,13 +11,9 @@ export default function CourseOverview() {
       {COURSES.map((course) => {
         const progress = Math.min(user.scores[course.id] ?? 0, 100)
         const content = (
-          <Card className="course-card">
+          <Card className="course-card" style={{ padding: '0.75rem' }}>
             {course.meme && (
-              <img
-                src={course.meme}
-                alt={`${course.title} meme`}
-                style={{ width: '100%', borderRadius: '4px' }}
-              />
+              <img src={course.meme} alt={`${course.title} meme`} />
             )}
             <h3>{course.title}</h3>
             <p>{course.description}</p>

--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -39,48 +39,6 @@
   }
 }
 
-.intro-hero {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  margin-bottom: 1rem;
-}
-
-.intro-gif {
-  width: 100%;
-  max-width: 300px;
-  height: auto;
-}
-
-.start-btn {
-  font-family: 'Roboto', sans-serif;
-  font-weight: bold;
-  font-size: 16px;
-  background: #32cd32;
-  min-width: 44px;
-  min-height: 44px;
-  margin-top: 1rem;
-  transition: background-color 0.3s ease;
-}
-
-.start-btn:hover {
-  background: #228b22;
-}
-
-.start-btn:active {
-  animation: bounce 0.3s;
-}
-
-@keyframes bounce {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-6px);
-  }
-}
 
 
 .game-grid {
@@ -122,23 +80,27 @@
   .game-grid {
     grid-template-columns: 1fr;
   }
-  .intro-gif {
-    max-width: 90%;
-  }
-  .intro-hero {
-    padding: 2rem 0;
-  }
-  .start-btn {
-    font-size: 1.2rem;
-    padding: 0.75rem 1.25rem;
-  }
 }
 
 
 
 .course-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
   margin: 1rem 0;
+}
+
+.course-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.course-card img {
+  width: 100%;
+  max-height: 120px;
+  object-fit: cover;
+  border-radius: 4px;
 }

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -39,18 +39,6 @@ export default function Home() {
 
   return (
     <div className="home">
-      {/* intro hero */}
-      <section className="intro-hero">
-        <img
-          src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTJhMWE2Yjc2Y2I5NmUxNDA2N2Y0Nzg3NDFiODRlOTk0ODE1MTdlNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/yrVn0u3qzO9nK/giphy.gif"
-          alt="Confetti celebration"
-          aria-label="celebratory animation"
-          className="intro-gif"
-        />
-        <button className="start-btn" onClick={() => navigate('/welcome')}>
-          Begin Your Journey
-        </button>
-      </section>
       {/* hero section */}
       <section className="hero reveal">
         <h1 className="hero-title">Embark on a Fruity Learning Adventure!</h1>


### PR DESCRIPTION
## Summary
- clean up home page intro
- make course cards smaller with new layout styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843345a2664832f8386ad12232736f0