### PR TITLE
Fix type import in CommunityPage

### DIFF
--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import Post, { PostData } from '../components/Post'
+import Post from '../components/Post'
+import type { PostData } from '../components/Post'
 
 const initialPosts: PostData[] = [
   {


### PR DESCRIPTION
## Summary
- fix a runtime import error in CommunityPage by making `PostData` a type-only import

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433f88d7b8832f99d9c78bbef4a175