### PR TITLE
Reorder Clarity Escape Room layout

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -1,13 +1,17 @@
 .escape-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 260px 1fr 260px;
+  grid-template-areas:
+    'sidebar room progress'
+    'sidebar next progress';
   gap: 1rem;
   justify-content: center;
   align-items: start;
 }
 
 .room {
+  grid-area: room;
   background: var(--color-deep-red);
   color: #fff;
   padding: 1.25rem;
@@ -48,6 +52,7 @@
 }
 
 .escape-sidebar {
+  grid-area: sidebar;
   max-width: 240px;
   background: var(--color-background);
   color: var(--color-text-dark);
@@ -67,9 +72,26 @@
   background-color: var(--color-orange);
 }
 
+.progress-sidebar {
+  grid-area: progress;
+}
+
+.next-area {
+  grid-area: next;
+  text-align: center;
+}
+
 @media (max-width: 600px) {
   .escape-wrapper {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      'sidebar'
+      'room'
+      'progress'
+      'next';
+  }
+  .progress-sidebar {
+    max-width: none;
   }
 }
 .prompt-form input::placeholder { color: #999; }

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -75,7 +75,6 @@ export default function ClarityEscapeRoom() {
         Enter a precise prompt to unlock each door.
       </InstructionBanner>
       <div className="escape-wrapper">
-        <ProgressSidebar />
         <aside className="escape-sidebar">
           <h3>Why Clarity Matters</h3>
           <p>Vague inputs lock AI in confusion loops; precise prompts open doors.</p>
@@ -96,6 +95,8 @@ export default function ClarityEscapeRoom() {
           {message && <p className="feedback">{message}</p>}
           <p className="score">Score: {score}</p>
         </div>
+        <ProgressSidebar />
+        <div className="next-area" />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- reorder escape room components so sidebar comes first
- use grid template areas for desktop and mobile layouts

## Testing
- `npm test --silent --prefix learning-games` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684383fbb8b8832f9318a00e4ffe2b6d