### PR TITLE
Improve prompt builder rounds and footer

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -553,6 +553,26 @@
   text-decoration: underline;
 }
 
+.coffee-link {
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  animation: coffee-pulse 2s ease-in-out infinite;
+}
+
+.coffee-link:hover {
+  color: var(--color-lime);
+}
+
+@keyframes coffee-pulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+}
+
 @media (max-width: 480px) {
   .footer-links {
     flex-direction: column;

--- a/learning-games/src/components/layout/Footer.tsx
+++ b/learning-games/src/components/layout/Footer.tsx
@@ -16,6 +16,14 @@ export default function Footer() {
           <a href="/terms">Terms of Service</a>
           <a href="/contact">Contact</a>
         </nav>
+        <a
+          className="coffee-link"
+          href="https://coff.ee/strawberrytech"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ☕️ Buy me a coffee
+        </a>
       </div>
     </footer>
   )

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -135,15 +135,6 @@ export default function LeaderboardPage() {
         <p style={{ marginTop: '2rem' }}>
           <Link to="/">Return Home</Link>
         </p>
-        <div className="buy-coffee">
-          <a
-            href="https://coff.ee/strawberrytech"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Did you like this content? Buy me a coffee as a thank you
-          </a>
-        </div>
       </div>
       <ProgressSidebar />
     </div>

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -9,33 +9,134 @@ import './PromptDartsGame.css'
 export interface DartRound {
   bad: string
   good: string
-
   why: string
+  /** Example model response for the good prompt */
+  response: string
 }
 
-export const ROUNDS: DartRound[] = [
-  { bad: 'Tell me about AI.', good: 'List 3 use cases of AI in customer service.' },
-  { bad: 'Write an email.', good: 'Draft a 3-sentence email to a hiring manager explaining your interest.' },
-  { bad: 'Explain climate change.', good: 'Summarize 2 key causes of climate change in one paragraph.' },
-  { bad: 'Summarize this article.', good: 'Provide a two-sentence summary highlighting the main argument.' },
-  { bad: 'Translate this text.', good: 'Translate the following text from English to Spanish.' },
-  { bad: 'Analyze our sales.', good: 'List 3 key insights from last quarter\'s sales data in bullet form.' },
-  { bad: 'Write marketing copy.', good: 'Compose a short tweet promoting our new product and mention its top benefit.' },
-  { bad: 'Weather?', good: 'Give today\'s weather forecast for Tokyo in Celsius.' },
-  { bad: 'Code a function.', good: 'Write a Python function that reverses a string.' },
-  { bad: 'Story please.', good: 'Write a short bedtime story about a dragon who learns to code.' },
-  { bad: 'Advice on focus.', good: 'Provide three tips for staying productive while working remotely.' },
-  { bad: 'Help with calculus.', good: 'Explain in two sentences how to find the derivative of x^2.' },
-  { bad: 'Improve sentence.', good: 'Rewrite the following sentence to sound more professional.' },
-  { bad: 'List activities.', good: 'Provide five kid-friendly indoor activities for a rainy day.' },
-  { bad: 'History facts.', good: 'Give a brief overview of the causes of the French Revolution.' },
-  { bad: 'Get user data.', good: 'Create an SQL query to find the ten most recent orders.' },
-  { bad: 'Recipe ideas.', good: 'Share a simple recipe for vegan chocolate chip cookies.' },
-  { bad: 'Explain quantum.', good: 'Explain quantum entanglement in simple terms for beginners.' },
-  { bad: 'Fix my laptop.', good: 'List three common solutions for a laptop that won\'t turn on.' },
-  { bad: 'Make an outline.', good: 'Create a 5-point outline for a blog post about time management tips.' },
- ]
 
+export const ROUNDS: DartRound[] = [
+  {
+    bad: 'Tell me about AI.',
+    good: 'List 3 use cases of AI in customer service.',
+    why: 'The good prompt is specific about the desired output.',
+    response: '1. Answer common questions\n2. Route tickets\n3. Provide 24/7 help'
+  },
+  {
+    bad: 'Write an email.',
+    good: 'Draft a 3-sentence email to a hiring manager explaining your interest.',
+    why: 'It clearly states the format and audience.',
+    response: 'Dear Hiring Manager, ... (three sentences)'
+  },
+  {
+    bad: 'Explain climate change.',
+    good: 'Summarize 2 key causes of climate change in one paragraph.',
+    why: 'A concise request focuses the response.',
+    response: 'The main causes are greenhouse gases and deforestation.'
+  },
+  {
+    bad: 'Summarize this article.',
+    good: 'Provide a two-sentence summary highlighting the main argument.',
+    why: 'Defining length keeps the summary tight.',
+    response: 'Sentence one. Sentence two.'
+  },
+  {
+    bad: 'Translate this text.',
+    good: 'Translate the following text from English to Spanish.',
+    why: 'Specifying languages makes the task clear.',
+    response: 'Texto traducido al español.'
+  },
+  {
+    bad: 'Analyze our sales.',
+    good: "List 3 key insights from last quarter's sales data in bullet form.",
+    why: 'The format and focus are spelled out.',
+    response: '- Insight one\n- Insight two\n- Insight three'
+  },
+  {
+    bad: 'Write marketing copy.',
+    good: 'Compose a short tweet promoting our new product and mention its top benefit.',
+    why: 'Including format and detail improves clarity.',
+    response: 'Check out our new product! It saves you time ⏱️ #NewRelease'
+  },
+  {
+    bad: 'Weather?',
+    good: "Give today's weather forecast for Tokyo in Celsius.",
+    why: 'Location and units guide the response.',
+    response: 'Today in Tokyo it will be 22°C with light rain.'
+  },
+  {
+    bad: 'Code a function.',
+    good: 'Write a Python function that reverses a string.',
+    why: 'The good prompt specifies language and purpose.',
+    response: 'def reverse_string(s):\n    return s[::-1]'
+  },
+  {
+    bad: 'Story please.',
+    good: 'Write a short bedtime story about a dragon who learns to code.',
+    why: 'Topic and tone are defined.',
+    response: 'Once upon a time, a curious dragon learned Python...'
+  },
+  {
+    bad: 'Advice on focus.',
+    good: 'Provide three tips for staying productive while working remotely.',
+    why: 'Numbered tips make expectations clear.',
+    response: '1. Keep a routine\n2. Set boundaries\n3. Take breaks'
+  },
+  {
+    bad: 'Help with calculus.',
+    good: 'Explain in two sentences how to find the derivative of x^2.',
+    why: 'The good prompt constrains the explanation.',
+    response: 'Use the power rule: bring down the exponent and subtract one.'
+  },
+  {
+    bad: 'Improve sentence.',
+    good: 'Rewrite the following sentence to sound more professional.',
+    why: 'The instruction is clearer about the goal.',
+    response: 'Original: ... Revised: ...'
+  },
+  {
+    bad: 'List activities.',
+    good: 'Provide five kid-friendly indoor activities for a rainy day.',
+    why: 'Quantity and audience are defined.',
+    response: '1. Build a blanket fort...'
+  },
+  {
+    bad: 'History facts.',
+    good: 'Give a brief overview of the causes of the French Revolution.',
+    why: 'The good prompt specifies the scope.',
+    response: 'High taxes and social inequality led to unrest...'
+  },
+  {
+    bad: 'Get user data.',
+    good: 'Create an SQL query to find the ten most recent orders.',
+    why: 'The request defines exactly what results are needed.',
+    response: 'SELECT * FROM orders ORDER BY created_at DESC LIMIT 10;'
+  },
+  {
+    bad: 'Recipe ideas.',
+    good: 'Share a simple recipe for vegan chocolate chip cookies.',
+    why: 'Specifying ingredients helps produce a useful recipe.',
+    response: 'Mix flour, sugar, vegan butter and chocolate chips...'
+  },
+  {
+    bad: 'Explain quantum.',
+    good: 'Explain quantum entanglement in simple terms for beginners.',
+    why: 'The audience is clearly defined.',
+    response: 'Entanglement means two particles share a linked state even when far apart.'
+  },
+  {
+    bad: 'Fix my laptop.',
+    good: "List three common solutions for a laptop that won't turn on.",
+    why: 'Stating number and issue guides troubleshooting.',
+    response: '1. Check the power cable\n2. Remove the battery\n3. Try a hard reset'
+  },
+  {
+    bad: 'Make an outline.',
+    good: 'Create a 5-point outline for a blog post about time management tips.',
+    why: 'The structure and topic are spelled out.',
+    response: 'I. Introduction ... V. Conclusion'
+  }
+]
 
 
 export function checkChoice(_round: DartRound, choice: 'bad' | 'good') {

--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -180,6 +180,15 @@
   font-weight: bold;
 }
 
+.round-info {
+  margin-right: auto;
+}
+
+.final-score {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
 .game-actions {
   margin-top: 0.5rem;
   display: flex;


### PR DESCRIPTION
## Summary
- refine PromptRecipeGame card parsing and generation
- add round tracking with five total rounds and final score screen
- remove local leaderboard coffee link
- move coffee link to footer and animate
- ensure Prompt Darts round data includes responses for testing

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68446a608a1c832f892eba718b3f44e9