### PR TITLE
Improve footer responsiveness

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -437,20 +437,45 @@
   margin-top: 2rem;
   box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.2);
 }
+
+.footer-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+}
+
 .footer-links {
-  margin-top: 0.75rem;
   font-size: 1rem;
   display: flex;
   justify-content: center;
   gap: 1rem;
 }
+
 .footer-links a {
   color: #fff;
   text-decoration: none;
 }
+
 .footer-links a:hover {
   color: var(--color-lime);
   text-decoration: underline;
+}
+
+@media (max-width: 480px) {
+  .footer-links {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+@media (min-width: 600px) {
+  .footer-content {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+  }
 }
 
 

--- a/learning-games/src/components/layout/Footer.tsx
+++ b/learning-games/src/components/layout/Footer.tsx
@@ -2,18 +2,20 @@ export default function Footer() {
   const year = new Date().getFullYear()
   return (
     <footer className="footer">
-      <div className="brand">
-        <img
-          src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
-          alt="Strawberry logo"
-          className="brand-logo"
-        />
-        <span>&copy; {year} StrawberryTech</span>
-      </div>
-      <div className="footer-links">
-        <a href="/privacy">Privacy Policy</a>
-        <a href="/terms">Terms of Service</a>
-        <a href="/contact">Contact</a>
+      <div className="footer-content">
+        <div className="brand">
+          <img
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
+            alt="Strawberry logo"
+            className="brand-logo"
+          />
+          <span>&copy; {year} StrawberryTech</span>
+        </div>
+        <nav className="footer-links">
+          <a href="/privacy">Privacy Policy</a>
+          <a href="/terms">Terms of Service</a>
+          <a href="/contact">Contact</a>
+        </nav>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
- make the footer markup include a `footer-content` wrapper
- add responsive styles for footer links and layout on small screens

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843865fb3f8832f88e6099a8da71ee7