### PR TITLE
Add ClarityEscapeRoom tests

### DIFF
--- a/learning-games/src/pages/__tests__/ClarityEscapeRoom.test.tsx
+++ b/learning-games/src/pages/__tests__/ClarityEscapeRoom.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import ClarityEscapeRoom from '../ClarityEscapeRoom'
+import { UserProvider } from '../../context/UserProvider'
+
+function setup() {
+  return render(
+    <MemoryRouter>
+      <UserProvider>
+        <ClarityEscapeRoom />
+      </UserProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  vi.spyOn(Math, 'random').mockReturnValue(0)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ClarityEscapeRoom', () => {
+  it('increments openPercent and reveals next segment on valid prompt', () => {
+    const { getByPlaceholderText, getByText } = setup()
+    const input = getByPlaceholderText(/type your prompt/i)
+    fireEvent.change(input, { target: { value: 'rewrite formal' } })
+    fireEvent.submit(input.closest('form')!)
+    expect(getByText(/door 2/i)).toBeTruthy()
+    expect(getByText(/The door unlocks with a click/i)).toBeTruthy()
+  })
+
+  it('limits input to 100 characters', () => {
+    const { getAllByPlaceholderText } = setup()
+    const input = getAllByPlaceholderText(/type your prompt/i)[0] as HTMLInputElement
+    const longText = 'a'.repeat(150)
+    fireEvent.change(input, { target: { value: longText } })
+    expect(input.value.length).toBeLessThanOrEqual(100)
+  })
+})


### PR DESCRIPTION
## Summary
- add ClarityEscapeRoom.test.tsx for escape room game
- mock shuffle order to make prompts deterministic
- check door progress and input length

## Testing
- `npm test` *(fails: ClarityEscapeRoom > limits input to 100 characters)*

------
https://chatgpt.com/codex/tasks/task_e_68438c8f1030832f89e5076f0316a1b3