### PR TITLE
Add generative AI to Prompt Recipe Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Swap adjectives to explore how word choice affects tone. Matches award points an
 ### Hallucinations
 A short quiz where you spot the single AI hallucination hidden among two truthful statements.
 
+### Prompt Recipe Builder
+Drag cards to assemble a prompt. Each round now fetches fresh card text from the OpenAI API and shows a short sample response after you build the recipe.
+
 ## Age‑Adaptive Features
 - Players enter their age and name on first visit.
 - Games read the stored age to tweak difficulty and show tailored tips.
@@ -31,7 +34,7 @@ A short quiz where you spot the single AI hallucination hidden among two truthfu
    npm start
    ```
 3. Create a `.env` file inside `learning-games` with your
-   `VITE_OPENAI_API_KEY=<your key>` for the Robot chat feature.
+   `VITE_OPENAI_API_KEY=<your key>` for the Robot chat and recipe features.
 4. Open the printed URL in your browser.
 
 Node **18+** is recommended. Major dependencies include React 19, React Router 7, Vite 6 and TypeScript. Toast notifications are provided by `react-hot-toast` and unit tests use `vitest`.
@@ -55,13 +58,13 @@ Without installing the packages first the `vitest` command used by
 `npm test` will not be available and the tests will fail.
 
 ## Environment Variables
-RobotChat uses the OpenAI API. Create a `.env` file inside `learning-games` containing:
+RobotChat and the Prompt Recipe Builder use the OpenAI API. Create a `.env` file inside `learning-games` containing:
 
 ```bash
 VITE_OPENAI_API_KEY=your-key
 ```
 
-Without this key, the RobotChat feature will not work.
+Without this key, the RobotChat and recipe features will not work.
 
 ## License
 This project is released under the [MIT License](LICENSE). Contributions are welcome under the same terms.

--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -196,6 +196,11 @@
   font-weight: bold;
 }
 
+.sample-output {
+  margin-top: 0.5rem;
+  font-weight: normal;
+}
+
 @media (max-width: 600px) {
   .recipe-wrapper {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- fetch recipe cards from OpenAI so every round has fresh text
- display a sample output for the assembled prompt
- style sample output and update docs

## Testing
- `npm install` within `learning-games`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684399a081ac832f98521ba6a7d4a3c6