### PR TITLE
Move contrast button to profile page

### DIFF
--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import ThemeToggle from './ThemeToggle'
 import Tooltip from '../ui/Tooltip'
 
 export default function NavBar() {
@@ -16,7 +15,6 @@ export default function NavBar() {
         />
         StrawberryTech
       </div>
-      <ThemeToggle />
       <button
         className="menu-toggle"
         aria-label="Toggle navigation"

--- a/learning-games/src/pages/ProfilePage.tsx
+++ b/learning-games/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { useContext, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import AgeInputForm from './AgeInputForm'
 import { UserContext } from '../context/UserContext'
+import ThemeToggle from '../components/layout/ThemeToggle'
 
 export default function ProfilePage() {
   const { user, setName } = useContext(UserContext)
@@ -31,6 +32,10 @@ export default function ProfilePage() {
 
       </form>
       <AgeInputForm allowEdit onSaved={() => navigate('/leaderboard')} />
+      <div style={{ marginTop: '1rem' }}>
+        <span style={{ marginRight: '0.5rem' }}>High Contrast Mode:</span>
+        <ThemeToggle />
+      </div>
       <p style={{ marginTop: '1rem' }}>
         <Link to="/leaderboard">Return to Progress</Link>
       </p>

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -75,7 +75,6 @@ export default function PromptRecipeGame() {
   const [perfectRounds, setPerfectRounds] = useState(0)
   const [showPrompt, setShowPrompt] = useState(false)
   const [hoverSlot, setHoverSlot] = useState<Slot | null>(null)
-  const [level, setLevel] = useState(1)
   const [timeLeft, setTimeLeft] = useState(30)
   const [hintSlot, setHintSlot] = useState<Slot | null>(null)
   const [feedback, setFeedback] = useState<Record<Slot, 'correct' | 'wrong' | null>>({
@@ -179,7 +178,6 @@ export default function PromptRecipeGame() {
   }
 
   function nextRound() {
-    setLevel(l => l + 1)
     startRound()
   }
 


### PR DESCRIPTION
## Summary
- move `ThemeToggle` off the navbar
- add the contrast toggle to the profile page with a label
- fix linter error in `PromptRecipeGame`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68438cfa07e8832f813f8943a5512b01