### PR TITLE
Improve layout consistency for Tone and Hallucinations

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -131,14 +131,13 @@
 }
 /* Match-3 styles */
 .match3-container {
+  grid-area: game;
   width: 100%;
   max-width: 420px;
   margin: 0 auto;
   background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
   padding: 1rem;
   border-radius: 8px;
-  grid-column: 2;
-  grid-row: 1;
 }
 
 .match3-page {
@@ -150,7 +149,10 @@
 .match3-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 260px 1fr 260px;
+  grid-template-areas:
+    'sidebar game progress'
+    'next    next progress';
   gap: 1rem;
   justify-content: center;
   align-items: start;
@@ -178,6 +180,7 @@
 }
 
 .match3-sidebar {
+  grid-area: sidebar;
   max-width: 240px;
   background: var(--color-background);
   color: var(--color-text-dark);
@@ -185,8 +188,11 @@
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   text-align: left;
-  grid-column: 1;
-  grid-row: 1;
+}
+
+.next-area {
+  grid-area: next;
+  text-align: center;
 }
 
 
@@ -272,6 +278,11 @@
 @media (max-width: 600px) {
   .match3-wrapper {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      'sidebar'
+      'game'
+      'progress'
+      'next';
   }
 
   .leaderboard-wrapper {

--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -11,7 +11,6 @@
   align-items: start;
   grid-template-columns: 1fr;
   grid-template-areas:
-    "sidebar"
     "game"
     "progress"
     "next";
@@ -20,6 +19,10 @@
 .dragdrop-game {
   padding: 1rem;
   grid-area: game;
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .progress-sidebar {
@@ -28,6 +31,7 @@
 
 .next-area {
   grid-area: next;
+  text-align: center;
 }
 
 .sentence {
@@ -112,7 +116,6 @@
   .dragdrop-wrapper {
     grid-template-columns: 1fr 260px;
     grid-template-areas:
-      "sidebar progress"
       "game progress"
       "next progress";
   }

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import InstructionBanner from '../components/ui/InstructionBanner'
 import './DragDropGame.css'
 
 const tones = [
@@ -63,6 +64,9 @@ export default function DragDropGame() {
 
   return (
     <div className="dragdrop-page">
+      <InstructionBanner>
+        Drag a tone into the blank to see how the wording changes.
+      </InstructionBanner>
       <div className="dragdrop-wrapper">
         <div className="dragdrop-game">
           <h2>Drag a tone into the blank</h2>

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -328,15 +328,20 @@ export default function Match3Game() {
         <div className="match3-container">
           <ToneMatchGame onComplete={handleComplete} />
         </div>
+        <ProgressSidebar />
+        <div className="next-area">
+          <button
+            className="btn-primary"
+            onClick={() => navigate('/games/quiz')}
+          >
+            Next Lesson
+          </button>
+          <p style={{ marginTop: '1rem' }}>
+            <Link to="/leaderboard">Return to Progress</Link>
+          </p>
+        </div>
       </div>
       <RobotChat />
-      <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-        <button className="btn-primary" onClick={() => navigate('/games/quiz')}>Next Lesson</button>
-
-      </p>
-      <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-        <Link to="/leaderboard">Return to Progress</Link>
-      </p>
     </div>
   );
 }

--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -1,21 +1,21 @@
 .truth-game {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 260px 1fr 260px;
   grid-template-areas:
-    "sidebar game"
-    "progress next";
+    "sidebar game progress"
+    "next    next progress";
   gap: 1rem;
   justify-content: center;
   align-items: start;
 }
 
 .statements {
-  background: linear-gradient(135deg, var(--color-purple-dark), var(--color-blue));
-  color: #fff;
+  background: var(--color-background);
+  color: var(--color-text-dark);
   padding: 1rem;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   margin-bottom: 1rem;
 }
 
@@ -148,6 +148,11 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .next-area {


### PR DESCRIPTION
## Summary
- give Match3 (Tone) page a progress sidebar and next-area
- style DragDrop and Quiz layouts like the other games
- add InstructionBanner to the drag/drop game
- update responsive grids in global styles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684387dd8578832fb9b27d61b7ab748d