### PR TITLE
Improve home GIF layout

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -61,14 +61,13 @@
 }
 
 .game-card {
-  padding: 1rem;
+  position: relative;
+  padding: 0;
   border: 2px solid transparent;
   border-radius: 10px;
   text-decoration: none;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
+  display: block;
+  overflow: hidden;
   background: #fff;
   color: var(--color-text-dark);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);

--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -48,10 +48,22 @@
 }
 
 .game-icon {
+  display: block;
   width: 100%;
-  max-height: 360px;
+  height: 100%;
   object-fit: cover;
-  border-radius: 4px;
+}
+
+.game-title {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+  font-weight: bold;
 }
 
 .hero-img {
@@ -62,7 +74,7 @@
 
 @media (max-width: 480px) {
   .game-icon {
-    max-height: 180px;
+    height: 100%;
   }
 }
 

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -69,7 +69,7 @@ export default function Home() {
             alt="Tone puzzle preview"
             className="game-icon"
           />
-          <span>Tone Puzzle</span>
+          <span className="game-title">Tone Puzzle</span>
         </Link>
         <Link className="game-card" to="/games/quiz">
           <img
@@ -77,7 +77,7 @@ export default function Home() {
             alt="Hallucinations preview"
             className="game-icon"
           />
-          <span>Hallucinations</span>
+          <span className="game-title">Hallucinations</span>
         </Link>
       </div>
 


### PR DESCRIPTION
## Summary
- make GIF cards fill their grid cells and show titles as overlays

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843487098b0832f99c68291b6bf170d