### PR TITLE
Improve escape room design and overall styles

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -91,7 +91,7 @@
 
 .progress-sidebar {
   max-width: 240px;
-  background: #fff;
+  background: #f9f9f9;
   color: var(--color-text-dark);
   padding: 1rem;
   border-radius: 8px;
@@ -102,10 +102,16 @@
 
 .progress-sidebar progress {
   width: 100%;
-  height: 1.5rem;
-  accent-color: #ffd700;
+  height: 1.75rem;
+  accent-color: var(--color-brand);
+  transition: all 0.3s ease;
 }
-
+.progress-sidebar progress::-webkit-progress-value {
+  background: linear-gradient(90deg, var(--color-brand), var(--color-orange));
+}
+.progress-sidebar progress::-moz-progress-bar {
+  background: linear-gradient(90deg, var(--color-brand), var(--color-orange));
+}
 /* Match-3 styles */
 .match3-container {
   width: 100%;
@@ -211,6 +217,13 @@
   animation: pop 0.6s ease;
 }
 
+.badge-icons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
 @keyframes pop {
   0% {
     transform: scale(0);
@@ -282,9 +295,13 @@
   padding: 0;
   font-size: 1.1rem;
 }
+.navbar li {
+  padding: 0 0.5rem;
+}
 
 .navbar a {
   color: #fff;
+  font-weight: 600;
   transition: color 0.3s ease, text-decoration 0.3s ease;
 }
 
@@ -382,14 +399,14 @@
 .footer {
   background: var(--color-brand);
   color: #fff;
-  padding: 1.5rem;
+  padding: 2rem 1rem;
   text-align: center;
   margin-top: 2rem;
   box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.2);
 }
 .footer-links {
-  margin-top: 0.5rem;
-  font-size: 0.9rem;
+  margin-top: 0.75rem;
+  font-size: 1rem;
   display: flex;
   justify-content: center;
   gap: 1rem;
@@ -592,3 +609,29 @@
   }
 }
 
+.top-scores-list{list-style:none;padding-left:0;margin:0;} .top-scores-list li{display:flex;justify-content:space-between;padding:0.25rem 0;font-size:0.9rem;} .top-scores-list li.top{color:#d4af37;font-weight:bold;} .view-leaderboard a{text-decoration:underline;} .view-leaderboard a:hover{color:var(--color-orange);} .top-scores-title{margin-top:1rem;}
+
+.top-scores-title {
+  margin-top: 1rem;
+}
+.top-scores-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.top-scores-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0;
+  font-size: 0.9rem;
+}
+.top-scores-list li.top {
+  color: #d4af37;
+  font-weight: bold;
+}
+.view-leaderboard a {
+  text-decoration: underline;
+}
+.view-leaderboard a:hover {
+  color: var(--color-orange);
+}

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -27,21 +27,21 @@ export default function ProgressSidebar() {
       <p aria-live="polite" aria-atomic="true">Total Points: {totalPoints}</p>
       <progress value={totalPoints} max={GOAL_POINTS} />
       <p aria-live="polite" aria-atomic="true">Badges Earned: {user.badges.length}</p>
-      <div className="badge-icons" style={{ marginTop: '0.5rem' }}>
+      <div className="badge-icons">
         {user.badges.map((b) => (
-          <span key={b}>🏅</span>
+          <span key={b} title={b}>🏅</span>
         ))}
         {user.badges.length === 0 && <span>No badges yet.</span>}
       </div>
-      <h4 style={{ marginTop: '1rem' }}>Top Scores</h4>
-      <ol style={{ paddingLeft: '1.2rem' }}>
-        {leaderboard.map((entry) => (
-          <li key={entry.name} style={{ fontWeight: entry.name === (user.name ?? 'You') ? 'bold' : undefined }}>
+      <h4 className="top-scores-title">Top Scores</h4>
+      <ol className="top-scores-list">
+        {leaderboard.map((entry, idx) => (
+          <li key={entry.name} className={idx === 0 ? 'top' : undefined}>
             {entry.name}: {entry.score}
           </li>
         ))}
       </ol>
-      <p style={{ marginTop: '0.5rem' }}>
+      <p className="view-leaderboard">
         <Link to="/leaderboard">View full leaderboard</Link>
       </p>
     </aside>

--- a/learning-games/src/components/ui/InstructionBanner.css
+++ b/learning-games/src/components/ui/InstructionBanner.css
@@ -1,5 +1,5 @@
 .instruction-banner {
-  background: #f1f5f9;
+  background: #f0f9ff;
   color: #000;
   padding: 0.75rem 1rem;
   border-radius: 8px;
@@ -14,6 +14,7 @@
   top: 4px;
   right: 8px;
   background: transparent;
+  transition: transform 0.2s ease;
   border: none;
   font-size: 1rem;
   cursor: pointer;
@@ -21,4 +22,8 @@
 
 .instruction-content {
   padding-right: 1.5rem;
+}
+
+.banner-close:hover {
+  transform: rotate(90deg);
 }

--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -8,8 +8,8 @@
   --color-lime: #a3e635;
   --color-blue: #1e3a8a;
   --color-purple-dark: #6d28d9;
-  --color-brand: #f43f5e;
-  --color-text-dark: #000;
+  --color-brand: #ee3a57;
+  --color-text-dark: #333;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);

--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -8,10 +8,10 @@
 }
 
 .room {
-  background: #222;
+  background: #333;
   color: #fff;
-  padding: 1rem;
-  border-radius: 8px;
+  padding: 1.25rem;
+  border-radius: 10px;
 }
 
 .hint {
@@ -27,6 +27,11 @@
 
 .prompt-form input {
   flex: 1;
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #f9f9f9;
+  color: #333;
 }
 
 .feedback {
@@ -34,8 +39,27 @@
   margin-bottom: 0.5rem;
 }
 
+.escape-sidebar {
+  max-width: 240px;
+  background: #f9f9f9;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.prompt-form button {
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: background-color 0.3s;
+}
+.prompt-form button:hover {
+  background-color: var(--color-orange);
+}
+
 @media (max-width: 600px) {
   .escape-wrapper {
     grid-template-columns: 1fr;
   }
 }
+.prompt-form input::placeholder { color: #999; }
+.score { font-weight: bold; color: var(--color-brand); margin-top: 0.5rem; }

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -10,6 +10,7 @@ type Task = {
 }
 
 const TASKS: Task[] = [
+  { hint: 'Draft an email', keywords: ['draft', 'email'] },
   { hint: 'Improve this greeting', keywords: ['rewrite', 'formal'] },
   { hint: 'Fix this text', keywords: ['correct', 'grammar'] },
   { hint: 'Summarize the announcement', keywords: ['summarize', 'sentences'] },
@@ -75,9 +76,15 @@ export default function ClarityEscapeRoom() {
       </InstructionBanner>
       <div className="escape-wrapper">
         <ProgressSidebar />
+        <aside className="escape-sidebar">
+          <h3>Why Clarity Matters</h3>
+          <p>Vague inputs lock AI in confusion loops; precise prompts open doors.</p>
+          <blockquote className="sidebar-quote">Why Card: Why Clarity Matters</blockquote>
+          <p className="sidebar-tip">Shows how specificity opens doors—literally. Teaching players to apply intent, tone, and task format.</p>
+        </aside>
         <div className="room">
-          <h3>Door {door + 1}</h3>
-          <p className="hint">Hint: {current.hint}</p>
+          <h3>{current.hint}</h3>
+          <p className="hint">Door {door + 1}</p>
           <form onSubmit={handleSubmit} className="prompt-form">
             <input
               value={input}
@@ -87,7 +94,7 @@ export default function ClarityEscapeRoom() {
             <button type="submit">Submit</button>
           </form>
           {message && <p className="feedback">{message}</p>}
-          <p>Score: {score}</p>
+          <p className="score">Score: {score}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle navbar links and footer
- update brand colors
- add animation and color to alert banners
- enhance progress sidebar with gradient progress bar and badge tooltips
- create sidebar with Why Card in Escape Room
- polish escape room page styles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684364d440cc832fb0a6146dfd7d3633