### PR TITLE
Add categories to game rounds

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -58,6 +58,11 @@
   margin-bottom: 0.5rem;
 }
 
+.round-category {
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}
+
 .final-score {
   font-size: 1.2rem;
   font-weight: bold;

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -8,15 +8,22 @@ import './PromptDartsGame.css'
 export interface DartRound {
   bad: string
   good: string
+  category: string
 }
 
 export const ROUNDS: DartRound[] = [
-  { bad: 'Tell me about AI.', good: 'List 3 use cases of AI in customer service.' },
   {
+    category: 'AI',
+    bad: 'Tell me about AI.',
+    good: 'List 3 use cases of AI in customer service.',
+  },
+  {
+    category: 'Email',
     bad: 'Write an email.',
     good: 'Draft a 3-sentence email to a hiring manager explaining your interest.',
   },
   {
+    category: 'Environment',
     bad: 'Explain climate change.',
     good: 'Summarize 2 key causes of climate change in one paragraph.',
   },
@@ -76,6 +83,7 @@ export default function PromptDartsGame() {
         </aside>
         <div className="darts-game">
           <h3>Round {round + 1} of {ROUNDS.length}</h3>
+          <p className="round-category">{current.category}</p>
           <p>Which prompt is clearer?</p>
           <div className="options">
             <button className="btn-primary" onClick={() => handleSelect('bad')} disabled={choice !== null}>{current.bad}</button>

--- a/learning-games/src/pages/QuizGame.css
+++ b/learning-games/src/pages/QuizGame.css
@@ -89,6 +89,11 @@
   margin-bottom: 0.5rem;
 }
 
+.round-category {
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}
+
 .header-instruction {
   margin-bottom: 0.25rem;
 }

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -10,6 +10,7 @@ import InstructionBanner from '../components/ui/InstructionBanner'
 interface StatementSet {
   statements: string[]
   lieIndex: number
+  category?: string
 }
 
 async function generateStatementSet(): Promise<StatementSet | null> {
@@ -54,6 +55,7 @@ async function generateStatementSet(): Promise<StatementSet | null> {
 
 const ROUNDS: StatementSet[] = [
   {
+    category: 'Science',
     statements: [
       'Bananas are berries.',
       'Venus is hotter than Mercury.',
@@ -62,6 +64,7 @@ const ROUNDS: StatementSet[] = [
     lieIndex: 2,
   },
   {
+    category: 'World Facts',
     statements: [
       'Adult humans have 206 bones.',
       'The Amazon River is the longest river in the world.',
@@ -70,6 +73,7 @@ const ROUNDS: StatementSet[] = [
     lieIndex: 1,
   },
   {
+    category: 'Human Body',
     statements: [
       'Honey never spoils.',
       'Mount Everest is the highest mountain above sea level.',
@@ -265,6 +269,9 @@ export default function QuizGame() {
             Pick the hallucination from the three statements.
           </p>
           <p className="round-info">Round {round + 1} / {ROUNDS.length}</p>
+          {current.category && (
+            <p className="round-category">{current.category}</p>
+          )}
           <ul className="statement-list">
             {current.statements.map((s, i) => (
               <li key={i}>


### PR DESCRIPTION
## Summary
- add `category` field to each `ROUNDS` object for Prompt Darts and Quiz games
- show the current round category in the UI
- style new `round-category` text

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445703f004832fa099018ab0d1608a