### PR TITLE
Enhance Prompt Builder UX

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -102,9 +102,9 @@
 
 .progress-sidebar progress {
   width: 100%;
-  height: 1.75rem;
+  height: 2rem;
   accent-color: var(--color-brand);
-  transition: all 0.3s ease;
+  transition: width 0.5s ease;
 }
 .progress-sidebar progress::-webkit-progress-value {
   background: linear-gradient(90deg, var(--color-brand), var(--color-orange));
@@ -146,6 +146,18 @@
   gap: 1rem;
   justify-content: center;
   align-items: start;
+}
+
+.leaderboard-card {
+  background: #fff;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.leaderboard-card .top-row {
+  background: #fffbe6;
 }
 
 .match3-sidebar {
@@ -219,9 +231,13 @@
 
 .badge-icons {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
   justify-content: center;
   margin-top: 0.5rem;
+}
+
+.badge-icons span {
+  font-size: 1.5rem;
 }
 
 @keyframes pop {
@@ -296,7 +312,7 @@
   font-size: 1.1rem;
 }
 .navbar li {
-  padding: 0 0.5rem;
+  padding: 0.5rem 0.5rem;
 }
 
 .navbar a {

--- a/learning-games/src/components/ui/InstructionBanner.css
+++ b/learning-games/src/components/ui/InstructionBanner.css
@@ -1,5 +1,5 @@
 .instruction-banner {
-  background: #f0f9ff;
+  background: #fef6e4;
   color: #000;
   padding: 0.75rem 1rem;
   border-radius: 8px;
@@ -7,6 +7,7 @@
   position: relative;
   margin-bottom: 1rem;
   text-align: left;
+  border: 1px solid #f3d9b3;
 }
 
 .banner-close {

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -27,7 +27,7 @@ export default function LeaderboardPage() {
       <div>
         <h2>Leaderboard</h2>
       {/* Show top scores for Tone */}
-      <section>
+      <section className="leaderboard-card">
         <h3>Tone High Scores</h3>
         <table style={{ margin: '0 auto' }}>
           <thead>
@@ -41,9 +41,10 @@ export default function LeaderboardPage() {
               .concat({ name: user.name ?? 'You', score: user.scores['tone'] ?? 0 })
               .sort((a, b) => b.score - a.score)
               .slice(0, 5)
-              .map((entry) => (
+              .map((entry, idx) => (
                 <tr
                   key={entry.name}
+                  className={idx === 0 ? 'top-row' : undefined}
                   style={{
                     fontWeight:
                       user.name && entry.name === user.name ? 'bold' : undefined,

--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -3,6 +3,21 @@
   background: url('https://images.unsplash.com/photo-1500835556837-99ac94a94552?auto=format&fit=crop&w=1200&q=60') center/cover fixed;
   padding: 1rem;
   min-height: 100vh;
+  position: relative;
+  color: var(--color-text-dark);
+}
+
+.recipe-page::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 0;
+}
+
+.recipe-page > * {
+  position: relative;
+  z-index: 1;
 }
 
 .recipe-wrapper {
@@ -12,6 +27,16 @@
   gap: 1rem;
   justify-content: center;
   align-items: start;
+}
+
+.recipe-sidebar {
+  max-width: 240px;
+  background: #fafafa;
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  margin-bottom: 1rem;
 }
 
 
@@ -45,11 +70,21 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  transition: background-color 0.3s, border-color 0.3s;
+}
+
+.bowl.hover {
+  background: #f0f0f0;
+  border-color: var(--color-brand);
 }
 
 .bowl-content {
   margin-top: 0.25rem;
   min-height: 1.2rem;
+}
+
+.bowl strong {
+  font-size: 1.1rem;
 }
 
 .cards {
@@ -66,6 +101,13 @@
   border-radius: 6px;
   cursor: grab;
   user-select: none;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: background-color 0.3s, box-shadow 0.3s;
+}
+
+.card:hover {
+  background: var(--color-brand);
+  box-shadow: 0 4px 6px rgba(0,0,0,0.15);
 }
 
 .bowls {

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -74,6 +74,7 @@ export default function PromptRecipeGame() {
   const [score, setScoreState] = useState(0)
   const [perfectRounds, setPerfectRounds] = useState(0)
   const [showPrompt, setShowPrompt] = useState(false)
+  const [hoverSlot, setHoverSlot] = useState<Slot | null>(null)
 
   function startRound() {
     const newCards: Card[] = [
@@ -118,10 +119,16 @@ export default function PromptRecipeGame() {
     const card = JSON.parse(data) as Card
     setDropped(prev => ({ ...prev, [slot]: card.text }))
     setCards(cs => cs.filter(c => c.text !== card.text))
+    setHoverSlot(null)
   }
 
-  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+  function handleDragOver(slot: Slot, e: React.DragEvent<HTMLDivElement>) {
     e.preventDefault()
+    setHoverSlot(slot)
+  }
+
+  function handleDragLeave() {
+    setHoverSlot(null)
   }
 
   function shuffle<T>(arr: T[]): T[] {
@@ -146,14 +153,21 @@ export default function PromptRecipeGame() {
       </InstructionBanner>
       <div className="recipe-wrapper">
         <ProgressSidebar />
+        <aside className="recipe-sidebar">
+          <h3>Why Build Prompts?</h3>
+          <p>Combining action, context, format and constraints clarifies intent.</p>
+          <blockquote className="sidebar-quote">Why Card: This page has potential but needs some polish to make it intuitive, clean, and engaging.</blockquote>
+          <p className="sidebar-tip">Arrange each ingredient to craft a clear request.</p>
+        </aside>
         <div className="recipe-game">
           <div className="bowls">
             {(['Action', 'Context', 'Format', 'Constraints'] as Slot[]).map(slot => (
               <div
                 key={slot}
-                className="bowl"
+                className={`bowl${hoverSlot === slot ? ' hover' : ''}`}
                 onDrop={e => handleDrop(slot, e)}
-                onDragOver={handleDragOver}
+                onDragOver={e => handleDragOver(slot, e)}
+                onDragLeave={handleDragLeave}
               >
                 <strong>{slot}</strong>
                 <div className="bowl-content">{dropped[slot] || 'Drop here'}</div>


### PR DESCRIPTION
## Summary
- style the Prompt Builder game with an overlay and new sidebar
- enlarge badge icons and animate progress bar
- improve drag-and-drop visuals
- tweak InstructionBanner and leaderboard styling
- highlight top scorer row

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684366a6fd74832f84182075d3c9c9f5