### PR TITLE
Improve prompt builder UX

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -62,6 +62,16 @@
 .kitchen {
   background: url('https://images.unsplash.com/photo-1606851092836-944c99e60463?auto=format&fit=crop&w=800&q=60');
   background-size: cover;
+  animation: kitchenZoom 20s infinite alternate;
+}
+
+@keyframes kitchenZoom {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.05);
+  }
 }
 
 .recipe-game {
@@ -159,6 +169,10 @@
   box-shadow: 0 4px 6px rgba(0,0,0,0.15);
 }
 
+.card.selected {
+  outline: 2px solid var(--color-brand);
+}
+
 .status-bar {
   display: flex;
   justify-content: space-between;
@@ -199,6 +213,16 @@
 .sample-output {
   margin-top: 0.5rem;
   font-weight: normal;
+}
+
+.prompt-image {
+  margin-top: 0.5rem;
+  width: 100%;
+  border-radius: 6px;
+}
+
+.copy-btn {
+  margin-top: 0.5rem;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- animate kitchen backdrop
- add progress bar timer
- support keyboard play and card tooltips
- show confetti on perfect rounds
- allow copying final prompt and display an example image
- tweak styles for selected cards and new controls

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443f28bba8832fb12b8fbeb209c2d7