### PR TITLE
Add Prompt Recipe Builder game

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -4,6 +4,7 @@ import AgeInputForm from './pages/AgeInputForm'
 import SplashPage from './pages/SplashPage'
 import Match3Game from './pages/Match3Game'
 import QuizGame from './pages/QuizGame'
+import PromptRecipeGame from './pages/PromptRecipeGame'
 import LeaderboardPage from './pages/LeaderboardPage'
 import CommunityPage from './pages/CommunityPage'
 import ProfilePage from './pages/ProfilePage'
@@ -26,6 +27,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/games/tone" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />
+        <Route path="/games/recipe" element={<PromptRecipeGame />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/community" element={<CommunityPage />} />
         <Route path="/help" element={<HelpPage />} />

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -42,6 +42,11 @@ export default function NavBar() {
         </li>
         <li>
           <Tooltip message="Hover here for a surprise!">
+            <Link to="/games/recipe">Prompt Builder</Link>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
             <Link to="/leaderboard">Progress</Link>
           </Tooltip>
         </li>

--- a/learning-games/src/data/badges.ts
+++ b/learning-games/src/data/badges.ts
@@ -26,4 +26,9 @@ export const BADGES: BadgeDefinition[] = [
     name: 'Tone Tactician',
     description: 'Matched every tone correctly in the mini-game',
   },
+  {
+    id: 'prompt-chef',
+    name: 'Master Chef of Prompts',
+    description: 'Create 10 flawless prompt recipes',
+  },
 ]

--- a/learning-games/src/data/courses.ts
+++ b/learning-games/src/data/courses.ts
@@ -24,6 +24,14 @@ export const COURSES: CourseMeta[] = [
     meme:
       'https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTZoaHpxY3AwbmN1OTMwN3dkY3c5eXI1eXB3cDJ5ajNudDdkcnJ6cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9dg/SR6WK6jz0rRWf2QK0t/giphy.gif',
   },
+  {
+    id: 'recipe',
+    title: 'Prompt Recipe Builder',
+    description: 'Assemble prompt ingredients by dragging cards into bowls.',
+    path: '/games/recipe',
+    meme:
+      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3h3cTR0cmEybWt0ZGM2Ymx0ZHB4ZjltbmR2dG55M3Y0MWh6dnRjZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ll22OhMLAlVDbDS3Mo/giphy.gif',
+  },
 ]
 
 export default COURSES

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -87,6 +87,14 @@ export default function Home() {
           />
           <span className="game-title">Hallucinations</span>
         </Link>
+        <Link className="game-card" to="/games/recipe">
+          <img
+            src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3h3cTR0cmEybWt0ZGM2Ymx0ZHB4ZjltbmR2dG55M3Y0MWh6dnRjZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ll22OhMLAlVDbDS3Mo/giphy.gif"
+            alt="Prompt recipe preview"
+            className="game-icon"
+          />
+          <span className="game-title">Prompt Builder</span>
+        </Link>
       </div>
 
       {/* navigation */}

--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -1,0 +1,77 @@
+.recipe-page {
+  background: url('https://images.unsplash.com/photo-1500835556837-99ac94a94552?auto=format&fit=crop&w=1200&q=60') center/cover fixed;
+  padding: 1rem;
+  min-height: 100vh;
+}
+
+.recipe-wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+  justify-content: center;
+  align-items: start;
+}
+
+.recipe-game {
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.bowls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.bowl {
+  min-height: 70px;
+  border: 2px dashed var(--color-purple-dark);
+  border-radius: 8px;
+  padding: 0.5rem;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.bowl-content {
+  margin-top: 0.25rem;
+  min-height: 1.2rem;
+}
+
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.card {
+  padding: 0.4rem 0.6rem;
+  background: var(--color-orange);
+  color: #fff;
+  border-radius: 6px;
+  cursor: grab;
+  user-select: none;
+}
+
+.plate {
+  margin-top: 1rem;
+  background: #fff;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+@media (max-width: 600px) {
+  .recipe-wrapper {
+    grid-template-columns: 1fr;
+  }
+  .progress-sidebar {
+    max-width: none;
+  }
+}

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect, useContext } from 'react'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
+import InstructionBanner from '../components/ui/InstructionBanner'
+import { UserContext } from '../context/UserContext'
+import './PromptRecipeGame.css'
+
+export type Slot = 'Action' | 'Context' | 'Format' | 'Constraints'
+
+export interface Card {
+  type: Slot
+  text: string
+}
+
+export interface Dropped {
+  Action: string | null
+  Context: string | null
+  Format: string | null
+  Constraints: string | null
+}
+
+export function evaluateRecipe(dropped: Dropped, cards: Card[]) {
+  let score = 0
+  let perfect = true
+  for (const card of cards) {
+    if (dropped[card.type] === card.text) {
+      score += 1
+    } else {
+      perfect = false
+    }
+  }
+  return { score, perfect }
+}
+
+const ACTIONS = [
+  'Write a short poem',
+  'Draft an email',
+  'Summarize the text',
+  'Explain the concept',
+]
+const CONTEXTS = [
+  'about renewable energy',
+  'for a job interview',
+  'for kids',
+  'with comedic tone',
+]
+const FORMATS = [
+  'as bullet points',
+  'in a single paragraph',
+  'in rhyme',
+  'as a numbered list',
+]
+const CONSTRAINTS = [
+  'under 50 words',
+  'using simple language',
+  'avoid technical terms',
+  'no more than 3 sentences',
+]
+
+function randomItem<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+export default function PromptRecipeGame() {
+  const { setScore, addBadge, user } = useContext(UserContext)
+  const [cards, setCards] = useState<Card[]>([])
+  const [roundCards, setRoundCards] = useState<Card[]>([])
+  const [dropped, setDropped] = useState<Dropped>({
+    Action: null,
+    Context: null,
+    Format: null,
+    Constraints: null,
+  })
+  const [score, setScoreState] = useState(0)
+  const [perfectRounds, setPerfectRounds] = useState(0)
+  const [showPrompt, setShowPrompt] = useState(false)
+
+  function startRound() {
+    const newCards: Card[] = [
+      { type: 'Action', text: randomItem(ACTIONS) },
+      { type: 'Context', text: randomItem(CONTEXTS) },
+      { type: 'Format', text: randomItem(FORMATS) },
+      { type: 'Constraints', text: randomItem(CONSTRAINTS) },
+    ]
+    setRoundCards(newCards)
+    setCards(shuffle([...newCards]))
+    setDropped({ Action: null, Context: null, Format: null, Constraints: null })
+    setShowPrompt(false)
+  }
+
+  useEffect(() => {
+    startRound()
+  }, [])
+
+  useEffect(() => {
+    if (Object.values(dropped).every(Boolean)) {
+      const { score: gained, perfect } = evaluateRecipe(dropped, roundCards)
+      setScoreState(s => s + gained)
+      if (perfect) {
+        setPerfectRounds(p => p + 1)
+        if (perfectRounds + 1 >= 10 && !user.badges.includes('prompt-chef')) {
+          addBadge('prompt-chef')
+        }
+      }
+      setScore('recipe', score + gained)
+      setShowPrompt(true)
+    }
+  }, [dropped])
+
+  function handleDragStart(e: React.DragEvent<HTMLDivElement>, card: Card) {
+    e.dataTransfer.setData('application/json', JSON.stringify(card))
+  }
+
+  function handleDrop(slot: Slot, e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+    const data = e.dataTransfer.getData('application/json')
+    if (!data) return
+    const card = JSON.parse(data) as Card
+    setDropped(prev => ({ ...prev, [slot]: card.text }))
+    setCards(cs => cs.filter(c => c.text !== card.text))
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+  }
+
+  function shuffle<T>(arr: T[]): T[] {
+    const a = [...arr]
+    for (let i = a.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[a[i], a[j]] = [a[j], a[i]]
+    }
+    return a
+  }
+
+  function nextRound() {
+    startRound()
+  }
+
+  const promptText = `${dropped.Action ?? ''} ${dropped.Context ?? ''} ${dropped.Format ?? ''} ${dropped.Constraints ?? ''}`
+
+  return (
+    <div className="recipe-page">
+      <InstructionBanner>
+        Drag each ingredient card into the correct bowl to build the prompt recipe.
+      </InstructionBanner>
+      <div className="recipe-wrapper">
+        <ProgressSidebar />
+        <div className="recipe-game">
+          <div className="bowls">
+            {(['Action','Context','Format','Constraints'] as Slot[]).map(slot => (
+              <div
+                key={slot}
+                className="bowl"
+                onDrop={e => handleDrop(slot, e)}
+                onDragOver={handleDragOver}
+              >
+                <strong>{slot}</strong>
+                <div className="bowl-content">{dropped[slot] || 'Drop here'}</div>
+              </div>
+            ))}
+          </div>
+          <div className="cards">
+            {cards.map(card => (
+              <div
+                key={card.text}
+                className="card"
+                draggable
+                onDragStart={e => handleDragStart(e, card)}
+              >
+                {card.text}
+              </div>
+            ))}
+          </div>
+          {showPrompt && (
+            <div className="plate">
+              <h3>Your Prompt</h3>
+              <p>{promptText}</p>
+              <button onClick={nextRound}>Next Recipe</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/learning-games/src/pages/__tests__/PromptRecipeGame.test.ts
+++ b/learning-games/src/pages/__tests__/PromptRecipeGame.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateRecipe, Dropped, Card } from '../PromptRecipeGame'
+
+describe('evaluateRecipe', () => {
+  it('scores 4 and is perfect when all placements correct', () => {
+    const cards: Card[] = [
+      { type: 'Action', text: 'Write' },
+      { type: 'Context', text: 'About' },
+      { type: 'Format', text: 'In style' },
+      { type: 'Constraints', text: 'Short' },
+    ]
+    const dropped: Dropped = {
+      Action: 'Write',
+      Context: 'About',
+      Format: 'In style',
+      Constraints: 'Short',
+    }
+    const result = evaluateRecipe(dropped, cards)
+    expect(result.score).toBe(4)
+    expect(result.perfect).toBe(true)
+  })
+
+  it('is not perfect when any placement wrong', () => {
+    const cards: Card[] = [
+      { type: 'Action', text: 'Write' },
+      { type: 'Context', text: 'About' },
+      { type: 'Format', text: 'In style' },
+      { type: 'Constraints', text: 'Short' },
+    ]
+    const dropped: Dropped = {
+      Action: 'Write',
+      Context: 'Wrong',
+      Format: 'In style',
+      Constraints: 'Short',
+    }
+    const result = evaluateRecipe(dropped, cards)
+    expect(result.score).toBe(3)
+    expect(result.perfect).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- create PromptRecipeGame page with drag-and-drop mechanics
- style the new game page
- link new route from App and NavBar
- list game on the home page and in courses data
- define `prompt-chef` badge
- test recipe scoring logic

## Testing
- `npm install --silent`
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684354d776c8832f9fd8f6810a30b5c6