### PR TITLE
Add diverse rounds to Prompt Darts

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -20,6 +20,50 @@ export const ROUNDS: DartRound[] = [
     bad: 'Explain climate change.',
     good: 'Summarize 2 key causes of climate change in one paragraph.',
   },
+  {
+    bad: 'Translate this paragraph.',
+    good: 'Translate the following paragraph from English to Spanish, keeping technical terms.',
+  },
+  {
+    bad: 'Write code.',
+    good: 'Generate a Python function that returns the factorial of a number.',
+  },
+  {
+    bad: 'How do I sell my product?',
+    good: 'Give 5 social media marketing ideas for a new eco-friendly water bottle.',
+  },
+  {
+    bad: 'Summarize this article about remote work.',
+    good: 'Provide a 2-sentence summary of an article on remote work trends.',
+  },
+  {
+    bad: 'Give ideas for a birthday party.',
+    good: 'List 4 affordable birthday party themes for a 10-year-old.',
+  },
+  {
+    bad: 'How do I bake a cake?',
+    good: 'Outline 5 steps to bake a basic vanilla cake.',
+  },
+  {
+    bad: 'Describe our new phone.',
+    good: 'Write a short product description highlighting 3 features of our new smartphone.',
+  },
+  {
+    bad: 'How is the market doing?',
+    good: 'Summarize key trends in the 2023 smartphone market in 3 bullet points.',
+  },
+  {
+    bad: 'Talk to me about support.',
+    good: 'Simulate a brief chat between a customer and support about resetting a password.',
+  },
+  {
+    bad: 'Tell a story.',
+    good: 'Write a 3-sentence short story about a robot discovering music.',
+  },
+  {
+    bad: 'Make a logo.',
+    good: 'Provide a text description of a logo idea for a coffee shop named Bean Buzz.',
+  },
 ]
 
 export function checkChoice(_round: DartRound, choice: 'bad' | 'good') {


### PR DESCRIPTION
## Summary
- extend Prompt Darts game with many new rounds covering translation, code generation, marketing, summarization, and more

## Testing
- `npm install` in `learning-games`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684457005170832f89987d28f252d856