### PR TITLE
Add leaderboard link to Escape Room completion

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useContext } from 'react'
+import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
@@ -138,6 +139,9 @@ export default function ClarityEscapeRoom() {
       <div className="escape-page">
         <InstructionBanner>You escaped the room!</InstructionBanner>
         <p>Your score: {score}</p>
+        <p style={{ marginTop: '1rem' }}>
+          <Link to="/leaderboard">Return to Progress</Link>
+        </p>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- show link to return to progress when escape room is finished

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68444244806c832f98a89ec798e700de