### PR TITLE
Add label to ClarityEscapeRoom prompt input

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -25,6 +25,7 @@
 
 .prompt-form {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
 }

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -178,7 +178,9 @@ export default function ClarityEscapeRoom() {
           <DoorAnimation openPercent={openPercent} />
 
           <form onSubmit={handleSubmit} className="prompt-form">
+            <label htmlFor="prompt-input">Your prompt</label>
             <input
+              id="prompt-input"
               value={input}
               onChange={e => setInput(e.target.value.slice(0, 100))}
               placeholder="Type your prompt"

--- a/learning-games/src/pages/__tests__/ClarityEscapeRoom.test.tsx
+++ b/learning-games/src/pages/__tests__/ClarityEscapeRoom.test.tsx
@@ -24,8 +24,8 @@ afterEach(() => {
 
 describe('ClarityEscapeRoom', () => {
   it('increments openPercent and reveals next segment on valid prompt', () => {
-    const { getByPlaceholderText, getByText } = setup()
-    const input = getByPlaceholderText(/type your prompt/i)
+    const { getByLabelText, getByText } = setup()
+    const input = getByLabelText(/your prompt/i)
     fireEvent.change(input, { target: { value: 'rewrite formal' } })
     fireEvent.submit(input.closest('form')!)
     expect(getByText(/door 2/i)).toBeTruthy()
@@ -33,8 +33,8 @@ describe('ClarityEscapeRoom', () => {
   })
 
   it('limits input to 100 characters', () => {
-    const { getAllByPlaceholderText } = setup()
-    const input = getAllByPlaceholderText(/type your prompt/i)[0] as HTMLInputElement
+    const { getAllByLabelText } = setup()
+    const input = getAllByLabelText(/your prompt/i)[0] as HTMLInputElement
     const longText = 'a'.repeat(150)
     fireEvent.change(input, { target: { value: longText } })
     expect(input.value.length).toBeLessThanOrEqual(100)


### PR DESCRIPTION
## Summary
- label the prompt input in ClarityEscapeRoom
- center items in the prompt form for better alignment
- update tests to use label text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444243fe30832f9c1d9ed0d76341c6