### PR TITLE
Add darts leaderboard support

### DIFF
--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -25,7 +25,7 @@ export default function ProgressSidebar() {
       fetch(`${base}/api/scores`)
         .then((res) => (res.ok ? res.json() : {}))
         .then((data: Record<string, ScoreEntry[]>) => {
-          setScores(Array.isArray(data.tone) ? data.tone : [])
+          setScores(Array.isArray(data.darts) ? data.darts : [])
         })
         .catch(() => {})
     }

--- a/server/index.js
+++ b/server/index.js
@@ -18,10 +18,10 @@ function loadData() {
     return JSON.parse(fs.readFileSync(DB_FILE, 'utf8'));
   } catch {
     return {
-      user: { name: null, age: null, badges: [], scores: {} },
+      user: { name: null, age: null, badges: [], scores: { darts: 0 } },
       posts: [],
       views: [],
-      scores: {},
+      scores: { darts: [] },
       sessions: [],
     };
   }
@@ -33,10 +33,12 @@ function saveData(data) {
 
 let data = loadData();
 if (!data.views) data.views = [];
-if (!data.scores) data.scores = {};
-if (!data.user) data.user = { name: null, age: null, badges: [], scores: {} };
+if (!data.scores) data.scores = { darts: [] };
+if (!data.scores.darts) data.scores.darts = [];
+if (!data.user) data.user = { name: null, age: null, badges: [], scores: { darts: 0 } };
 if (!data.user.badges) data.user.badges = [];
-if (!data.user.scores) data.user.scores = {};
+if (!data.user.scores) data.user.scores = { darts: 0 };
+if (data.user.scores.darts === undefined) data.user.scores.darts = 0;
 if (!data.sessions) data.sessions = [];
 
 app.get('/api/user', (req, res) => {


### PR DESCRIPTION
## Summary
- track darts scores in `server/index.js`
- display darts leaderboard in `ProgressSidebar`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68445706e940832fb5a85d09da404767