### PR TITLE
Expand home gifs and add next buttons

### DIFF
--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -49,15 +49,21 @@
 
 .game-icon {
   width: 100%;
-  max-height: 120px;
+  max-height: 360px;
   object-fit: cover;
   border-radius: 4px;
 }
 
 .hero-img {
-  width: 80px;
+  width: min(240px, 80%);
   margin: 0.5rem auto;
   display: block;
+}
+
+@media (max-width: 480px) {
+  .game-icon {
+    max-height: 180px;
+  }
 }
 
 .hero-title {

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -330,6 +330,9 @@ export default function Match3Game() {
       </div>
       <RobotChat />
       <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+        <button onClick={() => navigate('/games/quiz')}>Next Lesson</button>
+      </p>
+      <p style={{ marginTop: '1rem', textAlign: 'center' }}>
         <Link to="/leaderboard">Return to Progress</Link>
       </p>
     </div>

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -240,6 +240,9 @@ export default function QuizGame() {
         </div>
         <ChatBox />
         <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+          <button onClick={() => navigate('/leaderboard')}>Next</button>
+        </p>
+        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
           <Link to="/leaderboard">Return to Progress</Link>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- resize home page GIFs and hero image for better visibility
- allow tone page to link onward to Hallucinations
- add Next button on hallucination quiz leading to the leaderboard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684345f4ad44832f8f6f450493e15a6a