### PR TITLE
Fix Tone and Hallucination layout

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -180,7 +180,7 @@ export default function ClarityEscapeRoom() {
           <form onSubmit={handleSubmit} className="prompt-form">
             <input
               value={input}
-              onChange={e => setInput(e.target.value)}
+              onChange={e => setInput(e.target.value.slice(0, 100))}
               placeholder="Type your prompt"
             />
             <button type="submit" className="btn-primary">Submit</button>

--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -1,6 +1,5 @@
 .dragdrop-page {
-  max-width: 800px;
-  margin: 0 auto;
+  padding: 1rem;
 }
 
 .dragdrop-wrapper {

--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -105,13 +105,12 @@
 }
 
 .quiz-page {
-  max-width: 800px;
-  margin: 0 auto;
+  padding: 1rem;
 }
 
 @media (max-width: 480px) {
   .quiz-page {
-    margin: 0 1rem;
+    padding: 1rem;
   }
   .statement-btn {
     font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- tone and hallucination game pages were using outdated page styles
- update tone (DragDropGame) and hallucination (QuizGame) page CSS
- ensure ClarityEscapeRoom input caps at 100 chars for passing tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684395589a58832f94bae64c8027e80f