### PR TITLE
Add canned responses after choosing prompts

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -58,6 +58,15 @@
   margin-bottom: 0.5rem;
 }
 
+.canned-response {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 0.5rem;
+  border-left: 4px solid var(--color-brand);
+  margin-bottom: 0.5rem;
+  white-space: pre-wrap;
+}
+
 .final-score {
   font-size: 1.2rem;
   font-weight: bold;

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -8,17 +8,27 @@ import './PromptDartsGame.css'
 export interface DartRound {
   bad: string
   good: string
+  response: string
 }
 
 export const ROUNDS: DartRound[] = [
-  { bad: 'Tell me about AI.', good: 'List 3 use cases of AI in customer service.' },
+  {
+    bad: 'Tell me about AI.',
+    good: 'List 3 use cases of AI in customer service.',
+    response:
+      'Chatbots for FAQs, automated ticket triage, and personalized recommendations.',
+  },
   {
     bad: 'Write an email.',
     good: 'Draft a 3-sentence email to a hiring manager explaining your interest.',
+    response:
+      'Dear Hiring Manager, I am excited about the role and believe my skills fit well. I look forward to contributing to the team. Thank you for your consideration.',
   },
   {
     bad: 'Explain climate change.',
     good: 'Summarize 2 key causes of climate change in one paragraph.',
+    response:
+      'Burning fossil fuels releases greenhouse gases, while deforestation reduces carbon absorption—both drive rising temperatures.',
   },
 ]
 
@@ -82,9 +92,14 @@ export default function PromptDartsGame() {
             <button className="btn-primary" onClick={() => handleSelect('good')} disabled={choice !== null}>{current.good}</button>
           </div>
           {choice !== null && (
-            <p className="feedback">
-              {checkChoice(current, choice) ? 'Correct! Clear prompts hit the bullseye.' : 'Not quite. Aim for specific wording.'}
-            </p>
+            <>
+              <p className="feedback">
+                {checkChoice(current, choice)
+                  ? 'Correct! Clear prompts hit the bullseye.'
+                  : 'Not quite. Aim for specific wording.'}
+              </p>
+              <pre className="canned-response">{current.response}</pre>
+            </>
           )}
         </div>
         <ProgressSidebar />

--- a/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
+++ b/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
@@ -7,4 +7,11 @@ describe('checkChoice', () => {
     expect(checkChoice(round, 'good')).toBe(true)
     expect(checkChoice(round, 'bad')).toBe(false)
   })
+
+  it('each round provides a canned response', () => {
+    for (const round of ROUNDS) {
+      expect(round.response).toBeDefined()
+      expect(typeof round.response).toBe('string')
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- enhance Prompt Darts rounds with canned responses
- show canned response once a choice is made
- style canned response block
- test for presence of canned responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445704f608832fb6bc0e2af44952c0