### PR TITLE
Update QuizGame layout styles

### DIFF
--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -2,6 +2,9 @@
   width: 100%;
   display: grid;
   grid-template-columns: 260px 1fr;
+  grid-template-areas:
+    "sidebar game"
+    "progress next";
   gap: 1rem;
   justify-content: center;
   align-items: start;
@@ -57,7 +60,6 @@
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-  grid-column: span 2;
 }
 
 .chatbox-history {
@@ -134,19 +136,38 @@
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   text-align: left;
   margin-bottom: 1rem;
-  grid-column: 1;
+  grid-area: sidebar;
 }
 
 .progress-sidebar {
-  grid-column: 1;
+  grid-area: progress;
+}
+
+.game-area {
+  grid-area: game;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.next-area {
+  grid-area: next;
+  text-align: center;
 }
 
 @media (max-width: 600px) {
   .truth-game {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      "sidebar"
+      "game"
+      "progress"
+      "next";
   }
   .quiz-sidebar,
-  .progress-sidebar {
+  .progress-sidebar,
+  .game-area,
+  .next-area {
     max-width: none;
     grid-column: auto;
   }

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -197,9 +197,9 @@ export default function QuizGame() {
         for new prompts and then select your answer.
       </InstructionBanner>
       <div className="truth-game">
-        <ProgressSidebar />
         <WhyItMatters />
-        <div className="statements">
+        <div className="game-area">
+          <div className="statements">
           <div className="statement-header">
             <h2>Hallucinations</h2>
             <button
@@ -241,14 +241,16 @@ export default function QuizGame() {
         )}
         </div>
         <ChatBox />
-        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-
-          <button className="btn-primary" onClick={() => navigate('/leaderboard')}>Next</button>
-
-        </p>
-        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-          <Link to="/leaderboard">Return to Progress</Link>
-        </p>
+        </div>
+        <ProgressSidebar />
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button className="btn-primary" onClick={() => navigate('/leaderboard')}>Next</button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link to="/leaderboard">Return to Progress</Link>
+          </p>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- restructure QuizGame layout with new `game-area` wrapper
- move navigation buttons to a `next-area` section
- use CSS grid areas for page layout
- add responsive arrangement for mobile
- remove unused grid-column rule on chatbox

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684383fb28f4832fa6bbe399a839e366