### PR TITLE
Implement reusable game page layout and components

### DIFF
--- a/learning-games/src/components/layout/GamePageLayout.css
+++ b/learning-games/src/components/layout/GamePageLayout.css
@@ -1,0 +1,100 @@
+.game-page-container {
+  display: flex;
+  gap: 2rem;
+  padding: 1rem;
+  background-color: #f7d4d9;
+  min-height: 80vh;
+  box-sizing: border-box;
+}
+
+.left-column {
+  flex: 0 0 28%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.game-image {
+  width: 150px;
+  height: auto;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.info-card {
+  background-color: #ffe5d9;
+  border-radius: 8px;
+  padding: 1rem;
+  font-weight: 600;
+  font-size: 1rem;
+  color: #3a3a3a;
+  text-align: center;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.1);
+  user-select: none;
+}
+
+.right-column {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.instructions-box {
+  background-color: #ffe5d9;
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1.15rem;
+  color: #2e2e2e;
+  margin-bottom: 1.5rem;
+  box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.05);
+  user-select: none;
+}
+
+.game-interaction {
+  flex-grow: 1;
+  margin-bottom: 2rem;
+}
+
+.cta-button {
+  background-color: #d81e39;
+  color: white;
+  border: none;
+  padding: 0.85rem 1.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  border-radius: 6px;
+  cursor: pointer;
+  align-self: flex-start;
+  transition: background-color 0.3s ease;
+}
+
+.cta-button:hover,
+.cta-button:focus {
+  background-color: #b7182d;
+  outline: none;
+}
+
+@media (max-width: 768px) {
+  .game-page-container {
+    flex-direction: column;
+    padding: 1rem 0.5rem;
+  }
+
+  .left-column {
+    flex: none;
+    width: 100%;
+    margin-bottom: 1.5rem;
+    align-items: center;
+  }
+
+  .right-column {
+    width: 100%;
+  }
+
+  .cta-button {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/learning-games/src/components/layout/GamePageLayout.tsx
+++ b/learning-games/src/components/layout/GamePageLayout.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import './GamePageLayout.css'
+
+interface GamePageLayoutProps {
+  imageSrc: string
+  imageAlt: string
+  infoCardContent: React.ReactNode
+  instructions: string
+  children: React.ReactNode
+  onCTAClick: () => void
+  ctaText: string
+}
+
+const GamePageLayout: React.FC<GamePageLayoutProps> = ({
+  imageSrc,
+  imageAlt,
+  infoCardContent,
+  instructions,
+  children,
+  onCTAClick,
+  ctaText,
+}) => {
+  return (
+    <div className="game-page-container">
+      <aside className="left-column">
+        <img src={imageSrc} alt={imageAlt} className="game-image" />
+        <div className="info-card">{infoCardContent}</div>
+      </aside>
+      <main className="right-column">
+        <div className="instructions-box">{instructions}</div>
+        <div className="game-interaction">{children}</div>
+        <button className="cta-button" onClick={onCTAClick}>
+          {ctaText}
+        </button>
+      </main>
+    </div>
+  )
+}
+
+export default GamePageLayout

--- a/learning-games/src/components/layout/NavBarSimple.css
+++ b/learning-games/src/components/layout/NavBarSimple.css
@@ -1,0 +1,49 @@
+.navbar-simple {
+  display: flex;
+  align-items: center;
+  background-color: #d81e39;
+  padding: 0.5rem 1rem;
+  user-select: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.navbar-logo img {
+  height: 40px;
+  width: auto;
+}
+
+.navbar-links {
+  display: flex;
+  list-style: none;
+  margin-left: 1.5rem;
+  padding: 0;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.navbar-links li a {
+  color: white;
+  font-weight: 700;
+  text-decoration: none;
+  font-size: 1rem;
+  padding: 0.5rem;
+  transition: background-color 0.25s ease;
+  border-radius: 4px;
+}
+
+.navbar-links li a:hover,
+.navbar-links li a:focus {
+  background-color: #b7182d;
+  outline: none;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .navbar-links {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+}

--- a/learning-games/src/components/layout/NavBarSimple.tsx
+++ b/learning-games/src/components/layout/NavBarSimple.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import './NavBarSimple.css'
+
+export interface NavLink {
+  label: string
+  href: string
+}
+
+interface NavBarSimpleProps {
+  logoSrc: string
+  logoAlt: string
+  links: NavLink[]
+  onSurpriseHover?: () => void
+}
+
+const NavBarSimple: React.FC<NavBarSimpleProps> = ({
+  logoSrc,
+  logoAlt,
+  links,
+  onSurpriseHover,
+}) => {
+  return (
+    <nav className="navbar-simple" role="navigation" aria-label="Main navigation">
+      <div className="navbar-logo">
+        <img src={logoSrc} alt={logoAlt} />
+      </div>
+      <ul className="navbar-links">
+        {links.map(({ label, href }) => (
+          <li key={label}>
+            <a href={href} onMouseOver={onSurpriseHover}>
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+export default NavBarSimple

--- a/learning-games/src/components/layout/ProgressSidebarSimple.css
+++ b/learning-games/src/components/layout/ProgressSidebarSimple.css
@@ -1,0 +1,50 @@
+.progress-sidebar-simple {
+  background-color: #f7d4d9;
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  width: 250px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  font-weight: 600;
+  font-size: 1rem;
+  color: #3a3a3a;
+  user-select: none;
+}
+
+.progress-bar {
+  background-color: #f0c0c6;
+  border-radius: 12px;
+  height: 16px;
+  width: 100%;
+  margin: 0.25rem 0 0.75rem;
+  overflow: hidden;
+}
+
+.progress-fill {
+  background-color: #d81e39;
+  height: 100%;
+  border-radius: 12px 0 0 12px;
+  transition: width 0.4s ease;
+}
+
+.goal-text {
+  font-weight: 700;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.top-scores-list {
+  list-style: none;
+  padding-left: 0;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.top-scores-list li {
+  padding: 0.2rem 0;
+  border-bottom: 1px solid #f0c0c6;
+  font-weight: 600;
+}
+
+.top-scores-list li:last-child {
+  border-bottom: none;
+}

--- a/learning-games/src/components/layout/ProgressSidebarSimple.tsx
+++ b/learning-games/src/components/layout/ProgressSidebarSimple.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import './ProgressSidebarSimple.css'
+
+export interface ScoreEntry {
+  name: string
+  points: number
+}
+
+interface ProgressSidebarSimpleProps {
+  totalPoints: number
+  badgesEarned: number
+  goalPoints: number
+  topScores: ScoreEntry[]
+}
+
+const ProgressSidebarSimple: React.FC<ProgressSidebarSimpleProps> = ({
+  totalPoints,
+  badgesEarned,
+  goalPoints,
+  topScores,
+}) => {
+  const progressPercent = Math.min((totalPoints / goalPoints) * 100, 100)
+
+  return (
+    <aside className="progress-sidebar-simple" aria-label="Player progress">
+      <h2>Your Progress</h2>
+      <p>Total Points: {totalPoints}</p>
+      <div className="progress-bar" role="progressbar" aria-valuemin={0} aria-valuemax={goalPoints} aria-valuenow={totalPoints}>
+        <div className="progress-fill" style={{ width: `${progressPercent}%` }} />
+      </div>
+      <p className="goal-text">Goal: Reach {goalPoints} points to unlock a new badge!</p>
+      <p>Badges Earned: {badgesEarned}</p>
+      <h3>Top Scores</h3>
+      <ul className="top-scores-list">
+        {topScores.length === 0 ? (
+          <li>No scores yet.</li>
+        ) : (
+          topScores.map(({ name, points }) => (
+            <li key={name}>
+              {name}: {points}
+            </li>
+          ))
+        )}
+      </ul>
+    </aside>
+  )
+}
+
+export default ProgressSidebarSimple

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import { Link } from 'react-router-dom'
-import ProgressSidebar from '../components/layout/ProgressSidebar'
+import ProgressSidebarSimple from '../components/layout/ProgressSidebarSimple'
+import GamePageLayout from '../components/layout/GamePageLayout'
+import { UserContext } from '../context/UserContext'
 import './DragDropGame.css'
 
 const tones = [
@@ -35,6 +37,9 @@ export default function DragDropGame() {
   const [quizAnswer, setQuizAnswer] = useState<Tone | null>(null)
   const [userMessage, setUserMessage] = useState('')
   const [submitted, setSubmitted] = useState(false)
+  const { user } = useContext(UserContext)
+  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const badgesEarned = user.badges.length
 
   function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {
     e.dataTransfer.setData('text/plain', tone)
@@ -63,90 +68,114 @@ export default function DragDropGame() {
 
   return (
     <div className="dragdrop-page">
-      <div className="dragdrop-wrapper">
-        <div className="dragdrop-game">
-          <h2>Drag a tone into the blank</h2>
-          <p className="sentence">
-          Write a
-          <span
-            className="drop-area"
-            onDrop={handleDrop}
-            onDragOver={handleDragOver}
-          >
-            {selected ? ` ${selected} ` : ' ____ '}
-          </span>
-          short text to my manager calling out of work sick today.
-          </p>
-          <div className="word-bank">
-            {tones.map((tone) => (
-              <div
-                key={tone}
-                draggable
-                onDragStart={(e) => handleDragStart(e, tone)}
-                className="word"
+      <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start' }}>
+        <GamePageLayout
+          imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
+          imageAlt="Tone game illustration"
+          infoCardContent={
+            <>
+              <h3>Why Tone Matters</h3>
+              <p>
+                Drag the adjectives into the blank to try different tones. Swap
+                words wisely and watch your message sparkle!
+              </p>
+            </>
+          }
+          instructions="Match adjectives to explore how tone changes the meaning of a message."
+          onCTAClick={() => {}}
+          ctaText="Start Playing"
+        >
+          <div className="dragdrop-game">
+            <h2>Drag a tone into the blank</h2>
+            <p className="sentence">
+              Write a
+              <span
+                className="drop-area"
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
               >
-                {tone}
-              </div>
-            ))}
-          </div>
-      {selected && (
-        <div className="response">
-          <h3>AI Response</h3>
-          <p>{examples[selected]}</p>
-          {!submitted && (
-            <div className="message-input">
-              <textarea
-                value={userMessage}
-                onChange={(e) => setUserMessage(e.target.value)}
-                placeholder="Type your message..."
-              />
-
-              <button onClick={handleSubmit} className="btn-primary" disabled={!userMessage.trim()}>
-
-                Submit Message
-              </button>
-            </div>
-          )}
-          {submitted && (
-            <p className="user-message">You wrote: {userMessage}</p>
-          )}
-        </div>
-      )}
-      {used.size === tones.length && (
-        <div className="quiz">
-          <h3>Quick test</h3>
-          <p>
-            What tone should you use when writing a message to your boss that you
-            will be out of work sick today?
-          </p>
-          <div className="options">
-            {tones.map((tone) => (
-              <button
-                key={tone}
-                className="btn-primary"
-                onClick={() => setQuizAnswer(tone)}
-                disabled={!!quizAnswer}
-              >
-                {tone}
-              </button>
-            ))}
-          </div>
-          {quizAnswer && (
-            <p className="feedback">
-              {quizAnswer === 'Polite'
-                ? 'Correct! A polite tone is best for informing your boss.'
-                : 'Not quite. A polite tone is usually most appropriate.'}
+                {selected ? ` ${selected} ` : ' ____ '}
+              </span>
+              short text to my manager calling out of work sick today.
             </p>
-          )}
-        </div>
-      )}
-        </div>
-        <ProgressSidebar />
-        <div className="next-area">
-          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-            <Link to="/leaderboard">Return to Progress</Link>
-          </p>
-        </div>
+            <div className="word-bank">
+              {tones.map((tone) => (
+                <div
+                  key={tone}
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, tone)}
+                  className="word"
+                >
+                  {tone}
+                </div>
+              ))}
+            </div>
+            {selected && (
+              <div className="response">
+                <h3>AI Response</h3>
+                <p>{examples[selected]}</p>
+                {!submitted && (
+                  <div className="message-input">
+                    <textarea
+                      value={userMessage}
+                      onChange={(e) => setUserMessage(e.target.value)}
+                      placeholder="Type your message..."
+                    />
+                    <button
+                      onClick={handleSubmit}
+                      className="btn-primary"
+                      disabled={!userMessage.trim()}
+                    >
+                      Submit Message
+                    </button>
+                  </div>
+                )}
+                {submitted && (
+                  <p className="user-message">You wrote: {userMessage}</p>
+                )}
+              </div>
+            )}
+            {used.size === tones.length && (
+              <div className="quiz">
+                <h3>Quick test</h3>
+                <p>
+                  What tone should you use when writing a message to your boss
+                  that you will be out of work sick today?
+                </p>
+                <div className="options">
+                  {tones.map((tone) => (
+                    <button
+                      key={tone}
+                      className="btn-primary"
+                      onClick={() => setQuizAnswer(tone)}
+                      disabled={!!quizAnswer}
+                    >
+                      {tone}
+                    </button>
+                  ))}
+                </div>
+                {quizAnswer && (
+                  <p className="feedback">
+                    {quizAnswer === 'Polite'
+                      ? 'Correct! A polite tone is best for informing your boss.'
+                      : 'Not quite. A polite tone is usually most appropriate.'}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </GamePageLayout>
+        <ProgressSidebarSimple
+          totalPoints={totalPoints}
+          badgesEarned={badgesEarned}
+          goalPoints={300}
+          topScores={[{ name: 'You', points: user.scores['tone'] ?? 0 }]}
+        />
+      </div>
+      <div className="next-area">
+        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+          <Link to="/leaderboard">Return to Progress</Link>
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add `GamePageLayout` component and styles
- create simple `NavBarSimple` and `ProgressSidebarSimple` components
- update DragDropGame page to use new layout example

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844e83e67b4832f83089b11f2b2fdcf