### PR TITLE
Fix Tone game layout on mobile

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -332,6 +332,7 @@
 @media (max-width: 600px) {
   .match3-wrapper {
     grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
   }
 
   .leaderboard-wrapper {
@@ -342,6 +343,7 @@
   .match3-container {
     max-width: none;
     grid-column: auto;
+    grid-row: auto;
   }
 
   .match3-sidebar {


### PR DESCRIPTION
## Summary
- adjust Match3Game CSS for mobile

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684446eab7f0832fb12dabfd5d40d919