### PR TITLE
Implement analytics and limit posts per user

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -16,15 +16,18 @@ import HelpPage from './pages/HelpPage'
 import PrivacyPage from './pages/PrivacyPage'
 import TermsPage from './pages/TermsPage'
 import ContactPage from './pages/ContactPage'
+import StatsPage from './pages/StatsPage'
 import { Toaster } from 'react-hot-toast'
 import NavBar from './components/layout/NavBar'
 import Footer from './components/layout/Footer'
+import AnalyticsTracker from './components/AnalyticsTracker'
 import './App.css'
 
 function App() {
   return (
     <Router>
       <NavBar />
+      <AnalyticsTracker />
       <Routes>
         <Route path="/age" element={<AgeInputForm />} />
         <Route path="/welcome" element={<SplashPage />} />
@@ -43,6 +46,7 @@ function App() {
         <Route path="/terms" element={<TermsPage />} />
         <Route path="/contact" element={<ContactPage />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/stats" element={<StatsPage />} />
       </Routes>
       {/* Verification comment: routes render correctly with context */}
       <Toaster

--- a/learning-games/src/components/AnalyticsTracker.tsx
+++ b/learning-games/src/components/AnalyticsTracker.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useContext } from 'react'
+import { useLocation } from 'react-router-dom'
+import { UserContext } from '../context/UserContext'
+
+export default function AnalyticsTracker() {
+  const location = useLocation()
+  const { user } = useContext(UserContext)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const base = window.location.origin
+      fetch(`${base}/api/views`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user: user.name, path: location.pathname }),
+      }).catch(() => {})
+    }
+  }, [location, user.name])
+
+  return null
+}

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -75,6 +75,11 @@ export default function NavBar() {
             <Link to="/profile">Profile</Link>
           </Tooltip>
         </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
+            <Link to="/stats">Stats</Link>
+          </Tooltip>
+        </li>
       </ul>
     </nav>
   )

--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -29,6 +29,7 @@ export default function CommunityPage() {
     return initialPosts
   })
   const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -61,6 +62,10 @@ export default function CommunityPage() {
         content: message.trim(),
         date: new Date().toISOString(),
       }
+      if (posts.some(p => p.author === newPost.author)) {
+        setError('Limit reached: only one post per user')
+        return
+      }
       setPosts((prev) => [...prev, newPost])
       if (typeof window !== 'undefined') {
         const base = window.location.origin
@@ -70,6 +75,7 @@ export default function CommunityPage() {
           body: JSON.stringify(newPost),
         }).catch(() => {})
       }
+      setError('')
       setMessage('')
     }
   }
@@ -90,6 +96,11 @@ export default function CommunityPage() {
           Post
         </button>
       </form>
+      {error && (
+        <p role="alert" style={{ color: 'red' }}>
+          {error}
+        </p>
+      )}
       {posts
         .slice()
         .reverse()

--- a/learning-games/src/pages/StatsPage.tsx
+++ b/learning-games/src/pages/StatsPage.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+interface ViewData {
+  id: number
+  user: string | null
+  path: string
+  timestamp: string
+}
+
+export default function StatsPage() {
+  const [views, setViews] = useState<ViewData[]>([])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const base = window.location.origin
+      fetch(`${base}/api/views`)
+        .then(res => (res.ok ? res.json() : []))
+        .then(data => setViews(Array.isArray(data) ? data : []))
+        .catch(() => {})
+    }
+  }, [])
+
+  const now = Date.now()
+  const lastHour = now - 60 * 60 * 1000
+  const lastDay = now - 24 * 60 * 60 * 1000
+  const lastWeek = now - 7 * 24 * 60 * 60 * 1000
+  const lastMonth = now - 30 * 24 * 60 * 60 * 1000
+
+  const viewsLastHour = views.filter(v => new Date(v.timestamp).getTime() >= lastHour).length
+  const viewsLastDay = views.filter(v => new Date(v.timestamp).getTime() >= lastDay).length
+  const viewsLastWeek = views.filter(v => new Date(v.timestamp).getTime() >= lastWeek).length
+  const viewsLastMonth = views.filter(v => new Date(v.timestamp).getTime() >= lastMonth).length
+
+  const dayCounts = Array.from({ length: 7 }).map((_, i) => {
+    const start = new Date(now - (6 - i) * 24 * 60 * 60 * 1000)
+    start.setHours(0, 0, 0, 0)
+    const end = new Date(start)
+    end.setDate(start.getDate() + 1)
+    return views.filter(v => {
+      const t = new Date(v.timestamp).getTime()
+      return t >= start.getTime() && t < end.getTime()
+    }).length
+  })
+
+  const chartWidth = 280
+  const chartHeight = 80
+  const max = Math.max(...dayCounts, 1)
+  const points = dayCounts
+    .map((c, i) => {
+      const x = (i / (dayCounts.length - 1)) * chartWidth + 10
+      const y = chartHeight - (c / max) * chartHeight + 10
+      return `${x},${y}`
+    })
+    .join(' ')
+
+  return (
+    <div className="stats-page">
+      <h2>Site Statistics</h2>
+      <p>Total Views: {views.length}</p>
+      <p>Views last hour: {viewsLastHour}</p>
+      <p>Views last day: {viewsLastDay}</p>
+      <p>Views last week: {viewsLastWeek}</p>
+      <p>Views last month: {viewsLastMonth}</p>
+      <svg width={chartWidth + 20} height={chartHeight + 20} aria-label="Views line chart">
+        <polyline points={points} fill="none" stroke="blue" strokeWidth="2" />
+      </svg>
+      <p style={{ marginTop: '2rem' }}>
+        <Link to="/">Return Home</Link>
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- enforce one community post per user
- track page views with IP and user agent
- add `/api/views` server endpoints
- show posting limit errors on the community page
- add `AnalyticsTracker` component
- create a new statistics page with a line chart
- link Stats page in the nav bar

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68439c5a8b04832fa110bb5974698279