### PR TITLE
Add open percent progress bar

### DIFF
--- a/learning-games/src/components/ui/ProgressBar.css
+++ b/learning-games/src/components/ui/ProgressBar.css
@@ -1,0 +1,14 @@
+.progress-bar {
+  width: 100%;
+  height: 0.5rem;
+  background: var(--color-secondary);
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 0.5rem 0;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: var(--color-brand);
+  transition: width 0.3s ease;
+}

--- a/learning-games/src/components/ui/ProgressBar.tsx
+++ b/learning-games/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import './ProgressBar.css'
+
+export default function ProgressBar({ percent }: { percent: number }) {
+  return (
+    <div className="progress-bar" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={percent}>
+      <div className="progress-bar-fill" style={{ width: `${percent}%` }} />
+    </div>
+  )
+}

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useContext } from 'react'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
+import ProgressBar from '../components/ui/ProgressBar'
 import { UserContext } from '../context/UserContext'
 import './ClarityEscapeRoom.css'
 
@@ -37,6 +38,7 @@ export default function ClarityEscapeRoom() {
   const [start] = useState(() => Date.now())
   const [timeLeft, setTimeLeft] = useState(30)
   const [hintVisible, setHintVisible] = useState(false)
+  const [openPercent, setOpenPercent] = useState(0)
 
   const current = tasks[door]
 
@@ -95,6 +97,10 @@ export default function ClarityEscapeRoom() {
   }, [door])
 
   useEffect(() => {
+    setOpenPercent(Math.round((door / tasks.length) * 100))
+  }, [door, tasks.length])
+
+  useEffect(() => {
     if (door === tasks.length) {
       setScore('escape', score)
     }
@@ -134,6 +140,7 @@ export default function ClarityEscapeRoom() {
             <button type="submit" className="btn-primary">Submit</button>
             <button type="button" onClick={showHint} className="btn-primary">Hint</button>
           </form>
+          <ProgressBar percent={openPercent} />
           {hintVisible && (
             <p className="hint-keywords">Keywords: {current.keywords.join(', ')}</p>
           )}


### PR DESCRIPTION
## Summary
- add new `ProgressBar` component using strawberry colors
- track `openPercent` in Clarity Escape Room and update when doors open
- show progress bar under the prompt input

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68438c8d8310832fb0f7b04405ff40ee