### PR TITLE
Fix typo in QuizGame

### DIFF
--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -211,7 +211,7 @@ export default function QuizGame() {
           </button>
           </div>
           <p className="header-instruction">
-            Pick the hulluscination from the three statements.
+            Pick the hallucination from the three statements.
           </p>
           <p className="round-info">Round {round + 1} / {ROUNDS.length}</p>
           <ul className="statement-list">


### PR DESCRIPTION
## Summary
- fix a typo in `QuizGame.tsx` where "hulluscination" appeared

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68437ad9ee44832f9db6d1f4de80469e