### PR TITLE
Enhance leaderboard UI and progress logic

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -108,16 +108,15 @@
   width: 100%;
   height: 20px;
   accent-color: var(--color-accent);
-  background-color: var(--color-secondary);
+  background-color: var(--color-brand);
   border-radius: 10px;
   overflow: hidden;
   transition: width 0.4s ease;
 }
 .progress-sidebar progress::-webkit-progress-bar {
-  background-color: var(--color-secondary);
+  background-color: var(--color-brand);
   border-radius: 10px;
   transition: width 0.5s ease;
-
 }
 .progress-sidebar progress::-webkit-progress-value {
   background: var(--color-accent);
@@ -128,6 +127,13 @@
   background: var(--color-accent);
   border-radius: 10px;
   transition: width 0.4s ease;
+}
+
+.goal-message {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-dark);
+  margin: 0.25rem 0 0.5rem;
 }
 /* Match-3 styles */
 .match3-container {
@@ -159,7 +165,7 @@
 .leaderboard-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 1fr 260px;
   gap: 1rem;
   justify-content: center;
   align-items: start;
@@ -174,7 +180,16 @@
 }
 
 .leaderboard-card .top-row {
-  background: var(--color-secondary);
+  background: #ffd700;
+  font-weight: bold;
+}
+
+.leaderboard-card tbody tr:nth-child(even) {
+  background: #fff0f5;
+}
+
+.leaderboard-card tbody tr:hover {
+  background: #fbe4e9;
 }
 
 .match3-sidebar {

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -8,7 +8,7 @@ import Tooltip from '../ui/Tooltip'
 export default function ProgressSidebar() {
   const { user } = useContext(UserContext)
   const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
-  const GOAL_POINTS = 100
+  const GOAL_POINTS = 300
   const celebrated = useRef(false)
 
   useEffect(() => {
@@ -27,6 +27,9 @@ export default function ProgressSidebar() {
       <h3>Your Progress</h3>
       <p aria-live="polite" aria-atomic="true">Total Points: {totalPoints}</p>
       <progress value={totalPoints} max={GOAL_POINTS} />
+      <p className="goal-message" aria-live="polite" aria-atomic="true">
+        Goal: Reach {GOAL_POINTS} points to unlock a new badge!
+      </p>
       <p aria-live="polite" aria-atomic="true">Badges Earned: {user.badges.length}</p>
       <div className="badge-icons">
         {user.badges.map((b) => (

--- a/learning-games/src/pages/LeaderboardPage.css
+++ b/learning-games/src/pages/LeaderboardPage.css
@@ -1,0 +1,46 @@
+.leaderboard-card {
+  background: #fff;
+  border: 2px solid #ee3a57;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  padding: 1rem;
+  font-family: 'Poppins', sans-serif;
+}
+
+.leaderboard-card table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.leaderboard-card th, .leaderboard-card td {
+  text-align: left;
+  padding: 0.5rem;
+}
+
+.leaderboard-card th button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+}
+
+.search-box {
+  margin-bottom: 0.75rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.search-box input {
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+@media (max-width: 600px) {
+  .leaderboard-card {
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign progress bar colors
- move sidebar to the right and polish leaderboard styles
- add search & sortable columns
- show goal message and raise goal in progress sidebar

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68439728ce50832f83a15e12f289857c