### PR TITLE
Integrate strawberry images throughout UI

### DIFF
--- a/learning-games/src/components/layout/Footer.tsx
+++ b/learning-games/src/components/layout/Footer.tsx
@@ -5,8 +5,8 @@ export default function Footer() {
       <div className="footer-content">
         <div className="brand">
           <img
-            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
-            alt="Strawberry logo"
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+            alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
             className="brand-logo"
           />
           <span>&copy; {year} StrawberryTech</span>

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -9,8 +9,8 @@ export default function NavBar() {
     <nav className="navbar" style={{ position: 'sticky', top: 0 }} aria-label="Main navigation">
       <div className="brand">
         <img
-          src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
-          alt="Strawberry logo"
+          src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+          alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
           className="brand-logo"
         />
         StrawberryTech

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -47,6 +47,12 @@ export default function ComposeTweetGame() {
   return (
     <div className="compose-page">
       <InstructionBanner>Guess the Prompt</InstructionBanner>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
+        alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
+        className="hero-img"
+        style={{ width: '200px' }}
+      />
       <div className="compose-wrapper">
         <aside className="compose-sidebar">
           <p className="timer">Time left: {timeLeft}s</p>
@@ -84,6 +90,14 @@ export default function ComposeTweetGame() {
               width={100}
               height={150}
             />
+            {doorUnlocked && (
+              <img
+                src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_29%20PM.png"
+                alt="Another version of strawberry calling out sick, same description."
+                className="hero-img"
+                style={{ width: '200px' }}
+              />
+            )}
           </div>
         </div>
         <ProgressSidebar />

--- a/learning-games/src/pages/HelpPage.tsx
+++ b/learning-games/src/pages/HelpPage.tsx
@@ -4,6 +4,12 @@ export default function HelpPage() {
   return (
     <div className="help-page">
       <h2>How to Play</h2>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+        alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
+        className="brand-logo"
+        style={{ width: '48px' }}
+      />
       <p>Choose a game from the home page and follow the on-screen instructions. Earn points and badges as you progress!</p>
       <p>If you run into issues, feel free to <Link to="/contact">reach out</Link>.</p>
       <p style={{ marginTop: '2rem' }}>

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -42,8 +42,8 @@ export default function Home() {
       <section className="hero reveal" aria-label="Homepage hero">
         <h1 className="hero-title">Embark on a Fruity Learning Adventure!</h1>
         <img
-          src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
-          alt="Strawberry logo"
+          src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+          alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
           className="hero-img"
         />
         <p className="tagline">Play engaging games and sharpen your skills.</p>

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -318,6 +318,12 @@ export default function Match3Game() {
       <InstructionBanner>
         Match adjectives to explore how tone changes the meaning of a message.
       </InstructionBanner>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png"
+        alt="Earlier prompt recipe builder with similar strawberry chef and cards."
+        className="hero-img"
+        style={{ width: '200px' }}
+      />
       <div className="match3-wrapper">
         <aside className="match3-sidebar">
           <h3>Why Tone Matters</h3>

--- a/learning-games/src/pages/PrivacyPage.tsx
+++ b/learning-games/src/pages/PrivacyPage.tsx
@@ -4,6 +4,12 @@ export default function PrivacyPage() {
   return (
     <div className="legal-page">
       <h2>Privacy Policy</h2>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+        alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
+        className="brand-logo"
+        style={{ width: '48px' }}
+      />
       <p>This demo app stores your progress locally in your browser and does not share personal data.</p>
       <p style={{ marginTop: '2rem' }}>
         <Link to="/">Return Home</Link>

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -207,6 +207,12 @@ export default function PromptDartsGame() {
       <InstructionBanner>
         Choose the clearer prompt that best targets the requested format.
       </InstructionBanner>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png"
+        alt="Strawberry throwing dart hitting \"Clear Prompt\" bullseye on prompt darts target."
+        className="hero-img"
+        style={{ width: '200px' }}
+      />
       <div className="darts-wrapper">
         <aside className="darts-sidebar">
           <h3>Why Clarity Matters</h3>

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -457,8 +457,8 @@ export default function PromptRecipeGame() {
               {example && <p className="sample-output">{example}</p>}
               <img
                 className="prompt-image"
-                src="https://images.unsplash.com/photo-1495567720989-cebdbdd97913?auto=format&fit=crop&w=400&q=60"
-                alt="prompt context"
+                src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
+                alt="Prompt recipe builder strawberry chef tossing cards labeled Action, Context, Format, Constraints."
               />
               <button className="btn-primary copy-btn" onClick={copyPrompt}>
                 Copy Prompt

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -286,6 +286,12 @@ export default function QuizGame() {
       <div className="truth-game">
         <WhyItMatters />
         <div className="game-area">
+          <img
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_51_28%20PM.png"
+            alt="Detective-themed strawberry examining statement cards under magnifying glass to spot false claim."
+            className="hero-img"
+            style={{ width: '200px' }}
+          />
           <div className="statements">
           <div className="statement-header">
             <h2>Hallucinations</h2>

--- a/learning-games/src/pages/SplashPage.tsx
+++ b/learning-games/src/pages/SplashPage.tsx
@@ -31,6 +31,11 @@ export default function SplashPage() {
     <div className="splash-container">
       <div className="overlay">
         <h1>Welcome to StrawberryTech! 🍓</h1>
+        <img
+          src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+          alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
+          className="hero-img"
+        />
         <p>Play while you learn.</p>
         <form onSubmit={handleSubmit} className="start-form">
           <input

--- a/learning-games/src/pages/StatsPage.tsx
+++ b/learning-games/src/pages/StatsPage.tsx
@@ -72,6 +72,12 @@ export default function StatsPage() {
   return (
     <div className="stats-page">
       <h2>Site Statistics</h2>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+        alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
+        className="brand-logo"
+        style={{ width: '48px' }}
+      />
       <p>Total Views: {views.length}</p>
       <p>Unique Visitors: {uniqueVisitors}</p>
       <p>Average Session (s): {avgDuration}</p>

--- a/learning-games/src/pages/TermsPage.tsx
+++ b/learning-games/src/pages/TermsPage.tsx
@@ -4,6 +4,12 @@ export default function TermsPage() {
   return (
     <div className="legal-page">
       <h2>Terms of Service</h2>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+        alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
+        className="brand-logo"
+        style={{ width: '48px' }}
+      />
       <p>Use these mini games for educational purposes only. No warranty is provided.</p>
       <p style={{ marginTop: '2rem' }}>
         <Link to="/">Return Home</Link>


### PR DESCRIPTION
## Summary
- replace placeholder art in NavBar and Footer with mascot image
- swap hero art on Home and Splash pages
- drop remote strawberry chef art into Tone and Recipe games
- add detective strawberry for Hallucinations quiz
- show sick strawberry variations in the Compose Tweet game
- decorate Darts, Help, Privacy, Terms and Stats pages with mascot

## Testing
- `npm test` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_6844df1cfe30832fb047e01c0bf12b76