### PR TITLE
Enhance escape room with generative AI check

### DIFF
--- a/docs/EscapeRoom-AI-ideas.md
+++ b/docs/EscapeRoom-AI-ideas.md
@@ -1,0 +1,14 @@
+# Generative Escape Room Concepts
+
+Below are ten ways generative AI can enhance the Clarity Escape Room experience:
+
+1. **Prompt Paraphrasing** – Accept different phrasings for the same intent using an AI scoring function.
+2. **Creative Suggestions** – Offer optional hints generated on demand when a player gets stuck.
+3. **Dynamic Storytelling** – Generate short scene descriptions after each door unlocks.
+4. **Adaptive Difficulty** – Rate player inputs and adjust timer lengths or required score.
+5. **Vocabulary Expansion** – Provide synonyms to encourage varied language in prompts.
+6. **Mini Lessons** – Summarize best practices after each successful door unlock.
+7. **AI Narrator** – Use a chat box to describe the room or provide flavor text.
+8. **Speech Input** – Transcribe voice commands and feed them to the AI evaluator.
+9. **Achievement Messages** – Generate personalized congratulations based on the player name.
+10. **End‑of‑Game Recap** – Summarize how well the player used clear prompts.

--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -114,3 +114,14 @@
 }
 .prompt-form input::placeholder { color: #999; }
 .score { font-weight: bold; color: var(--color-brand); margin-top: 0.5rem; }
+.escape-img {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+}
+
+.escape-video {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+}

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -365,7 +365,12 @@ export default function PromptRecipeGame() {
                   draggable
                   tabIndex={0}
                   role="button"
-                  onDragStart={e => handleDragStart(e, card)}
+                  onDragStart={(e: MouseEvent | TouchEvent | PointerEvent) =>
+                    handleDragStart(
+                      e as unknown as React.DragEvent<HTMLDivElement>,
+                      card,
+                    )
+                  }
                   onKeyDown={e => handleCardKeyDown(e, card)}
                 >
                   {card.text}

--- a/learning-games/src/pages/__tests__/ClarityEscapeRoom.test.tsx
+++ b/learning-games/src/pages/__tests__/ClarityEscapeRoom.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import ClarityEscapeRoom from '../ClarityEscapeRoom'
 import { UserProvider } from '../../context/UserProvider'
@@ -16,6 +16,9 @@ function setup() {
 
 beforeEach(() => {
   vi.spyOn(Math, 'random').mockReturnValue(0)
+  vi.spyOn(global, 'fetch').mockResolvedValue({
+    json: async () => ({ choices: [{ message: { content: 'yes' } }] }),
+  } as any)
 })
 
 afterEach(() => {
@@ -23,13 +26,13 @@ afterEach(() => {
 })
 
 describe('ClarityEscapeRoom', () => {
-  it('increments openPercent and reveals next segment on valid prompt', () => {
-    const { getByLabelText, getByText } = setup()
+  it('increments openPercent and reveals next segment on valid prompt', async () => {
+    const { getByLabelText, getByText, findByText } = setup()
     const input = getByLabelText(/your prompt/i)
-    fireEvent.change(input, { target: { value: 'rewrite formal' } })
+    fireEvent.change(input, { target: { value: 'any text' } })
     fireEvent.submit(input.closest('form')!)
-    expect(getByText(/door 2/i)).toBeTruthy()
-    expect(getByText(/The door unlocks with a click/i)).toBeTruthy()
+    await waitFor(() => expect(getByText(/door 2/i)).toBeTruthy())
+    expect(await findByText(/The door unlocks with a click/i)).toBeTruthy()
   })
 
   it('limits input to 100 characters', () => {


### PR DESCRIPTION
## Summary
- add AI-powered evaluation to ClarityEscapeRoom
- expand tasks with 10 everyday scenarios
- show hints when requested and add media assets
- document generative AI ideas for the escape room
- adjust unit test with fetch mocking

## Testing
- `npx tsc --noEmit` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844493df854832f8a9592c365794708