### PR TITLE
Add ComposeTweetGame page

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -7,6 +7,7 @@ import QuizGame from './pages/QuizGame'
 import PromptRecipeGame from './pages/PromptRecipeGame'
 import PromptDartsGame from './pages/PromptDartsGame'
 import PromptGuessEscape from './pages/PromptGuessEscape'
+import ComposeTweetGame from './pages/ComposeTweetGame'
 
 import ClarityEscapeRoom from './pages/ClarityEscapeRoom'
 
@@ -41,6 +42,7 @@ function App() {
         <Route path="/games/quiz" element={<QuizGame />} />
         <Route path="/games/recipe" element={<PromptRecipeGame />} />
         <Route path="/games/darts" element={<PromptDartsGame />} />
+        <Route path="/games/compose" element={<ComposeTweetGame />} />
         <Route path="/games/guess" element={<PromptGuessEscape />} />
         <Route path="/prompt-builder" element={<PromptRecipeGame />} />
 

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -57,6 +57,11 @@ export default function NavBar() {
         </li>
         <li>
           <Tooltip message="Hover here for a surprise!">
+            <Link to="/games/compose">Compose Tweet</Link>
+          </Tooltip>
+        </li>
+        <li>
+          <Tooltip message="Hover here for a surprise!">
             <Link to="/leaderboard">Progress</Link>
           </Tooltip>
         </li>

--- a/learning-games/src/pages/ComposeTweetGame.css
+++ b/learning-games/src/pages/ComposeTweetGame.css
@@ -1,0 +1,73 @@
+.compose-wrapper {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 200px 1fr 200px;
+  grid-template-areas:
+    'sidebar game progress';
+  gap: 1rem;
+  align-items: start;
+}
+
+.compose-sidebar {
+  grid-area: sidebar;
+  background: var(--color-background);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.compose-game {
+  grid-area: game;
+  background: var(--color-background);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ai-box {
+  background: #ee3a57;
+  color: white;
+  padding: 0.75rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  min-height: 60px;
+}
+
+.prompt-form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.prompt-form input {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+}
+
+.feedback {
+  font-weight: bold;
+}
+
+.door-area {
+  text-align: center;
+}
+
+.timer {
+  font-weight: bold;
+  color: var(--color-orange);
+}
+
+@media (max-width: 600px) {
+  .compose-wrapper {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'game'
+      'sidebar'
+      'progress';
+  }
+}

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect, useRef } from 'react'
+import InstructionBanner from '../components/ui/InstructionBanner'
+import ProgressSidebar from '../components/layout/ProgressSidebar'
+import './ComposeTweetGame.css'
+
+const SAMPLE_RESPONSE =
+  'Just finished reading an amazing book on technology! Highly recommend it to everyone. #BookLovers'
+const CORRECT_PROMPT = 'Compose a tweet about reading a new book'
+
+export default function ComposeTweetGame() {
+  const [guess, setGuess] = useState('')
+  const [feedback, setFeedback] = useState('')
+  const [doorUnlocked, setDoorUnlocked] = useState(false)
+  const [timeLeft, setTimeLeft] = useState(30)
+  const timerRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    timerRef.current = window.setInterval(() => {
+      setTimeLeft(t => {
+        if (t <= 1) {
+          clearInterval(timerRef.current!)
+          setFeedback('Too slow! The door remains locked.')
+          return 0
+        }
+        return t - 1
+      })
+    }, 1000)
+    return () => clearInterval(timerRef.current!)
+  }, [])
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (guess.trim().toLowerCase() === CORRECT_PROMPT.toLowerCase()) {
+      setFeedback('Correct! The door is unlocked.')
+      setDoorUnlocked(true)
+      clearInterval(timerRef.current!)
+    } else {
+      setFeedback('Incorrect guess, try again.')
+    }
+    setGuess('')
+  }
+
+  function handleHint() {
+    setFeedback(`Hint: The prompt is about ${CORRECT_PROMPT.split(' ')[2]}...`)
+  }
+
+  return (
+    <div className="compose-page">
+      <InstructionBanner>Guess the Prompt</InstructionBanner>
+      <div className="compose-wrapper">
+        <aside className="compose-sidebar">
+          <p className="timer">Time left: {timeLeft}s</p>
+        </aside>
+        <div className="compose-game">
+          <div className="ai-box" aria-live="polite">
+            {SAMPLE_RESPONSE}
+          </div>
+          <form onSubmit={handleSubmit} className="prompt-form">
+            <label htmlFor="prompt-input">Your guess</label>
+            <input
+              id="prompt-input"
+              value={guess}
+              onChange={e => setGuess(e.target.value)}
+              placeholder="Guess the prompt..."
+              aria-label="Input your guess for the prompt"
+            />
+            <button type="submit" className="btn-primary" aria-label="Submit your guess">
+              Submit
+            </button>
+            <button
+              type="button"
+              onClick={handleHint}
+              className="btn-primary"
+              aria-label="Get a hint"
+            >
+              Hint
+            </button>
+          </form>
+          {feedback && <p className="feedback">{feedback}</p>}
+          <div className="door-area">
+            <img
+              src={doorUnlocked ? '/images/door-open.png' : '/images/door-closed.png'}
+              alt={doorUnlocked ? 'Door unlocked' : 'Door locked'}
+              width={100}
+              height={150}
+            />
+          </div>
+        </div>
+        <ProgressSidebar />
+      </div>
+    </div>
+  )
+}

--- a/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
+++ b/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import ComposeTweetGame from '../ComposeTweetGame'
+
+function setup() {
+  return render(
+    <MemoryRouter>
+      <ComposeTweetGame />
+    </MemoryRouter>
+  )
+}
+
+describe('ComposeTweetGame', () => {
+  it('unlocks door when prompt guessed correctly', () => {
+    const { getByLabelText, getByRole, getByText } = setup()
+    const input = getByLabelText(/input your guess/i)
+    fireEvent.change(input, { target: { value: 'Compose a tweet about reading a new book' } })
+    fireEvent.click(getByRole('button', { name: /submit your guess/i }))
+    expect(getByText(/door is unlocked/i)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- add ComposeTweetGame page and styles
- link ComposeTweetGame in nav
- expose ComposeTweetGame route in App
- test ComposeTweetGame page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844d2a1ad44832f82ab5335550ef65c