### PR TITLE
Fix mobile layout stacking in tone game

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -143,8 +143,7 @@
   background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
   padding: 1rem;
   border-radius: 8px;
-  grid-column: 2;
-  grid-row: 1;
+  grid-area: game;
 }
 
 .match3-page {
@@ -160,6 +159,7 @@
   gap: 1rem;
   justify-content: center;
   align-items: start;
+  grid-template-areas: 'sidebar game';
 }
 
 .leaderboard-wrapper {
@@ -215,8 +215,7 @@
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   text-align: left;
-  grid-column: 1;
-  grid-row: 1;
+  grid-area: sidebar;
 }
 
 
@@ -333,6 +332,9 @@
   .match3-wrapper {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto;
+    grid-template-areas:
+      'sidebar'
+      'game';
   }
 
   .leaderboard-wrapper {
@@ -342,8 +344,6 @@
   .match3-sidebar,
   .match3-container {
     max-width: none;
-    grid-column: auto;
-    grid-row: auto;
   }
 
   .match3-sidebar {


### PR DESCRIPTION
## Summary
- ensure tone game stacks Why Tone Matters above game on small screens
- use CSS grid areas for reliable column order

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68445402eb28832f9e4d93560d512f02