### PR TITLE
Fix duplicate state in ClarityEscapeRoom

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -44,7 +44,6 @@ export default function ClarityEscapeRoom() {
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
   const [hintVisible, setHintVisible] = useState(false)
-  const [openPercent, setOpenPercent] = useState(0)
 
   const segments = [
     'The door creaks open a little.',


### PR DESCRIPTION
## Summary
- remove duplicated `openPercent` state hook in `ClarityEscapeRoom`

## Testing
- `npm test`
- `npm run lint` *(fails: 'level' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68438f159ce4832fa4994795ef37250c