### PR TITLE
Add difficulty selection and adjust gameplay

### DIFF
--- a/learning-games/src/context/UserContext.ts
+++ b/learning-games/src/context/UserContext.ts
@@ -4,6 +4,7 @@ import type { UserData, UserContextType } from '../types/user'
 export const defaultUser: UserData = {
   name: null,
   age: null,
+  difficulty: 'medium',
   scores: {},
   badges: [],
 }
@@ -15,4 +16,5 @@ export const UserContext = createContext<UserContextType>({
   setName: () => {},
   setScore: () => {},
   addBadge: () => {},
+  setDifficulty: () => {},
 })

--- a/learning-games/src/context/UserProvider.tsx
+++ b/learning-games/src/context/UserProvider.tsx
@@ -47,6 +47,10 @@ export function UserProvider({ children }: { children: ReactNode }) {
     setUser((prev) => ({ ...prev, name }))
   }, [])
 
+  const setDifficulty = useCallback((level: 'easy' | 'medium' | 'hard') => {
+    setUser(prev => ({ ...prev, difficulty: level }))
+  }, [])
+
   // Record the best score for a specific game
   const setScore = useCallback(
     (game: string, score: number) => {
@@ -102,6 +106,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
             age: user.age,
             badges: user.badges,
             scores: user.scores,
+            difficulty: user.difficulty,
           }),
         }).catch((err) => console.error('Failed to save user', err))
       }
@@ -111,7 +116,15 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
   return (
     <UserContext.Provider
-      value={{ user, setUser, setAge, setName, setScore, addBadge }}
+      value={{
+        user,
+        setUser,
+        setAge,
+        setName,
+        setScore,
+        addBadge,
+        setDifficulty,
+      }}
     >
       {children}
     </UserContext.Provider>

--- a/learning-games/src/pages/AgeInputForm.tsx
+++ b/learning-games/src/pages/AgeInputForm.tsx
@@ -15,9 +15,10 @@ export default function AgeInputForm({
   onSaved?: () => void
   allowEdit?: boolean
 }) {
-  const { user, setAge, setName } = useContext(UserContext)
+  const { user, setAge, setName, setDifficulty } = useContext(UserContext)
   const [age, setAgeState] = useState<number | ''>(user.age ?? '')
   const [name, setNameState] = useState(user.name ?? '')
+  const [difficulty, setDifficultyState] = useState(user.difficulty)
   const navigate = useNavigate()
 
   // If age already exists and editing isn't allowed, redirect away
@@ -31,6 +32,7 @@ export default function AgeInputForm({
     if (!Number.isNaN(ageNumber) && ageNumber > 0) {
       setAge(ageNumber)
       if (name) setName(name)
+      setDifficulty(difficulty)
       if (onSaved) {
         onSaved()
       } else {
@@ -63,6 +65,16 @@ export default function AgeInputForm({
           }}
           required
         />
+        <label htmlFor="difficulty">Difficulty:</label>
+        <select
+          id="difficulty"
+          value={difficulty}
+          onChange={e => setDifficultyState(e.target.value as 'easy' | 'medium' | 'hard')}
+        >
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
         <button type="submit" className="btn-primary">Save</button>
       </form>
       <p style={{ marginTop: '1rem' }}>

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -106,13 +106,15 @@ async function evaluatePrompt(task: Task, inputText: string): Promise<boolean> {
 
 export default function ClarityEscapeRoom() {
   const { setScore, addBadge, user } = useContext(UserContext)
+  const BASE_TIME =
+    user.difficulty === 'easy' ? 45 : user.difficulty === 'hard' ? 20 : 30
   const [door, setDoor] = useState(0)
   const [tasks] = useState<Task[]>(() => shuffle(TASKS))
   const [input, setInput] = useState('')
   const [score, setScoreState] = useState(0)
   const [message, setMessage] = useState('')
   const [start] = useState(() => Date.now())
-  const [timeLeft, setTimeLeft] = useState(30)
+  const [timeLeft, setTimeLeft] = useState(BASE_TIME)
   const [openPercent, setOpenPercent] = useState(0)
   const [hintVisible, setHintVisible] = useState(false)
 
@@ -161,7 +163,7 @@ export default function ClarityEscapeRoom() {
   }
 
   useEffect(() => {
-    setTimeLeft(30)
+    setTimeLeft(BASE_TIME)
     const id = setInterval(() => {
       setTimeLeft(t => {
         if (t <= 1) {
@@ -169,7 +171,7 @@ export default function ClarityEscapeRoom() {
           setMessage('Too slow! The door remains locked.')
           setInput('')
           setHintVisible(false)
-          return 30
+          return BASE_TIME
         }
         return t - 1
       })

--- a/learning-games/src/pages/ProfilePage.tsx
+++ b/learning-games/src/pages/ProfilePage.tsx
@@ -5,9 +5,10 @@ import { UserContext } from '../context/UserContext'
 import './ProfilePage.css'
 
 export default function ProfilePage() {
-  const { user, setName, setAge } = useContext(UserContext)
+  const { user, setName, setAge, setDifficulty } = useContext(UserContext)
   const [name, setNameState] = useState(user.name ?? '')
   const [age, setAgeState] = useState<string>(user.age ? String(user.age) : '')
+  const [difficulty, setDifficultyState] = useState(user.difficulty)
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -22,6 +23,7 @@ export default function ProfilePage() {
     }
     setName(name.trim())
     setAge(ageNum)
+    setDifficulty(difficulty)
     toast.success('Profile saved successfully!')
   }
 
@@ -43,6 +45,16 @@ export default function ProfilePage() {
           value={age}
           onChange={(e) => setAgeState(e.target.value)}
         />
+        <label htmlFor="difficulty">Difficulty</label>
+        <select
+          id="difficulty"
+          value={difficulty}
+          onChange={e => setDifficultyState(e.target.value as 'easy' | 'medium' | 'hard')}
+        >
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
         <button type="submit">Save</button>
         <Link to="/leaderboard" className="return-link">
           Return to Progress

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -117,9 +117,11 @@ async function generateCards(): Promise<Card[]> {
 }
 
 export default function PromptRecipeGame() {
-  const TOTAL_TIME = 30
-
   const { setScore, addBadge, user } = useContext(UserContext)
+  const TOTAL_TIME =
+    user.difficulty === 'easy' ? 45 : user.difficulty === 'hard' ? 20 : 30
+  const SCORE_MULT =
+    user.difficulty === 'easy' ? 1 : user.difficulty === 'hard' ? 2 : 1.5
   const [cards, setCards] = useState<Card[]>([])
   const [roundCards, setRoundCards] = useState<Card[]>([])
   const [dropped, setDropped] = useState<Dropped>({
@@ -190,7 +192,8 @@ export default function PromptRecipeGame() {
   useEffect(() => {
     if (Object.values(dropped).every(Boolean)) {
       const { score: gained, perfect } = evaluateRecipe(dropped, roundCards)
-      const finalScore = gained + Math.floor(timeLeft / 5)
+      const baseScore = gained + Math.floor(timeLeft / 5)
+      const finalScore = Math.round(baseScore * SCORE_MULT)
       setScoreState(s => s + finalScore)
       if (perfect) {
         confetti({ particleCount: 70, spread: 60, origin: { y: 0.7 } })

--- a/learning-games/src/types/user.ts
+++ b/learning-games/src/types/user.ts
@@ -2,6 +2,8 @@ export interface UserData {
   /** User's name for personalized greetings */
   name: string | null
   age: number | null
+  /** Player selected difficulty level */
+  difficulty: 'easy' | 'medium' | 'hard'
   scores: Record<string, number>
   badges: string[]
 }
@@ -27,4 +29,8 @@ export interface UserContextType {
    * Award a badge when the player reaches a milestone.
    */
   addBadge: (badge: string) => void
+  /**
+   * Update the difficulty setting for all games.
+   */
+  setDifficulty: (level: 'easy' | 'medium' | 'hard') => void
 }


### PR DESCRIPTION
## Summary
- add difficulty field to user data and context
- include difficulty selectors on the age form and profile page
- tweak recipe and escape room games to use difficulty for time/score

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684457089cbc832fa8d7ae0c21d88027