### PR TITLE
Fix unused round variable and clarify build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Node **18+** is recommended. Major dependencies include React 19, React Router 7
 - `npm run lint` checks code style with ESLint.
 - `npm run test` runs the Vitest unit tests.
 - `npm run build` creates a production build in `dist/`.
+- Run `npm install` before `npm run build` if dependencies haven't been installed.
 
 ### Running Tests
 

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -22,8 +22,8 @@ export const ROUNDS: DartRound[] = [
   },
 ]
 
-export function checkChoice(_round: DartRound, choice: 'bad' | 'good') {
-  return choice === 'good'
+export function checkChoice(round: DartRound, choice: 'bad' | 'good') {
+  return round[choice] === round.good
 }
 
 export default function PromptDartsGame() {


### PR DESCRIPTION
## Summary
- reference each round when validating Prompt Darts choice
- note that `npm install` is required before `npm run build`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843a172d3dc832f9c07c2f4693d714d