### PR TITLE
Improve badge sharing

### DIFF
--- a/learning-games/src/data/badges.ts
+++ b/learning-games/src/data/badges.ts
@@ -2,6 +2,8 @@ export interface BadgeDefinition {
   id: string
   name: string
   description: string
+  /** Small emoji representing the badge when sharing */
+  emoji: string
 }
 
 /** List of all possible badges and their criteria descriptions. */
@@ -10,32 +12,38 @@ export const BADGES: BadgeDefinition[] = [
     id: 'first-match3',
     name: 'First Tone Game Complete',
     description: 'Finish a Tone game once',
+    emoji: '🥇',
   },
   {
     id: 'match-master',
     name: 'Tone Master',
     description: 'Score at least 100 points in Tone',
+    emoji: '🏆',
   },
   {
     id: 'quiz-whiz',
     name: 'Quiz Whiz',
     description: 'Get a perfect score on any quiz',
+    emoji: '🤓',
   },
   {
     id: 'tone-whiz',
     name: 'Tone Tactician',
     description: 'Matched every tone correctly in the mini-game',
+    emoji: '🎯',
   },
   {
 
     id: 'escape-artist',
     name: 'Escape Artist of Clarity',
     description: 'Exit all 5 rooms under 3 minutes',
+    emoji: '🚪',
   },
   {
 
     id: 'prompt-chef',
     name: 'Master Chef of Prompts',
     description: 'Create 10 flawless prompt recipes',
+    emoji: '👩‍🍳',
   },
 ]

--- a/learning-games/src/pages/BadgesPage.css
+++ b/learning-games/src/pages/BadgesPage.css
@@ -15,9 +15,16 @@
   border-radius: 8px;
   padding: 0.5rem 1rem;
   margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
 }
 
 .badge-list li.earned {
   border-color: #ee3a57;
   background: #fff5f7;
+}
+
+.badge-list li .emoji {
+  margin-right: 0.5rem;
+  font-size: 1.5rem;
 }

--- a/learning-games/src/pages/BadgesPage.tsx
+++ b/learning-games/src/pages/BadgesPage.tsx
@@ -12,6 +12,9 @@ export default function BadgesPage() {
       <ul className="badge-list">
         {BADGES.map(b => (
           <li key={b.id} className={user.badges.includes(b.id) ? 'earned' : ''}>
+            <span className="emoji" role="img" aria-label={b.name}>
+              {b.emoji}
+            </span>
             <strong>{b.name}</strong>
             <p>{b.description}</p>
           </li>
@@ -21,8 +24,15 @@ export default function BadgesPage() {
         <button
           type="button"
           onClick={() => {
-            const earned = user.badges.join(', ') || 'none'
-            const text = `I have earned these badges on StrawberryTech: ${earned}`
+            const earnedList = user.badges
+              .map(id => {
+                const badge = BADGES.find(b => b.id === id)
+                return badge ? `${badge.emoji} ${badge.name}` : id
+              })
+              .join(', ')
+            const text = earnedList
+              ? `Check out my StrawberryTech badges: ${earnedList}! Try the games at https://strawberry-tech.vercel.app/`
+              : `I'm playing StrawberryTech! Earn badges at https://strawberry-tech.vercel.app/`
             if (navigator.share) {
               navigator.share({ text }).catch(() => {})
             } else {


### PR DESCRIPTION
## Summary
- add emoji metadata to badges
- display emoji icons on Badges page
- share badge names with emoji and app link

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684458037028832f8bc116c17ddd8b07