### PR TITLE
Add CI workflow for build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI Build & Test
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: learning-games
+
+      - name: Run lint checks
+        run: npm run lint
+        working-directory: learning-games
+
+      - name: Run tests
+        run: npm test
+        working-directory: learning-games
+
+      - name: Build project
+        run: npm run build
+        working-directory: learning-games


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint, test and build on PRs and pushes to main and develop

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843ab299284832f828ed1a19f5fc4fe