### PR TITLE
Add simple local message board

### DIFF
--- a/learning-games/src/components/Post.tsx
+++ b/learning-games/src/components/Post.tsx
@@ -2,8 +2,13 @@ import Card from './ui/card'
 
 export interface PostData {
   id: number
-  title: string
-  image: string
+  /** Name of the author posting the message */
+  author: string
+  /** Text content of the post */
+  content: string
+  /** ISO timestamp of when the post was created */
+  date: string
+  /** Whether a post has been flagged by a user */
   flagged?: boolean
 }
 
@@ -15,8 +20,10 @@ export interface PostProps {
 export default function Post({ post, onFlag }: PostProps) {
   return (
     <Card className="post" style={{ marginBottom: '1rem' }}>
-      <h4>{post.title}</h4>
-      <img src={post.image} alt={post.title} style={{ width: '100%', borderRadius: '4px' }} />
+      <p style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
+        {post.author} on {new Date(post.date).toLocaleString()}
+      </p>
+      <p style={{ whiteSpace: 'pre-wrap' }}>{post.content}</p>
       <div style={{ marginTop: '0.5rem' }}>
         <button onClick={() => onFlag(post.id)} disabled={post.flagged}>
           {post.flagged ? 'Flagged' : 'Report'}

--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -1,36 +1,79 @@
-import { useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import Post from '../components/Post'
 import type { PostData } from '../components/Post'
+import { UserContext } from '../context/UserContext'
+
+const STORAGE_KEY = 'community_posts'
 
 const initialPosts: PostData[] = [
   {
     id: 1,
-    title: 'Welcome Meme',
-    image:
-      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmM2cG9tbDNmYzIybHM4aGd1aXBhbHFhb3M1eTUwczdtdGN1eDBydCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3oEduSbSGpGaRX2Vri/giphy.gif',
-  },
-  {
-    id: 2,
-    title: 'Coding Time',
-    image:
-      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdG1sbmFzeG8zazI4dGIxeHF6NmZ2dXg5YWNra2k1bzJiZTZjdHA1biZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l4FGuhL4U2WyjdkaY/giphy.gif',
+    author: 'Admin',
+    content: 'Welcome to the new message board!',
+    date: '2025-01-01T00:00:00Z',
   },
 ]
 
 export default function CommunityPage() {
-  const [posts, setPosts] = useState(initialPosts)
+  const { user } = useContext(UserContext)
+  const [posts, setPosts] = useState<PostData[]>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      try {
+        return JSON.parse(saved) as PostData[]
+      } catch {
+        return initialPosts
+      }
+    }
+    return initialPosts
+  })
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(posts))
+  }, [posts])
 
   function flagPost(id: number) {
     setPosts((prev) => prev.map((p) => (p.id === id ? { ...p, flagged: true } : p)))
   }
 
+  function addPost(e: React.FormEvent) {
+    e.preventDefault()
+    if (message.trim()) {
+      const newPost: PostData = {
+        id: Date.now(),
+        author: user.name ?? 'Anonymous',
+        content: message.trim(),
+        date: new Date().toISOString(),
+      }
+      setPosts((prev) => [...prev, newPost])
+      setMessage('')
+    }
+  }
+
   return (
     <div className="community-page">
       <h2>Community</h2>
-      {posts.map((p) => (
-        <Post key={p.id} post={p} onFlag={flagPost} />
-      ))}
+      <form onSubmit={addPost} style={{ marginBottom: '1rem' }}>
+        <label htmlFor="message">Share your thoughts:</label>
+        <textarea
+          id="message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          style={{ display: 'block', width: '100%', marginTop: '0.5rem' }}
+        />
+        <button type="submit" style={{ marginTop: '0.5rem' }}>
+          Post
+        </button>
+      </form>
+      {posts
+        .slice()
+        .reverse()
+        .map((p) => (
+          <Post key={p.id} post={p} onFlag={flagPost} />
+        ))}
       <p style={{ marginTop: '2rem' }}>
         <Link to="/">Return Home</Link>
       </p>

--- a/learning-games/src/pages/__tests__/CommunityPage.test.tsx
+++ b/learning-games/src/pages/__tests__/CommunityPage.test.tsx
@@ -1,14 +1,27 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import {
+  render,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Post, { PostData } from '../../components/Post'
 import CommunityPage from '../CommunityPage'
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
 
 describe('Post component', () => {
   it('calls onFlag when report clicked', () => {
-    const data: PostData = { id: 1, title: 't', image: 'img' }
+    const data: PostData = {
+      id: 1,
+      author: 'Tester',
+      content: 'hello',
+      date: '2025-01-01T00:00:00Z',
+    }
     const onFlag = vi.fn()
     const { getByRole } = render(<Post post={data} onFlag={onFlag} />)
     fireEvent.click(getByRole('button'))
@@ -23,10 +36,27 @@ describe('CommunityPage', () => {
         <CommunityPage />
       </MemoryRouter>
     )
-    const buttons = getAllByRole('button', { name: /report/i })
-    fireEvent.click(buttons[0])
+    const reportButtons = getAllByRole('button', { name: /report/i })
+    fireEvent.click(reportButtons[0])
     await waitFor(() => {
-      expect(getAllByRole('button')[0].textContent).toBe('Flagged')
+      expect(
+        getAllByRole('button', { name: /flagged/i })[0].textContent
+      ).toBe('Flagged')
+    })
+  })
+
+  it('adds a post via the form', async () => {
+    const { getByLabelText, getByRole, getAllByText } = render(
+      <MemoryRouter>
+        <CommunityPage />
+      </MemoryRouter>
+    )
+    fireEvent.change(getByLabelText(/share your thoughts/i), {
+      target: { value: 'New message' },
+    })
+    fireEvent.click(getByRole('button', { name: /post/i }))
+    await waitFor(() => {
+      expect(getAllByText('New message').length).toBe(1)
     })
   })
 })


### PR DESCRIPTION
## Summary
- refactor community posts into a basic message board stored in localStorage
- allow creating new posts and keep posts between sessions
- adjust Post component to display author and text
- update tests for new functionality

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684349127bdc832f9e8ee8ecc95e998e