### PR TITLE
Improve prompt placeholder

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -181,7 +181,7 @@ export default function ClarityEscapeRoom() {
             <input
               value={input}
               onChange={e => setInput(e.target.value.slice(0, 100))}
-              placeholder="Type your prompt"
+              placeholder="e.g., 'Rewrite in a formal tone'"
             />
             <button type="submit" className="btn-primary">Submit</button>
             <button type="button" onClick={showHint} className="btn-primary">Hint</button>


### PR DESCRIPTION
## Summary
- show example in the text input placeholder so users know what to type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444245aa40832fb90fd532c599b051