### PR TITLE
Add character limit to RobotChat

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -618,6 +618,13 @@
   flex: 1;
 }
 
+.char-counter {
+  text-align: right;
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
 /* RobotChat enhancements */
 .chat-close {
   position: absolute;

--- a/learning-games/src/components/RobotChat.tsx
+++ b/learning-games/src/components/RobotChat.tsx
@@ -92,9 +92,17 @@ export default function RobotChat() {
                 value={input}
                 onChange={e => setInput(e.target.value)}
                 placeholder="Say something..."
+                maxLength={100}
               />
-              <button type="submit" className="btn-primary">Send</button>
+              <button
+                type="submit"
+                className="btn-primary"
+                disabled={input.length >= 100}
+              >
+                Send
+              </button>
             </form>
+            <p className="char-counter">{input.length} / 100</p>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- limit RobotChat message input to 100 characters
- show a character counter
- disable send button when at limit

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68438c86cc18832fa2aff2b043e6d532