### PR TITLE
Add Prompt Darts game

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -5,6 +5,7 @@ import SplashPage from './pages/SplashPage'
 import Match3Game from './pages/Match3Game'
 import QuizGame from './pages/QuizGame'
 import PromptRecipeGame from './pages/PromptRecipeGame'
+import PromptDartsGame from './pages/PromptDartsGame'
 
 import ClarityEscapeRoom from './pages/ClarityEscapeRoom'
 
@@ -31,6 +32,7 @@ function App() {
         <Route path="/games/tone" element={<Match3Game />} />
         <Route path="/games/quiz" element={<QuizGame />} />
         <Route path="/games/recipe" element={<PromptRecipeGame />} />
+        <Route path="/games/darts" element={<PromptDartsGame />} />
 
         <Route path="/games/escape" element={<ClarityEscapeRoom />} />
 

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -54,6 +54,11 @@ export default function NavBar() {
         </li>
         <li>
           <Tooltip message="Hover here for a surprise!">
+            <Link to="/games/darts">Prompt Darts</Link>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
             <Link to="/leaderboard">Progress</Link>
           </Tooltip>
         </li>

--- a/learning-games/src/data/courses.ts
+++ b/learning-games/src/data/courses.ts
@@ -25,7 +25,6 @@ export const COURSES: CourseMeta[] = [
       'https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTZoaHpxY3AwbmN1OTMwN3dkY3c5eXI1eXB3cDJ5ajNudDdkcnJ6cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9dg/SR6WK6jz0rRWf2QK0t/giphy.gif',
   },
   {
-
     id: 'escape',
     title: 'Clarity Escape Room',
     description: 'Solve vague tasks with precise prompts to escape.',
@@ -36,18 +35,18 @@ export const COURSES: CourseMeta[] = [
   {
     id: 'recipe',
     title: 'Prompt Recipe Builder',
-    description: 'Drag ingredients to craft a four-part prompt.',
-    path: '/games/recipe',
-    meme:
-      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGlkeG45MmJ6bzI0NGR4YXV0bnU4em5idGdqd29yMjF0cGxpcnltZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Pj1sRt1KB9vK0K4Cph/giphy.gif',
-
-    id: 'recipe',
-    title: 'Prompt Recipe Builder',
     description: 'Assemble prompt ingredients by dragging cards into bowls.',
     path: '/games/recipe',
     meme:
       'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3h3cTR0cmEybWt0ZGM2Ymx0ZHB4ZjltbmR2dG55M3Y0MWh6dnRjZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ll22OhMLAlVDbDS3Mo/giphy.gif',
-
+  },
+  {
+    id: 'darts',
+    title: 'Prompt Darts',
+    description: 'Aim for clarity by picking the better prompt.',
+    path: '/games/darts',
+    meme:
+      'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWp1bDgwZ2RwYXFmejI0MGpqdGJvMWg3ODZlN2tlNHFndTRxOW0wNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Y4pAX5oO1jQS0/giphy.gif',
   },
 ]
 

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -104,6 +104,14 @@ export default function Home() {
           />
           <span className="game-title">Prompt Builder</span>
         </Link>
+        <Link className="game-card" to="/games/darts">
+          <img
+            src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWp1bDgwZ2RwYXFmejI0MGpqdGJvMWg3ODZlN2tlNHFndTRxOW0wNSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Y4pAX5oO1jQS0/giphy.gif"
+            alt="Prompt darts preview"
+            className="game-icon"
+          />
+          <span className="game-title">Prompt Darts</span>
+        </Link>
       </div>
 
       {/* navigation */}

--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -1,0 +1,54 @@
+.darts-page {
+  padding: 1rem;
+}
+
+.darts-wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+  justify-content: center;
+  align-items: start;
+}
+
+.darts-game {
+  background: #fff;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.darts-sidebar {
+  max-width: 240px;
+  background: #fff;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.feedback {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.final-score {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  .darts-wrapper {
+    grid-template-columns: 1fr;
+  }
+  .progress-sidebar {
+    max-width: none;
+  }
+}

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -1,0 +1,97 @@
+import { useState, useContext } from 'react'
+import { Link } from 'react-router-dom'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
+import InstructionBanner from '../components/ui/InstructionBanner'
+import { UserContext } from '../context/UserContext'
+import './PromptDartsGame.css'
+
+export interface DartRound {
+  bad: string
+  good: string
+}
+
+export const ROUNDS: DartRound[] = [
+  { bad: 'Tell me about AI.', good: 'List 3 use cases of AI in customer service.' },
+  {
+    bad: 'Write an email.',
+    good: 'Draft a 3-sentence email to a hiring manager explaining your interest.',
+  },
+  {
+    bad: 'Explain climate change.',
+    good: 'Summarize 2 key causes of climate change in one paragraph.',
+  },
+]
+
+export function checkChoice(round: DartRound, choice: 'bad' | 'good') {
+  return choice === 'good'
+}
+
+export default function PromptDartsGame() {
+  const { setScore } = useContext(UserContext)
+  const [round, setRound] = useState(0)
+  const [choice, setChoice] = useState<'bad' | 'good' | null>(null)
+  const [score, setScoreState] = useState(0)
+  const current = ROUNDS[round]
+
+  function handleSelect(option: 'bad' | 'good') {
+    setChoice(option)
+    if (checkChoice(current, option)) {
+      setScoreState(s => s + 10)
+    }
+  }
+
+  function next() {
+    if (round + 1 < ROUNDS.length) {
+      setRound(r => r + 1)
+      setChoice(null)
+    } else {
+      setScore('darts', score)
+      setRound(r => r + 1)
+    }
+  }
+
+  if (round >= ROUNDS.length) {
+    return (
+      <div className="darts-page">
+        <InstructionBanner>You finished Prompt Darts!</InstructionBanner>
+        <p className="final-score">Your score: {score}</p>
+        <p style={{ marginTop: '1rem' }}>
+          <Link to="/leaderboard">Return to Progress</Link>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="darts-page">
+      <InstructionBanner>
+        Choose the clearer prompt that best targets the requested format.
+      </InstructionBanner>
+      <div className="darts-wrapper">
+        <ProgressSidebar />
+        <aside className="darts-sidebar">
+          <h3>Why Clarity Matters</h3>
+          <p>The clearer your target, the better your aim. Clear prompts act like aiming sights for AI.</p>
+          <blockquote className="sidebar-quote">Why Card: Why Clarity Matters</blockquote>
+          <p className="sidebar-tip">Align prompt language with output types (teaching specificity and clarity).</p>
+        </aside>
+        <div className="darts-game">
+          <h3>Round {round + 1} of {ROUNDS.length}</h3>
+          <p>Which prompt is clearer?</p>
+          <div className="options">
+            <button onClick={() => handleSelect('bad')} disabled={choice !== null}>{current.bad}</button>
+            <button onClick={() => handleSelect('good')} disabled={choice !== null}>{current.good}</button>
+          </div>
+          {choice !== null && (
+            <p className="feedback">
+              {checkChoice(current, choice) ? 'Correct! Clear prompts hit the bullseye.' : 'Not quite. Aim for specific wording.'}
+            </p>
+          )}
+          {choice !== null && (
+            <button onClick={next}>{round + 1 < ROUNDS.length ? 'Next Round' : 'Finish'}</button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
+++ b/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { checkChoice, ROUNDS } from '../PromptDartsGame'
+
+describe('checkChoice', () => {
+  it('returns true only for the clear option', () => {
+    const round = ROUNDS[0]
+    expect(checkChoice(round, 'good')).toBe(true)
+    expect(checkChoice(round, 'bad')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- introduce Prompt Darts mini game
- link new game from navbar and home page
- register it as a course
- add routing for the new game
- include basic unit test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684360e554a8832fb19e228bcb80031b