### PR TITLE
Add community playlist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
 - A unified leaderboard with tabs displays top scores for every game.
 - A dedicated Badges page lets you track all achievements.
 - A hidden `/stats` page displays live visitor analytics collected on the server.
+- A community playlist page lets everyone share bad and good prompt pairs.
 
 ## Getting Started
 1. Install dependencies and start the dev server:

--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -11,6 +11,7 @@ import ClarityEscapeRoom from './pages/ClarityEscapeRoom'
 
 import LeaderboardPage from './pages/LeaderboardPage'
 import CommunityPage from './pages/CommunityPage'
+import CommunityPlaylistPage from './pages/CommunityPlaylistPage'
 import ProfilePage from './pages/ProfilePage'
 import HelpPage from './pages/HelpPage'
 import PrivacyPage from './pages/PrivacyPage'
@@ -43,6 +44,7 @@ function App() {
         <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/badges" element={<BadgesPage />} />
         <Route path="/community" element={<CommunityPage />} />
+        <Route path="/playlist" element={<CommunityPlaylistPage />} />
         <Route path="/help" element={<HelpPage />} />
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -72,6 +72,11 @@ export default function NavBar() {
         </li>
         <li>
           <Tooltip message="Hover here for a surprise!">
+            <Link to="/playlist">Playlist</Link>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
             <Link to="/help">Help</Link>
           </Tooltip>
         </li>

--- a/learning-games/src/pages/CommunityPlaylistPage.tsx
+++ b/learning-games/src/pages/CommunityPlaylistPage.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+export interface PromptPair {
+  id: number
+  bad: string
+  good: string
+}
+
+const STORAGE_KEY = 'prompt_pairs'
+
+export default function CommunityPlaylistPage() {
+  const [pairs, setPairs] = useState<PromptPair[]>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      try {
+        return JSON.parse(saved) as PromptPair[]
+      } catch {
+        return []
+      }
+    }
+    return []
+  })
+  const [bad, setBad] = useState('')
+  const [good, setGood] = useState('')
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const base = window.location.origin
+      fetch(`${base}/api/pairs`)
+        .then(res => (res.ok ? res.json() : []))
+        .then((data: PromptPair[]) => data.length && setPairs(data))
+        .catch(() => {})
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(pairs))
+  }, [pairs])
+
+  function addPair(e: React.FormEvent) {
+    e.preventDefault()
+    if (!bad.trim() || !good.trim()) return
+    const pair: PromptPair = { id: Date.now(), bad: bad.trim(), good: good.trim() }
+    setPairs(prev => [...prev, pair])
+    if (typeof window !== 'undefined') {
+      const base = window.location.origin
+      fetch(`${base}/api/pairs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(pair),
+      }).catch(() => {})
+    }
+    setBad('')
+    setGood('')
+  }
+
+  return (
+    <div className="playlist-page">
+      <h2>Community Playlist</h2>
+      <form onSubmit={addPair} style={{ marginBottom: '1rem' }}>
+        <label htmlFor="bad">Bad prompt:</label>
+        <textarea
+          id="bad"
+          value={bad}
+          onChange={e => setBad(e.target.value)}
+          required
+          style={{ display: 'block', width: '100%', marginBottom: '0.5rem' }}
+        />
+        <label htmlFor="good">Good prompt:</label>
+        <textarea
+          id="good"
+          value={good}
+          onChange={e => setGood(e.target.value)}
+          required
+          style={{ display: 'block', width: '100%', marginBottom: '0.5rem' }}
+        />
+        <button type="submit" className="btn-primary">
+          Save Pair
+        </button>
+      </form>
+      <ul style={{ paddingLeft: 0, listStyle: 'none' }}>
+        {pairs
+          .slice()
+          .reverse()
+          .map(p => (
+            <li key={p.id} style={{ marginBottom: '1rem' }}>
+              <strong>Bad:</strong> {p.bad}
+              <br />
+              <strong>Good:</strong> {p.good}
+            </li>
+          ))}
+      </ul>
+      <p style={{ marginTop: '2rem' }}>
+        <Link to="/">Return Home</Link>
+      </p>
+    </div>
+  )
+}

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -60,6 +60,14 @@ export default function Home() {
         >
           Community
         </button>
+        <button
+          onClick={() => navigate('/playlist')}
+          className="btn-primary"
+          style={{ marginLeft: '1rem' }}
+          aria-label="See prompt playlist"
+        >
+          Playlist
+        </button>
       </section>
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,7 @@ function loadData() {
       views: [],
       scores: {},
       sessions: [],
+      promptPairs: [],
     };
   }
 }
@@ -38,6 +39,7 @@ if (!data.user) data.user = { name: null, age: null, badges: [], scores: {} };
 if (!data.user.badges) data.user.badges = [];
 if (!data.user.scores) data.user.scores = {};
 if (!data.sessions) data.sessions = [];
+if (!data.promptPairs) data.promptPairs = [];
 
 app.get('/api/user', (req, res) => {
   res.json(data.user);
@@ -80,6 +82,21 @@ app.post('/api/posts/:id/flag', (req, res) => {
   } else {
     res.status(404).end();
   }
+});
+
+app.get('/api/pairs', (req, res) => {
+  res.json(data.promptPairs);
+});
+
+app.post('/api/pairs', (req, res) => {
+  const pair = {
+    id: Date.now(),
+    bad: req.body.bad || '',
+    good: req.body.good || '',
+  };
+  data.promptPairs.push(pair);
+  saveData(data);
+  res.status(201).json(pair);
 });
 
 app.get('/api/views', (req, res) => {


### PR DESCRIPTION
## Summary
- add API endpoints and storage for prompt pairs
- create `CommunityPlaylistPage` and new route
- add playlist link in navigation and homepage
- document the new community playlist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684457116a5c832fa288e899e405d1c9