### PR TITLE
Fix small-screen layout on Escape Room page

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -141,9 +141,21 @@
   margin-bottom: 0.5rem;
 }
 
-.escape-video {
-  width: 100%;
-  height: auto;
-  border-radius: 8px;
-  margin-bottom: 0.5rem;
+@media (max-width: 360px) {
+  .prompt-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .prompt-form input {
+    width: 100%;
+  }
+
+  .prompt-form button {
+    width: 100%;
+  }
+
+  .escape-sidebar {
+    max-width: none;
+  }
 }

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -279,13 +279,6 @@ export default function ClarityEscapeRoom() {
             </div>
             <div className="door-area">
               <DoorAnimation openPercent={openPercent} />
-              <video
-                className="escape-video"
-                autoPlay
-                loop
-                muted
-                src="https://www.w3schools.com/html/mov_bbb.mp4"
-              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the autoplaying video from the Escape Room page
- adjust layout styling for very small screens so the input and buttons stack
- ensure the sidebar can shrink on tiny screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844544f4538832f8d556805ba0f07e4