### PR TITLE
Fix PromptRecipeGame component

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -1,50 +1,10 @@
-
-import { useState, useEffect, useContext, useRef } from 'react'
+import { useState, useEffect, useContext } from 'react'
 
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import { UserContext } from '../context/UserContext'
 import './PromptRecipeGame.css'
 
-
-type Part = 'Action' | 'Context' | 'Format' | 'Constraints'
-
-interface PromptParts {
-  action: string
-  context: string
-  format: string
-  constraints: string
-}
-
-const PROMPTS: PromptParts[] = [
-  {
-    action: 'Summarize',
-    context: 'this press release',
-    format: 'as 3 bullets',
-    constraints: 'in 50 words',
-  },
-  {
-    action: 'Rewrite',
-    context: 'the instructions',
-    format: 'as a numbered list',
-    constraints: 'under 100 words',
-  },
-  {
-    action: 'Translate',
-    context: 'this paragraph',
-    format: 'into Spanish',
-    constraints: 'preserving tone',
-  },
-]
-
-export default function PromptRecipeGame() {
-  const { setScore, addBadge, user } = useContext(UserContext)
-  const [current, setCurrent] = useState(0)
-  const [score, setScoreState] = useState(0)
-  const [perfect, setPerfect] = useState(0)
-  const [cards, setCards] = useState<{ text: string; part: Part }[]>([])
-  const [placed, setPlaced] = useState<Partial<PromptParts>>({})
-  const dragged = useRef<{ text: string; part: Part } | null>(null)
 export type Slot = 'Action' | 'Context' | 'Format' | 'Constraints'
 
 export interface Card {
@@ -128,77 +88,9 @@ export default function PromptRecipeGame() {
     setShowPrompt(false)
   }
 
-
   useEffect(() => {
     startRound()
   }, [])
-
-
-  function startRound() {
-    const idx = Math.floor(Math.random() * PROMPTS.length)
-    setCurrent(idx)
-    const next = PROMPTS[idx]
-    const newCards: { text: string; part: Part }[] = [
-      { text: next.action, part: 'Action' },
-      { text: next.context, part: 'Context' },
-      { text: next.format, part: 'Format' },
-      { text: next.constraints, part: 'Constraints' },
-    ].sort(() => Math.random() - 0.5)
-    setPlaced({})
-    setCards(newCards)
-  }
-
-  function handleDragStart(card: { text: string; part: Part }) {
-    dragged.current = card
-  }
-
-  function handleDrop(part: Part) {
-    if (dragged.current) {
-      setPlaced(prev => ({
-        ...prev,
-        [part.toLowerCase() as keyof PromptParts]: dragged.current!.text,
-      }))
-      if (dragged.current.part === part) {
-        setScoreState(s => s + 10)
-      }
-      dragged.current = null
-    }
-  }
-
-  useEffect(() => {
-    if (
-      placed.action &&
-      placed.context &&
-      placed.format &&
-      placed.constraints
-    ) {
-      const correct =
-        placed.action === PROMPTS[current].action &&
-        placed.context === PROMPTS[current].context &&
-        placed.format === PROMPTS[current].format &&
-        placed.constraints === PROMPTS[current].constraints
-      if (correct) {
-        setScoreState(s => s + 30)
-        setPerfect(p => p + 1)
-      }
-      startRound()
-    }
-  }, [placed, current])
-
-  useEffect(() => {
-    if (perfect >= 10 && !user.badges.includes('prompt-chef')) {
-      addBadge('prompt-chef')
-    }
-    setScore('recipe', score)
-  }, [score, perfect, addBadge, setScore, user.badges])
-
-  const assembled =
-    placed.action &&
-    placed.context &&
-    placed.format &&
-    placed.constraints
-      ? `${placed.action} ${placed.context} ${placed.format} ${placed.constraints}`
-      : null
 
   useEffect(() => {
     if (Object.values(dropped).every(Boolean)) {
@@ -247,52 +139,16 @@ export default function PromptRecipeGame() {
 
   const promptText = `${dropped.Action ?? ''} ${dropped.Context ?? ''} ${dropped.Format ?? ''} ${dropped.Constraints ?? ''}`
 
-
   return (
     <div className="recipe-page">
       <InstructionBanner>
-
-        Drag each card into the correct bowl to build a clear prompt.
-      </InstructionBanner>
-      <div className="recipe-wrapper">
-        <ProgressSidebar />
-        <div className="kitchen">
-          <div className="cards">
-            {cards.map((c) => (
-              <div
-                key={c.text}
-                className="card"
-                draggable
-                onDragStart={() => handleDragStart(c)}
-              >
-                {c.text}
-              </div>
-            ))}
-          </div>
-          <div className="bowls">
-            {(['Action', 'Context', 'Format', 'Constraints'] as Part[]).map((p) => (
-              <div
-                key={p}
-                className="bowl"
-                onDragOver={e => e.preventDefault()}
-                onDrop={() => handleDrop(p)}
-              >
-                <strong>{p}</strong>
-                <p>
-                  {(placed as Record<string, string>)[p.toLowerCase()] ?? '---'}
-                </p>
-              </div>
-            ))}
-          </div>
-          {assembled && <div className="plate">{assembled}</div>}
-
         Drag each ingredient card into the correct bowl to build the prompt recipe.
       </InstructionBanner>
       <div className="recipe-wrapper">
         <ProgressSidebar />
         <div className="recipe-game">
           <div className="bowls">
-            {(['Action','Context','Format','Constraints'] as Slot[]).map(slot => (
+            {(['Action', 'Context', 'Format', 'Constraints'] as Slot[]).map(slot => (
               <div
                 key={slot}
                 className="bowl"
@@ -322,10 +178,9 @@ export default function PromptRecipeGame() {
               <p>{promptText}</p>
               <button onClick={nextRound}>Next Recipe</button>
             </div>
-
+          )}
         </div>
       </div>
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary
- simplify and clean up `PromptRecipeGame` implementation
- remove duplicate logic causing parsing errors
- keep exported helpers and drag/drop recipe game logic

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684359806d40832fb2da5db8cdcfcbf2