### PR TITLE
Implement advanced Prompt Recipe features

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -225,6 +225,15 @@
   margin-top: 0.5rem;
 }
 
+.combo {
+  margin-left: 0.5rem;
+  color: var(--color-accent);
+}
+
+.difficulty-select {
+  margin-bottom: 0.5rem;
+}
+
 @media (max-width: 600px) {
   .recipe-wrapper {
     grid-template-columns: 1fr;

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -10,19 +10,22 @@ import ProgressBar from '../components/ui/ProgressBar'
 import { UserContext } from '../context/UserContext'
 import './PromptRecipeGame.css'
 
-export type Slot = 'Action' | 'Context' | 'Format' | 'Constraints'
+export type Slot =
+  | 'Action'
+  | 'Context'
+  | 'Format'
+  | 'Constraints'
+  | 'Audience'
+  | 'Setting'
+
+export type Difficulty = 'easy' | 'medium' | 'hard'
 
 export interface Card {
   type: Slot
   text: string
 }
 
-export interface Dropped {
-  Action: string | null
-  Context: string | null
-  Format: string | null
-  Constraints: string | null
-}
+export type Dropped = Record<Slot, string | null>
 
 export function evaluateRecipe(dropped: Dropped, cards: Card[]) {
   let score = 0
@@ -62,11 +65,66 @@ const CONSTRAINTS = [
   'no more than 3 sentences',
 ]
 
+const AUDIENCES = [
+  'for beginners',
+  'for executives',
+  'for teenagers',
+  'for engineers',
+]
+
+const SETTINGS = [
+  'in a fantasy world',
+  'in outer space',
+  'in a dystopian future',
+  'during medieval times',
+]
+
+const SLOT_SETS: Record<Difficulty, Slot[]> = {
+  easy: ['Action', 'Context', 'Format', 'Constraints'],
+  medium: ['Action', 'Context', 'Format', 'Constraints', 'Audience'],
+  hard: ['Action', 'Context', 'Format', 'Constraints', 'Audience', 'Setting'],
+}
+
+const DEFAULTS: Record<Slot, string[]> = {
+  Action: ACTIONS,
+  Context: CONTEXTS,
+  Format: FORMATS,
+  Constraints: CONSTRAINTS,
+  Audience: AUDIENCES,
+  Setting: SETTINGS,
+}
+
+export function parseCardLines(text: string): string[] {
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean)
+
+  const result: string[] = []
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].replace(/^[-*\d.\s]+/, '')
+    const m = /^(Action|Context|Format|Constraints|Audience|Setting)[:\-\s]+(.+)/i.exec(line)
+    if (m) {
+      result.push(m[2].trim())
+      continue
+    }
+    if (/^(Action|Context|Format|Constraints|Audience|Setting)$/i.test(line)) {
+      if (i + 1 < lines.length) {
+        result.push(lines[i + 1].replace(/^[-*\d.\s]+/, ''))
+        i++
+        continue
+      }
+    }
+    result.push(line)
+  }
+  return result
+}
+
 function randomItem<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)]
 }
 
-async function generateCards(): Promise<Card[]> {
+async function generateCards(slots: Slot[]): Promise<Card[]> {
   try {
     const resp = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -79,8 +137,7 @@ async function generateCards(): Promise<Card[]> {
         messages: [
           {
             role: 'system',
-            content:
-              'Return four short phrases for Action, Context, Format and Constraint in that order, each on its own line.',
+            content: `Return ${slots.length} short phrases for ${slots.join(', ')} in that order, each on its own line.`,
           },
           { role: 'user', content: 'Provide the phrases.' },
         ],
@@ -91,79 +148,74 @@ async function generateCards(): Promise<Card[]> {
     const data = await resp.json()
     const text: string | undefined = data?.choices?.[0]?.message?.content
     if (text) {
-      const lines = text
-        .split('\n')
-        .map((l: string) => l.replace(/^[-*\d.\s]+/, '').trim())
-        .filter(Boolean)
-      if (lines.length >= 4) {
-        return [
-          { type: 'Action', text: lines[0] },
-          { type: 'Context', text: lines[1] },
-          { type: 'Format', text: lines[2] },
-          { type: 'Constraints', text: lines[3] },
-        ]
+      const lines = parseCardLines(text)
+      if (lines.length >= slots.length) {
+        return slots.map((s, i) => ({ type: s, text: lines[i] }))
       }
     }
   } catch (err) {
     console.error(err)
     toast.error('Unable to fetch new cards. Using defaults.')
   }
-  return [
-    { type: 'Action', text: randomItem(ACTIONS) },
-    { type: 'Context', text: randomItem(CONTEXTS) },
-    { type: 'Format', text: randomItem(FORMATS) },
-    { type: 'Constraints', text: randomItem(CONSTRAINTS) },
-  ]
+  return slots.map(s => ({ type: s, text: randomItem(DEFAULTS[s]) }))
 }
 
 export default function PromptRecipeGame() {
   const TOTAL_TIME = 30
 
   const { setScore, addBadge, user } = useContext(UserContext)
+  const [difficulty, setDifficulty] = useState<Difficulty>('easy')
+  const slots = SLOT_SETS[difficulty]
+
+  const createDropped = () => {
+    const obj = {} as Dropped
+    slots.forEach(s => {
+      obj[s] = null
+    })
+    return obj
+  }
+
   const [cards, setCards] = useState<Card[]>([])
   const [roundCards, setRoundCards] = useState<Card[]>([])
-  const [dropped, setDropped] = useState<Dropped>({
-    Action: null,
-    Context: null,
-    Format: null,
-    Constraints: null,
-  })
+  const [dropped, setDropped] = useState<Dropped>(createDropped)
   const [score, setScoreState] = useState(0)
   const [perfectRounds, setPerfectRounds] = useState(0)
+  const [combo, setCombo] = useState(0)
   const [showPrompt, setShowPrompt] = useState(false)
   const [hoverSlot, setHoverSlot] = useState<Slot | null>(null)
   const [timeLeft, setTimeLeft] = useState(TOTAL_TIME)
   const [hintSlot, setHintSlot] = useState<Slot | null>(null)
   const [selectedCard, setSelectedCard] = useState<Card | null>(null)
-  const [feedback, setFeedback] = useState<Record<Slot, 'correct' | 'wrong' | null>>({
-    Action: null,
-    Context: null,
-    Format: null,
-    Constraints: null,
+  const [feedback, setFeedback] = useState<Record<Slot, 'correct' | 'wrong' | null>>(() => {
+    const obj = {} as Record<Slot, 'correct' | 'wrong' | null>
+    slots.forEach(s => {
+      obj[s] = null
+    })
+    return obj
   })
   const [example, setExample] = useState<string | null>(null)
 
   async function startRound() {
-    const newCards = await generateCards()
+    const newCards = await generateCards(slots)
     setRoundCards(newCards)
     setCards(shuffle([...newCards]))
-    setDropped({ Action: null, Context: null, Format: null, Constraints: null })
+    setDropped(createDropped())
     setShowPrompt(false)
     setExample(null)
     setTimeLeft(TOTAL_TIME)
     setSelectedCard(null)
     setHintSlot(null)
-    setFeedback({
-      Action: null,
-      Context: null,
-      Format: null,
-      Constraints: null,
-    })
+    setFeedback(createDropped() as Record<Slot, 'correct' | 'wrong' | null>)
+    setCombo(0)
   }
 
   useEffect(() => {
     startRound()
   }, [])
+
+  useEffect(() => {
+    startRound()
+  }, [difficulty])
 
   useEffect(() => {
     if (showPrompt) return
@@ -182,7 +234,7 @@ export default function PromptRecipeGame() {
 
   useEffect(() => {
     if (showPrompt) {
-      const text = `${dropped.Action ?? ''} ${dropped.Context ?? ''} ${dropped.Format ?? ''} ${dropped.Constraints ?? ''}`.trim()
+      const text = slots.map(s => dropped[s] ?? '').join(' ').trim()
       if (text) generateExampleOutput(text)
     }
   }, [showPrompt])
@@ -190,15 +242,21 @@ export default function PromptRecipeGame() {
   useEffect(() => {
     if (Object.values(dropped).every(Boolean)) {
       const { score: gained, perfect } = evaluateRecipe(dropped, roundCards)
-      const finalScore = gained + Math.floor(timeLeft / 5)
-      setScoreState(s => s + finalScore)
+      let finalScore = gained + Math.floor(timeLeft / 5)
       if (perfect) {
         confetti({ particleCount: 70, spread: 60, origin: { y: 0.7 } })
         setPerfectRounds(p => p + 1)
+        setCombo(c => c + 1)
+        const multiplier = 1 + (combo + 1) * 0.5
+        finalScore = Math.round(finalScore * multiplier)
+        toast.success(`Combo x${combo + 1}!`)
         if (perfectRounds + 1 >= 10 && !user.badges.includes('prompt-chef')) {
           addBadge('prompt-chef')
         }
+      } else {
+        setCombo(0)
       }
+      setScoreState(s => s + finalScore)
       setScore('recipe', score + finalScore)
       setShowPrompt(true)
     }
@@ -272,21 +330,46 @@ export default function PromptRecipeGame() {
 
   function clearRound() {
     setCards(shuffle([...roundCards]))
-    setDropped({ Action: null, Context: null, Format: null, Constraints: null })
-    setFeedback({
-      Action: null,
-      Context: null,
-      Format: null,
-      Constraints: null,
-    })
+    setDropped(createDropped())
+    setFeedback(createDropped() as Record<Slot, 'correct' | 'wrong' | null>)
     setHintSlot(null)
+    setCombo(0)
   }
 
   function showHint() {
     const remaining = roundCards.filter(c => !Object.values(dropped).includes(c.text))
     if (remaining.length === 0) return
     const card = remaining[Math.floor(Math.random() * remaining.length)]
-    setHintSlot(card.type)
+    if (perfectRounds >= 3) {
+      fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            {
+              role: 'system',
+              content: 'Provide a short cryptic hint for the following phrase',
+            },
+            { role: 'user', content: card.text },
+          ],
+          max_tokens: 20,
+          temperature: 0.8,
+        }),
+      })
+        .then(res => res.json())
+        .then(data => {
+          const t: string | undefined = data?.choices?.[0]?.message?.content
+          if (t) toast(t.trim())
+          else setHintSlot(card.type)
+        })
+        .catch(() => setHintSlot(card.type))
+    } else {
+      setHintSlot(card.type)
+    }
     setScoreState(s => Math.max(0, s - 1))
   }
 
@@ -319,7 +402,16 @@ export default function PromptRecipeGame() {
     })
   }
 
-  const promptText = `${dropped.Action ?? ''} ${dropped.Context ?? ''} ${dropped.Format ?? ''} ${dropped.Constraints ?? ''}`
+  function sharePrompt() {
+    const text = `I scored ${score} in Prompt Recipe Builder! Prompt: ${promptText}`
+    if (navigator.share) {
+      navigator.share({ text }).catch(() => {})
+    } else {
+      navigator.clipboard.writeText(text).then(() => toast.success('Share text copied'))
+    }
+  }
+
+  const promptText = slots.map(s => dropped[s] ?? '').join(' ')
 
   return (
     <div className="recipe-page">
@@ -338,10 +430,21 @@ export default function PromptRecipeGame() {
           <div className="status-bar">
             <span className="score">Score: {score}</span>
             <span className="timer">Time: {timeLeft}s</span>
+            {combo > 0 && <span className="combo">Combo x{combo + 1}</span>}
+          </div>
+          <div className="difficulty-select">
+            <label>
+              Difficulty
+              <select value={difficulty} onChange={e => setDifficulty(e.target.value as Difficulty)}>
+                <option value="easy">Easy</option>
+                <option value="medium">Medium</option>
+                <option value="hard">Hard</option>
+              </select>
+            </label>
           </div>
           <ProgressBar percent={(timeLeft / TOTAL_TIME) * 100} />
           <div className="bowls">
-            {(['Action', 'Context', 'Format', 'Constraints'] as Slot[]).map(slot => (
+            {slots.map(slot => (
               <div
                 key={slot}
                 className={`bowl${hoverSlot === slot ? ' hover' : ''}${hintSlot === slot ? ' hint' : ''}${feedback[slot] === 'correct' ? ' correct' : ''}${feedback[slot] === 'wrong' ? ' wrong' : ''}`}
@@ -397,6 +500,9 @@ export default function PromptRecipeGame() {
               />
               <button className="btn-primary copy-btn" onClick={copyPrompt}>
                 Copy Prompt
+              </button>
+              <button className="btn-primary copy-btn" onClick={sharePrompt}>
+                Share
               </button>
             </div>
           )}

--- a/learning-games/src/pages/__tests__/PromptRecipeGame.test.ts
+++ b/learning-games/src/pages/__tests__/PromptRecipeGame.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { evaluateRecipe, type Dropped, type Card } from '../PromptRecipeGame'
+import {
+  evaluateRecipe,
+  parseCardLines,
+  type Dropped,
+  type Card,
+} from '../PromptRecipeGame'
 
 describe('evaluateRecipe', () => {
   it('scores 4 and is perfect when all placements correct', () => {
@@ -14,6 +19,8 @@ describe('evaluateRecipe', () => {
       Context: 'About',
       Format: 'In style',
       Constraints: 'Short',
+      Audience: null,
+      Setting: null,
     }
     const result = evaluateRecipe(dropped, cards)
     expect(result.score).toBe(4)
@@ -32,9 +39,28 @@ describe('evaluateRecipe', () => {
       Context: 'Wrong',
       Format: 'In style',
       Constraints: 'Short',
+      Audience: null,
+      Setting: null,
     }
     const result = evaluateRecipe(dropped, cards)
     expect(result.score).toBe(3)
     expect(result.perfect).toBe(false)
+  })
+})
+
+describe('parseCardLines', () => {
+  it('handles prefixes on same line', () => {
+    const text = 'Action: Write\nContext: About\nFormat: List\nConstraints: Short'
+    expect(parseCardLines(text)).toEqual(['Write', 'About', 'List', 'Short'])
+  })
+
+  it('handles label lines separately', () => {
+    const text = 'Action\nWrite an email\nContext\nFor work\nFormat\nBullet\nConstraints\nBrief'
+    expect(parseCardLines(text)).toEqual([
+      'Write an email',
+      'For work',
+      'Bullet',
+      'Brief',
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- sanitize OpenAI responses for Prompt Recipe builder
- add difficulty levels with extra ingredient slots
- track combo streaks and show multiplier in status bar
- provide share functionality and adaptive AI hints
- update build to use mapped type and adjust tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684456f482f4832fbaae155332aa8548