### PR TITLE
Add Prompt Builder and Escape Room games

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -4,6 +4,8 @@ import AgeInputForm from './pages/AgeInputForm'
 import SplashPage from './pages/SplashPage'
 import Match3Game from './pages/Match3Game'
 import QuizGame from './pages/QuizGame'
+import PromptRecipeGame from './pages/PromptRecipeGame'
+import ClarityEscapeRoom from './pages/ClarityEscapeRoom'
 import LeaderboardPage from './pages/LeaderboardPage'
 import CommunityPage from './pages/CommunityPage'
 import ProfilePage from './pages/ProfilePage'
@@ -26,6 +28,8 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/games/tone" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />
+        <Route path="/games/recipe" element={<PromptRecipeGame />} />
+        <Route path="/games/escape" element={<ClarityEscapeRoom />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/community" element={<CommunityPage />} />
         <Route path="/help" element={<HelpPage />} />

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -42,6 +42,16 @@ export default function NavBar() {
         </li>
         <li>
           <Tooltip message="Hover here for a surprise!">
+            <Link to="/games/escape">Escape Room</Link>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/games/recipe">Prompt Builder</Link>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
             <Link to="/leaderboard">Progress</Link>
           </Tooltip>
         </li>

--- a/learning-games/src/data/badges.ts
+++ b/learning-games/src/data/badges.ts
@@ -26,4 +26,14 @@ export const BADGES: BadgeDefinition[] = [
     name: 'Tone Tactician',
     description: 'Matched every tone correctly in the mini-game',
   },
+  {
+    id: 'escape-artist',
+    name: 'Escape Artist of Clarity',
+    description: 'Exit all 5 rooms under 3 minutes',
+  },
+  {
+    id: 'prompt-chef',
+    name: 'Master Chef of Prompts',
+    description: 'Create 10 flawless prompt recipes',
+  },
 ]

--- a/learning-games/src/data/courses.ts
+++ b/learning-games/src/data/courses.ts
@@ -24,6 +24,22 @@ export const COURSES: CourseMeta[] = [
     meme:
       'https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTZoaHpxY3AwbmN1OTMwN3dkY3c5eXI1eXB3cDJ5ajNudDdkcnJ6cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9dg/SR6WK6jz0rRWf2QK0t/giphy.gif',
   },
+  {
+    id: 'escape',
+    title: 'Clarity Escape Room',
+    description: 'Solve vague tasks with precise prompts to escape.',
+    path: '/games/escape',
+    meme:
+      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWxxNTN2aWptZHVsaHhtbTg3Y3E0Zm1jbnJ6ODltZzQ5YmQ5ZjZmMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GnQx3FIX9qH7O/giphy.gif',
+  },
+  {
+    id: 'recipe',
+    title: 'Prompt Recipe Builder',
+    description: 'Drag ingredients to craft a four-part prompt.',
+    path: '/games/recipe',
+    meme:
+      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGlkeG45MmJ6bzI0NGR4YXV0bnU4em5idGdqd29yMjF0cGxpcnltZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Pj1sRt1KB9vK0K4Cph/giphy.gif',
+  },
 ]
 
 export default COURSES

--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -1,0 +1,41 @@
+.escape-wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+  justify-content: center;
+  align-items: start;
+}
+
+.room {
+  background: #222;
+  color: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.hint {
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}
+
+.prompt-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.prompt-form input {
+  flex: 1;
+}
+
+.feedback {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .escape-wrapper {
+    grid-template-columns: 1fr;
+  }
+}

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,0 +1,95 @@
+import { useState, useEffect, useContext } from 'react'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
+import InstructionBanner from '../components/ui/InstructionBanner'
+import { UserContext } from '../context/UserContext'
+import './ClarityEscapeRoom.css'
+
+type Task = {
+  hint: string
+  keywords: string[]
+}
+
+const TASKS: Task[] = [
+  { hint: 'Improve this greeting', keywords: ['rewrite', 'formal'] },
+  { hint: 'Fix this text', keywords: ['correct', 'grammar'] },
+  { hint: 'Summarize the announcement', keywords: ['summarize', 'sentences'] },
+  { hint: 'Format for email', keywords: ['email'] },
+  { hint: 'Condense this paragraph', keywords: ['condense', 'paragraph'] },
+]
+
+export default function ClarityEscapeRoom() {
+  const { setScore, addBadge, user } = useContext(UserContext)
+  const [door, setDoor] = useState(0)
+  const [input, setInput] = useState('')
+  const [score, setScoreState] = useState(0)
+  const [message, setMessage] = useState('')
+  const [start] = useState(() => Date.now())
+
+  const current = TASKS[door]
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!input.trim()) return
+    const lower = input.toLowerCase()
+    const success = current.keywords.every(k => lower.includes(k))
+    if (success) {
+      setScoreState(s => s + 50)
+      setMessage('The door unlocks with a click!')
+      if (door + 1 === TASKS.length) {
+        const time = Date.now() - start
+        setScore('escape', score + 50)
+        if (time < 180000 && !user.badges.includes('escape-artist')) {
+          addBadge('escape-artist')
+        }
+      } else {
+        setDoor(d => d + 1)
+        setInput('')
+      }
+    } else {
+      setScoreState(s => Math.max(0, s - 10))
+      setMessage('Foggy response... try a clearer prompt!')
+    }
+  }
+
+  useEffect(() => {
+    if (door === TASKS.length) {
+      setScore('escape', score)
+    }
+  }, [door, score, setScore])
+
+  if (door === TASKS.length) {
+    return (
+      <div className="escape-page">
+        <InstructionBanner>You escaped the room!</InstructionBanner>
+        <p>Your score: {score}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="escape-page">
+      <InstructionBanner>
+        Enter a precise prompt to unlock each door.
+      </InstructionBanner>
+      <div className="escape-wrapper">
+        <ProgressSidebar />
+        <div className="room">
+          <h3>Door {door + 1}</h3>
+          <p className="hint">Hint: {current.hint}</p>
+          <form onSubmit={handleSubmit} className="prompt-form">
+            <input
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              placeholder="Type your prompt"
+            />
+            <button type="submit">Submit</button>
+          </form>
+          {message && <p className="feedback">{message}</p>}
+          <p>Score: {score}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -33,14 +33,16 @@ export default function ClarityEscapeRoom() {
     const lower = input.toLowerCase()
     const success = current.keywords.every(k => lower.includes(k))
     if (success) {
-      setScoreState(s => s + 50)
+      const nextScore = score + 50
+      setScoreState(nextScore)
       setMessage('The door unlocks with a click!')
       if (door + 1 === TASKS.length) {
         const time = Date.now() - start
-        setScore('escape', score + 50)
+        setScore('escape', nextScore)
         if (time < 180000 && !user.badges.includes('escape-artist')) {
           addBadge('escape-artist')
         }
+        setDoor(TASKS.length)
       } else {
         setDoor(d => d + 1)
         setInput('')

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -87,6 +87,22 @@ export default function Home() {
           />
           <span className="game-title">Hallucinations</span>
         </Link>
+        <Link className="game-card" to="/games/escape">
+          <img
+            src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWxxNTN2aWptZHVsaHhtbTg3Y3E0Zm1jbnJ6ODltZzQ5YmQ5ZjZmMiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GnQx3FIX9qH7O/giphy.gif"
+            alt="Escape room preview"
+            className="game-icon"
+          />
+          <span className="game-title">Escape Room</span>
+        </Link>
+        <Link className="game-card" to="/games/recipe">
+          <img
+            src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGlkeG45MmJ6bzI0NGR4YXV0bnU4em5idGdqd29yMjF0cGxpcnltZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Pj1sRt1KB9vK0K4Cph/giphy.gif"
+            alt="Prompt builder preview"
+            className="game-icon"
+          />
+          <span className="game-title">Prompt Builder</span>
+        </Link>
       </div>
 
       {/* navigation */}

--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -1,0 +1,59 @@
+.recipe-wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+  justify-content: center;
+  align-items: start;
+}
+
+.kitchen {
+  background: url('https://images.unsplash.com/photo-1606851092836-944c99e60463?auto=format&fit=crop&w=800&q=60');
+  background-size: cover;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.card {
+  padding: 0.4rem 0.6rem;
+  background: var(--color-orange);
+  color: #fff;
+  border-radius: 6px;
+  cursor: grab;
+  user-select: none;
+}
+
+.bowls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.bowl {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+  padding: 0.5rem;
+  min-height: 60px;
+  text-align: center;
+}
+
+.plate {
+  margin-top: 1rem;
+  background: #fffbe6;
+  padding: 1rem;
+  border-radius: 8px;
+  font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  .recipe-wrapper {
+    grid-template-columns: 1fr;
+  }
+}

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect, useContext, useRef } from 'react'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
+import InstructionBanner from '../components/ui/InstructionBanner'
+import { UserContext } from '../context/UserContext'
+import './PromptRecipeGame.css'
+
+type Part = 'Action' | 'Context' | 'Format' | 'Constraints'
+
+interface PromptParts {
+  action: string
+  context: string
+  format: string
+  constraints: string
+}
+
+const PROMPTS: PromptParts[] = [
+  {
+    action: 'Summarize',
+    context: 'this press release',
+    format: 'as 3 bullets',
+    constraints: 'in 50 words',
+  },
+  {
+    action: 'Rewrite',
+    context: 'the instructions',
+    format: 'as a numbered list',
+    constraints: 'under 100 words',
+  },
+  {
+    action: 'Translate',
+    context: 'this paragraph',
+    format: 'into Spanish',
+    constraints: 'preserving tone',
+  },
+]
+
+export default function PromptRecipeGame() {
+  const { setScore, addBadge, user } = useContext(UserContext)
+  const [round, setRound] = useState(0)
+  const [score, setScoreState] = useState(0)
+  const [perfect, setPerfect] = useState(0)
+  const [cards, setCards] = useState<{ text: string; part: Part }[]>([])
+  const [placed, setPlaced] = useState<Partial<PromptParts>>({})
+  const dragged = useRef<{ text: string; part: Part } | null>(null)
+
+  useEffect(() => {
+    startRound()
+  }, [])
+
+  function startRound() {
+    const next = PROMPTS[Math.floor(Math.random() * PROMPTS.length)]
+    const newCards: { text: string; part: Part }[] = [
+      { text: next.action, part: 'Action' },
+      { text: next.context, part: 'Context' },
+      { text: next.format, part: 'Format' },
+      { text: next.constraints, part: 'Constraints' },
+    ].sort(() => Math.random() - 0.5)
+    setPlaced({})
+    setCards(newCards)
+  }
+
+  function handleDragStart(card: { text: string; part: Part }) {
+    dragged.current = card
+  }
+
+  function handleDrop(part: Part) {
+    if (dragged.current) {
+      setPlaced(prev => ({ ...prev, [part.toLowerCase()]: dragged.current!.text }))
+      if (dragged.current.part === part) {
+        setScoreState(s => s + 10)
+      }
+      dragged.current = null
+    }
+  }
+
+  useEffect(() => {
+    if (
+      placed.action &&
+      placed.context &&
+      placed.format &&
+      placed.constraints
+    ) {
+      const correct =
+        placed.action === PROMPTS[round].action &&
+        placed.context === PROMPTS[round].context &&
+        placed.format === PROMPTS[round].format &&
+        placed.constraints === PROMPTS[round].constraints
+      if (correct) {
+        setScoreState(s => s + 30)
+        setPerfect(p => p + 1)
+      }
+      const nextRound = (round + 1) % PROMPTS.length
+      setRound(nextRound)
+      startRound()
+    }
+  }, [placed, round])
+
+  useEffect(() => {
+    if (perfect >= 10 && !user.badges.includes('prompt-chef')) {
+      addBadge('prompt-chef')
+    }
+    setScore('recipe', score)
+  }, [score, perfect, addBadge, setScore, user.badges])
+
+  const assembled =
+    placed.action &&
+    placed.context &&
+    placed.format &&
+    placed.constraints
+      ? `${placed.action} ${placed.context} ${placed.format} ${placed.constraints}`
+      : null
+
+  return (
+    <div className="recipe-page">
+      <InstructionBanner>
+        Drag each card into the correct bowl to build a clear prompt.
+      </InstructionBanner>
+      <div className="recipe-wrapper">
+        <ProgressSidebar />
+        <div className="kitchen">
+          <div className="cards">
+            {cards.map((c) => (
+              <div
+                key={c.text}
+                className="card"
+                draggable
+                onDragStart={() => handleDragStart(c)}
+              >
+                {c.text}
+              </div>
+            ))}
+          </div>
+          <div className="bowls">
+            {(['Action', 'Context', 'Format', 'Constraints'] as Part[]).map((p) => (
+              <div
+                key={p}
+                className="bowl"
+                onDragOver={e => e.preventDefault()}
+                onDrop={() => handleDrop(p)}
+              >
+                <strong>{p}</strong>
+                <p>
+                  {(placed as Record<string, string>)[p.toLowerCase()] ?? '---'}
+                </p>
+              </div>
+            ))}
+          </div>
+          {assembled && <div className="plate">{assembled}</div>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -36,7 +36,7 @@ const PROMPTS: PromptParts[] = [
 
 export default function PromptRecipeGame() {
   const { setScore, addBadge, user } = useContext(UserContext)
-  const [round, setRound] = useState(0)
+  const [current, setCurrent] = useState(0)
   const [score, setScoreState] = useState(0)
   const [perfect, setPerfect] = useState(0)
   const [cards, setCards] = useState<{ text: string; part: Part }[]>([])
@@ -48,7 +48,9 @@ export default function PromptRecipeGame() {
   }, [])
 
   function startRound() {
-    const next = PROMPTS[Math.floor(Math.random() * PROMPTS.length)]
+    const idx = Math.floor(Math.random() * PROMPTS.length)
+    setCurrent(idx)
+    const next = PROMPTS[idx]
     const newCards: { text: string; part: Part }[] = [
       { text: next.action, part: 'Action' },
       { text: next.context, part: 'Context' },
@@ -65,7 +67,10 @@ export default function PromptRecipeGame() {
 
   function handleDrop(part: Part) {
     if (dragged.current) {
-      setPlaced(prev => ({ ...prev, [part.toLowerCase()]: dragged.current!.text }))
+      setPlaced(prev => ({
+        ...prev,
+        [part.toLowerCase() as keyof PromptParts]: dragged.current!.text,
+      }))
       if (dragged.current.part === part) {
         setScoreState(s => s + 10)
       }
@@ -81,19 +86,17 @@ export default function PromptRecipeGame() {
       placed.constraints
     ) {
       const correct =
-        placed.action === PROMPTS[round].action &&
-        placed.context === PROMPTS[round].context &&
-        placed.format === PROMPTS[round].format &&
-        placed.constraints === PROMPTS[round].constraints
+        placed.action === PROMPTS[current].action &&
+        placed.context === PROMPTS[current].context &&
+        placed.format === PROMPTS[current].format &&
+        placed.constraints === PROMPTS[current].constraints
       if (correct) {
         setScoreState(s => s + 30)
         setPerfect(p => p + 1)
       }
-      const nextRound = (round + 1) % PROMPTS.length
-      setRound(nextRound)
       startRound()
     }
-  }, [placed, round])
+  }, [placed, current])
 
   useEffect(() => {
     if (perfect >= 10 && !user.badges.includes('prompt-chef')) {


### PR DESCRIPTION
## Summary
- implement PromptRecipeGame with drag-and-drop prompt crafting
- implement ClarityEscapeRoom puzzle game
- register new game routes
- add nav links and home page cards
- extend courses and badge data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684354120748832f9ccca7b5fa77becc