### PR TITLE
Refine escape room layout

### DIFF
--- a/learning-games/src/components/DoorAnimation.css
+++ b/learning-games/src/components/DoorAnimation.css
@@ -1,6 +1,7 @@
 .door-container {
   position: relative;
-  width: 150px;
+  width: 100%;
+  max-width: 150px;
   height: 200px;
   margin: 0 auto 1rem;
   background: #111;

--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -18,6 +18,24 @@
   border-radius: 10px;
 }
 
+.room-grid {
+  display: grid;
+  grid-template-columns: 1fr 160px;
+  gap: 1rem;
+  align-items: start;
+}
+
+.room-main {
+  display: flex;
+  flex-direction: column;
+}
+
+.door-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .hint {
   font-style: italic;
   margin-bottom: 0.5rem;
@@ -108,6 +126,9 @@
       'progress'
       'next';
   }
+  .room-grid {
+    grid-template-columns: 1fr;
+  }
   .progress-sidebar {
     max-width: none;
   }
@@ -122,6 +143,7 @@
 
 .escape-video {
   width: 100%;
+  height: auto;
   border-radius: 8px;
   margin-bottom: 0.5rem;
 }

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -230,6 +230,8 @@ export default function ClarityEscapeRoom() {
           <p className="sidebar-tip">Shows how specificity opens doors—literally. Teaching players to apply intent, tone, and task format.</p>
         </aside>
         <div className="room">
+          <div className="room-grid">
+            <div className="room-main">
           <InstructionBanner>
             <p>Enter a precise prompt to unlock each door.</p>
             <ol>
@@ -256,14 +258,6 @@ export default function ClarityEscapeRoom() {
             ))}
           </p>
 
-          <DoorAnimation openPercent={openPercent} />
-          <video
-            className="escape-video"
-            autoPlay
-            loop
-            muted
-            src="https://www.w3schools.com/html/mov_bbb.mp4"
-          />
 
           <form onSubmit={handleSubmit} className="prompt-form">
             <label htmlFor="prompt-input">Your prompt</label>
@@ -282,6 +276,18 @@ export default function ClarityEscapeRoom() {
           )}
           {message && <p className="feedback">{message}</p>}
           <p className="score">Score: {score}</p>
+            </div>
+            <div className="door-area">
+              <DoorAnimation openPercent={openPercent} />
+              <video
+                className="escape-video"
+                autoPlay
+                loop
+                muted
+                src="https://www.w3schools.com/html/mov_bbb.mp4"
+              />
+            </div>
+          </div>
         </div>
         <ProgressSidebar />
         <div className="next-area" />


### PR DESCRIPTION
## Summary
- place escape room content in a grid with a side door
- add responsive styles for smaller screens
- shrink door animation component to fit its column

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68444c8300d8832f9bcd8256823e0c91