### PR TITLE
Add donation link and improve Progress layout

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -299,6 +299,36 @@
   }
 }
 
+.top-scores-title {
+  margin-top: 1rem;
+}
+.top-scores-card {
+  background: var(--color-background);
+  padding: 0.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+.top-scores-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.top-scores-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0;
+  font-size: 0.9rem;
+}
+.top-scores-list li.top {
+  color: var(--color-brand);
+  font-weight: bold;
+}
+.view-leaderboard a {
+  text-decoration: underline;
+}
+.view-leaderboard a:hover {
+  color: var(--color-orange);
+}
 @media (max-width: 600px) {
   .match3-wrapper {
     grid-template-columns: 1fr;
@@ -689,50 +719,3 @@
   border-color: var(--color-mint);
 }
 
-@media (max-width: 600px) {
-  .menu-toggle {
-    display: block;
-  }
-  .navbar ul {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    left: 0;
-    flex-direction: column;
-    background: var(--color-purple);
-    padding: 1rem;
-    display: none;
-  }
-  .navbar ul.open {
-    display: flex;
-  }
-.top-scores-title {
-  margin-top: 1rem;
-}
-.top-scores-card {
-  background: var(--color-background);
-  padding: 0.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-.top-scores-list {
-  list-style: none;
-  padding-left: 0;
-  margin: 0;
-}
-.top-scores-list li {
-  display: flex;
-  justify-content: space-between;
-  padding: 0.25rem 0;
-  font-size: 0.9rem;
-}
-.top-scores-list li.top {
-  color: var(--color-brand);
-  font-weight: bold;
-}
-.view-leaderboard a {
-  text-decoration: underline;
-}
-.view-leaderboard a:hover {
-  color: var(--color-orange);
-}

--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -192,6 +192,21 @@
   background: #fbe4e9;
 }
 
+.buy-coffee {
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.buy-coffee a {
+  color: var(--color-brand);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.buy-coffee a:hover {
+  color: var(--color-deep-red);
+}
+
 .match3-sidebar {
   max-width: 240px;
   background: var(--color-background);
@@ -305,6 +320,10 @@
 
   .progress-sidebar {
     max-width: none;
+  }
+
+  .buy-coffee {
+    margin-top: 1rem;
   }
 
 }
@@ -687,10 +706,6 @@
   .navbar ul.open {
     display: flex;
   }
-}
-
-.top-scores-list{list-style:none;padding-left:0;margin:0;} .top-scores-list li{display:flex;justify-content:space-between;padding:0.25rem 0;font-size:0.9rem;} .top-scores-list li.top{color:#d4af37;font-weight:bold;} .view-leaderboard a{text-decoration:underline;} .view-leaderboard a:hover{color:var(--color-orange);} .top-scores-title{margin-top:1rem;}
-
 .top-scores-title {
   margin-top: 1rem;
 }

--- a/learning-games/src/pages/LeaderboardPage.css
+++ b/learning-games/src/pages/LeaderboardPage.css
@@ -42,5 +42,6 @@
 @media (max-width: 600px) {
   .leaderboard-card {
     font-size: 0.9rem;
+    padding: 0.75rem;
   }
 }

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -99,6 +99,15 @@ export default function LeaderboardPage() {
         <p style={{ marginTop: '2rem' }}>
           <Link to="/">Return Home</Link>
         </p>
+        <div className="buy-coffee">
+          <a
+            href="https://coff.ee/strawberrytech"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Did you like this content? Buy me a coffee as a thank you
+          </a>
+        </div>
       </div>
       <ProgressSidebar />
     </div>


### PR DESCRIPTION
## Summary
- add "Buy me a coffee" call to action on the progress/leaderboard page
- clean up leftover CSS and style the new link
- tweak leaderboard card for very small screens

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844422782e0832fb5f94900045c4492