### PR TITLE
Add next-area layout

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -23,14 +23,32 @@
 .recipe-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 260px 1fr 260px;
+  grid-template-areas:
+    'sidebar game progress'
+    'next    next next';
   gap: 1rem;
   justify-content: center;
   align-items: start;
   margin-top: 1rem;
 }
 
+
+.recipe-game {
+  grid-area: game;
+}
+
+.progress-sidebar {
+  grid-area: progress;
+}
+
+.next-area {
+  grid-area: next;
+  text-align: center;
+}
+
 .recipe-sidebar {
+  grid-area: sidebar;
   max-width: 240px;
   background: var(--color-background);
   color: var(--color-text-dark);
@@ -53,7 +71,7 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.recipe-game button {
+.next-area button {
   margin-top: 0.5rem;
   font-size: 1rem;
   padding: 0.6rem 1.2rem;
@@ -145,6 +163,11 @@
 @media (max-width: 600px) {
   .recipe-wrapper {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      'sidebar'
+      'game'
+      'progress'
+      'next';
   }
 
   .progress-sidebar {

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -152,7 +152,6 @@ export default function PromptRecipeGame() {
         Drag each ingredient card into the correct bowl to build the prompt recipe.
       </InstructionBanner>
       <div className="recipe-wrapper">
-        <ProgressSidebar />
         <aside className="recipe-sidebar">
           <h3>Why Build Prompts?</h3>
           <p>Combining action, context, format and constraints clarifies intent.</p>
@@ -190,12 +189,15 @@ export default function PromptRecipeGame() {
             <div className="plate">
               <h3>Your Prompt</h3>
               <p>{promptText}</p>
-
-              <button className="btn-primary" onClick={nextRound}>Next Recipe</button>
-
             </div>
           )}
         </div>
+        <ProgressSidebar />
+        {showPrompt && (
+          <div className="next-area">
+            <button className="btn-primary" onClick={nextRound}>Next Recipe</button>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- reorganize layout for PromptRecipeGame page
- allow Next Recipe button to span full width using new grid areas

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684383fa8b40832f9db6f3a81dce8fdb