### PR TITLE
Add timer scoring to Prompt Darts

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react'
+import { useState, useContext, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
@@ -31,12 +31,30 @@ export default function PromptDartsGame() {
   const [round, setRound] = useState(0)
   const [choice, setChoice] = useState<'bad' | 'good' | null>(null)
   const [score, setScoreState] = useState(0)
+  const TOTAL_TIME = 15
+  const MAX_POINTS = 10
+  const [timeLeft, setTimeLeft] = useState(TOTAL_TIME)
+  const [pointsLeft, setPointsLeft] = useState(MAX_POINTS)
   const current = ROUNDS[round]
+
+  useEffect(() => {
+    setTimeLeft(TOTAL_TIME)
+    setPointsLeft(MAX_POINTS)
+  }, [round])
+
+  useEffect(() => {
+    if (choice !== null || timeLeft <= 0) return
+    const id = setTimeout(() => {
+      setTimeLeft(t => t - 1)
+      setPointsLeft(p => Math.max(0, p - 1))
+    }, 1000)
+    return () => clearTimeout(id)
+  }, [timeLeft, choice])
 
   function handleSelect(option: 'bad' | 'good') {
     setChoice(option)
     if (checkChoice(current, option)) {
-      setScoreState(s => s + 10)
+      setScoreState(s => s + pointsLeft)
     }
   }
 
@@ -44,6 +62,8 @@ export default function PromptDartsGame() {
     if (round + 1 < ROUNDS.length) {
       setRound(r => r + 1)
       setChoice(null)
+      setTimeLeft(TOTAL_TIME)
+      setPointsLeft(MAX_POINTS)
     } else {
       setScore('darts', score)
       setRound(r => r + 1)
@@ -76,6 +96,8 @@ export default function PromptDartsGame() {
         </aside>
         <div className="darts-game">
           <h3>Round {round + 1} of {ROUNDS.length}</h3>
+          <p className="timer">Time: {timeLeft}s</p>
+          <p className="points">Available points: {pointsLeft}</p>
           <p>Which prompt is clearer?</p>
           <div className="options">
             <button className="btn-primary" onClick={() => handleSelect('bad')} disabled={choice !== null}>{current.bad}</button>
@@ -83,8 +105,13 @@ export default function PromptDartsGame() {
           </div>
           {choice !== null && (
             <p className="feedback">
-              {checkChoice(current, choice) ? 'Correct! Clear prompts hit the bullseye.' : 'Not quite. Aim for specific wording.'}
+              {checkChoice(current, choice)
+                ? 'Correct! Clear prompts hit the bullseye.'
+                : 'Not quite. Aim for specific wording.'}
             </p>
+          )}
+          {timeLeft === 0 && choice === null && (
+            <p className="feedback">Time’s up! No points this round.</p>
           )}
         </div>
         <ProgressSidebar />


### PR DESCRIPTION
## Summary
- add timer logic and points decay to PromptDartsGame
- display remaining time and available points during rounds
- show message when time expires

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844570e60c4832fb96ad85ec3175967