### PR TITLE
Fix tiny gifs on home page

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -72,6 +72,7 @@
   color: var(--color-text-dark);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s ease, border-color 0.2s ease;
+  height: 200px;
 }
 .game-card:hover {
   transform: scale(1.05);
@@ -348,10 +349,12 @@
   transform: scale(1.05);
 }
 
+
 .game-icon {
-  width: 64px;
-  height: 64px;
-  object-fit: contain;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- refactor home page game card styles so the GIF previews are large

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68434b99c3d4832fb7a1010144f76bef