### PR TITLE
Add next round area layout to Prompt Darts

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -5,7 +5,12 @@
 .darts-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "why"
+    "game"
+    "progress"
+    "next";
   gap: 1rem;
   justify-content: center;
   align-items: start;
@@ -16,6 +21,7 @@
   color: var(--color-text-dark);
   padding: 1rem;
   border-radius: 8px;
+  grid-area: game;
 }
 
 .darts-sidebar {
@@ -28,6 +34,16 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  grid-area: why;
+}
+
+.progress-sidebar {
+  grid-area: progress;
+}
+
+.next-area {
+  grid-area: next;
+  text-align: center;
 }
 
 .options {
@@ -47,9 +63,12 @@
   font-weight: bold;
 }
 
-@media (max-width: 600px) {
+@media (min-width: 600px) {
   .darts-wrapper {
-    grid-template-columns: 1fr;
+    grid-template-columns: 260px 1fr;
+    grid-template-areas:
+      "why game"
+      "progress next";
   }
   .progress-sidebar {
     max-width: none;

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -68,7 +68,6 @@ export default function PromptDartsGame() {
         Choose the clearer prompt that best targets the requested format.
       </InstructionBanner>
       <div className="darts-wrapper">
-        <ProgressSidebar />
         <aside className="darts-sidebar">
           <h3>Why Clarity Matters</h3>
           <p>The clearer your target, the better your aim. Clear prompts act like aiming sights for AI.</p>
@@ -87,10 +86,11 @@ export default function PromptDartsGame() {
               {checkChoice(current, choice) ? 'Correct! Clear prompts hit the bullseye.' : 'Not quite. Aim for specific wording.'}
             </p>
           )}
+        </div>
+        <ProgressSidebar />
+        <div className="next-area">
           {choice !== null && (
-
             <button className="btn-primary" onClick={next}>{round + 1 < ROUNDS.length ? 'Next Round' : 'Finish'}</button>
-
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- adjust PromptDartsGame layout to include a dedicated **next-area** for the next round button
- reorder PromptDartsGame children for grid-area usage
- update PromptDartsGame styles to use grid-template-areas and responsive two-column layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684383f3a8fc832fb512554272214749