### PR TITLE
Fix drag event type conflict

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -365,7 +365,7 @@ export default function PromptRecipeGame() {
                   draggable
                   tabIndex={0}
                   role="button"
-                  onDragStart={e => handleDragStart(e, card)}
+                  onDragStartCapture={e => handleDragStart(e, card)}
                   onKeyDown={e => handleCardKeyDown(e, card)}
                 >
                   {card.text}


### PR DESCRIPTION
## Summary
- ensure `onDragStart` uses the DOM drag event

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844482d3988832fa908f603b11bf738