### PR TITLE
Fix prompt round data and wrap card images

### DIFF
--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -173,3 +173,34 @@ body.high-contrast button {
   white-space: nowrap;
   border: 0;
 }
+
+.game-card-image {
+  float: left;
+  width: 120px;
+  height: auto;
+  margin: 0 1rem 1rem 0;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.game-text {
+  line-height: 1.5;
+  font-size: 1rem;
+  color: #333;
+}
+
+.clearfix::after {
+  content: '';
+  display: table;
+  clear: both;
+}
+
+@media (max-width: 600px) {
+  .game-card-image {
+    float: none;
+    display: block;
+    margin: 0 0 1rem 0;
+    width: 100%;
+    height: auto;
+  }
+}

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -45,13 +45,12 @@ export default function ComposeTweetGame() {
   }
 
   return (
-    <div className="compose-page">
+    <div className="compose-page clearfix">
       <InstructionBanner>Guess the Prompt</InstructionBanner>
       <img
         src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
         alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
-        className="hero-img"
-        style={{ width: '200px' }}
+        className="game-card-image"
       />
       <div className="compose-wrapper">
         <aside className="compose-sidebar">

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -85,9 +85,14 @@ export default function DragDropGame() {
           onCTAClick={() => {}}
           ctaText="Start Playing"
         >
-          <div className="dragdrop-game">
+          <div className="dragdrop-game clearfix">
             <h2>Drag a tone into the blank</h2>
-            <p className="sentence">
+            <img
+              src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
+              alt="Tone game illustration"
+              className="game-card-image"
+            />
+            <p className="sentence game-text">
               Write a
               <span
                 className="drop-area"

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -110,6 +110,24 @@ const CONSTRAINTS = [
   'limit to three sentences',
 ]
 
+const CATEGORY_POOLS: Record<Slot, string[]> = {
+  Action: ACTIONS,
+  Context: CONTEXTS,
+  Format: FORMATS,
+  Constraints: CONSTRAINTS,
+}
+
+export function ensureCardSet(lines: string[]): Card[] {
+  const categories: Slot[] = ['Action', 'Context', 'Format', 'Constraints']
+  return categories.map((cat, idx) => ({
+    type: cat,
+    text:
+      lines[idx] && lines[idx].trim()
+        ? lines[idx].trim()
+        : randomItem(CATEGORY_POOLS[cat]),
+  }))
+}
+
 function randomItem<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)]
 }
@@ -141,24 +159,14 @@ async function generateCards(): Promise<Card[]> {
     if (text) {
       const lines = parseCardLines(text)
       if (lines.length >= 4) {
-        return [
-          { type: 'Action', text: lines[0] },
-          { type: 'Context', text: lines[1] },
-          { type: 'Format', text: lines[2] },
-          { type: 'Constraints', text: lines[3] },
-        ]
+        return ensureCardSet(lines)
       }
     }
   } catch (err) {
     console.error(err)
     toast.error('Unable to fetch new cards. Using defaults.')
   }
-  return [
-    { type: 'Action', text: randomItem(ACTIONS) },
-    { type: 'Context', text: randomItem(CONTEXTS) },
-    { type: 'Format', text: randomItem(FORMATS) },
-    { type: 'Constraints', text: randomItem(CONSTRAINTS) },
-  ]
+  return ensureCardSet([])
 }
 
 export default function PromptRecipeGame() {

--- a/learning-games/src/pages/__tests__/PromptRecipeGame.test.ts
+++ b/learning-games/src/pages/__tests__/PromptRecipeGame.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   evaluateRecipe,
   parseCardLines,
+  ensureCardSet,
   type Dropped,
   type Card,
 } from '../PromptRecipeGame'
@@ -67,5 +68,20 @@ describe('parseCardLines', () => {
       'bullet',
       'short',
     ])
+  })
+})
+
+describe('ensureCardSet', () => {
+  it('fills missing categories with defaults', () => {
+    const result = ensureCardSet(['Do it', 'quickly'])
+    expect(result).toHaveLength(4)
+    expect(result[0].type).toBe('Action')
+    expect(result[0].text).toBe('Do it')
+    expect(result[1].type).toBe('Context')
+    expect(result[1].text).toBe('quickly')
+    expect(result[2].type).toBe('Format')
+    expect(typeof result[2].text).toBe('string')
+    expect(result[3].type).toBe('Constraints')
+    expect(typeof result[3].text).toBe('string')
   })
 })


### PR DESCRIPTION
## Summary
- float game images so text wraps nicely
- embed game-card images in Compose Tweet and Tone DragDrop
- guarantee one card per category in Prompt Recipe game
- test ensureCardSet helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68457964b088832f88a082ac275a4ae0