### PR TITLE
Update DragDropGame layout

### DIFF
--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -1,7 +1,3 @@
-.dragdrop-game {
-  padding: 1rem;
-}
-
 .dragdrop-page {
   max-width: 800px;
   margin: 0 auto;
@@ -10,10 +6,28 @@
 .dragdrop-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr;
   gap: 1rem;
   justify-content: center;
   align-items: start;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "sidebar"
+    "game"
+    "progress"
+    "next";
+}
+
+.dragdrop-game {
+  padding: 1rem;
+  grid-area: game;
+}
+
+.progress-sidebar {
+  grid-area: progress;
+}
+
+.next-area {
+  grid-area: next;
 }
 
 .sentence {
@@ -94,12 +108,15 @@
   }
 }
 
-@media (max-width: 600px) {
+@media (min-width: 600px) {
   .dragdrop-wrapper {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 260px;
+    grid-template-areas:
+      "sidebar progress"
+      "game progress"
+      "next progress";
   }
   .progress-sidebar {
-    max-width: none;
-    grid-column: auto;
+    max-width: 260px;
   }
 }

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import './DragDropGame.css'
 
@@ -63,7 +64,6 @@ export default function DragDropGame() {
   return (
     <div className="dragdrop-page">
       <div className="dragdrop-wrapper">
-        <ProgressSidebar />
         <div className="dragdrop-game">
           <h2>Drag a tone into the blank</h2>
           <p className="sentence">
@@ -140,6 +140,12 @@ export default function DragDropGame() {
           )}
         </div>
       )}
+        </div>
+        <ProgressSidebar />
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link to="/leaderboard">Return to Progress</Link>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- reorganize DragDropGame page so game is first, followed by the progress sidebar and new next-area wrapper
- implement responsive grid using `grid-template-areas`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684383fc9328832f96efa0d3031cd1f6