### PR TITLE
Persist theme preference with localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A short quiz where you spot the single AI hallucination hidden among two truthfu
 - Players enter their age and name on first visit.
 - Games read the stored age to tweak difficulty and show tailored tips.
 - High scores and earned badges persist using `localStorage`.
+- High contrast theme preference persists via `ThemeToggle`.
 
 ## Getting Started
 1. Install dependencies and start the dev server:

--- a/docs/UX-Changes.md
+++ b/docs/UX-Changes.md
@@ -2,7 +2,7 @@
 
 The following updates were applied across the codebase based on the UX review:
 
-- **High contrast theme toggle** via new `ThemeToggle` component and `high-contrast` styles.
+- **High contrast theme toggle** via new `ThemeToggle` component and `high-contrast` styles. The user's preference now persists in `localStorage`.
 - **Accessible notifications** by giving `Toaster` an ARIA live region.
 - **Consistent back navigation** with “Return Home” links on game and profile pages.
 - **Improved form layout** in `AgeInputForm` using flexbox and spacing.

--- a/learning-games/src/components/layout/ThemeToggle.tsx
+++ b/learning-games/src/components/layout/ThemeToggle.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useState } from 'react'
 
+const STORAGE_KEY = 'strawberrytech_contrast'
+
 export default function ThemeToggle() {
-  const [enabled, setEnabled] = useState(false)
+  const [enabled, setEnabled] = useState(() => {
+    return localStorage.getItem(STORAGE_KEY) === 'true'
+  })
 
   useEffect(() => {
     document.body.classList.toggle('high-contrast', enabled)
+    localStorage.setItem(STORAGE_KEY, String(enabled))
   }, [enabled])
 
   return (


### PR DESCRIPTION
## Summary
- store high-contrast preference under `strawberrytech_contrast`
- persist the mode selection and apply on load
- mention the persistent theme in docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68437cf3bc58832f87758583f7af80ab