### PR TITLE
Improve escape game prompt hints

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -8,6 +8,7 @@ import Tooltip from '../components/ui/Tooltip'
 import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './ClarityEscapeRoom.css'
+import { scorePrompt } from '../utils/scorePrompt'
 
 interface Clue {
   aiResponse: string
@@ -68,27 +69,6 @@ const CLUES: Clue[] = [
   }
 ]
 
-const ACTION_WORDS = ['write', 'tell', 'show', 'give', 'describe', 'explain', 'summarize', 'suggest']
-
-function scoreGuess(expected: string, guess: string): number {
-  const normGuess = guess.toLowerCase()
-  const normExpected = expected.toLowerCase()
-  let score = 0
-
-  const tokens = normExpected.split(/\W+/)
-  const overlap = tokens.filter(t => t && normGuess.includes(t)).length
-  if (overlap >= Math.max(1, Math.floor(tokens.length / 2))) score += 10
-
-  const contextMatch = /\d+|teacher|teen|student|man|python|cell|water|french/.exec(normExpected)
-  if (contextMatch && normGuess.includes(contextMatch[0])) {
-    score += 10
-  }
-
-  if (ACTION_WORDS.some(w => normGuess.includes(w))) score += 5
-  if (/simple|quick|short|daily|weekly|fun|persuasive/.test(normGuess)) score += 5
-
-  return score
-}
 
 export default function ClarityEscapeRoom() {
   const navigate = useNavigate()
@@ -127,7 +107,7 @@ export default function ClarityEscapeRoom() {
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    const score = scoreGuess(clue.expectedPrompt, input.trim())
+    const { score, tips } = scorePrompt(clue.expectedPrompt, input.trim())
     if (score >= 20) {
       const timeBonus = Date.now() - startRef.current < 10000 ? 5 : 0
       const total = score + 10 + timeBonus
@@ -137,7 +117,8 @@ export default function ClarityEscapeRoom() {
       setOpenPercent(((index + 1) / doors.length) * 100)
       setShowNext(true)
     } else {
-      setMessage('Too vague or off-target. Try again!')
+      const tipText = tips.join(' ')
+      setMessage(`Too vague. ${tipText}`)
       setStatus('error')
     }
   }

--- a/learning-games/src/utils/scorePrompt.ts
+++ b/learning-games/src/utils/scorePrompt.ts
@@ -1,0 +1,45 @@
+export interface ScoreDetails {
+  score: number
+  tips: string[]
+}
+
+const ACTION_WORDS = ['write','tell','show','give','describe','explain','summarize','suggest']
+const DESCRIPTIVE = /simple|quick|short|daily|weekly|fun|persuasive/
+const CONTEXT_REGEX = /\d+|teacher|teen|student|man|python|cell|water|french/
+
+export function scorePrompt(expected: string, guess: string): ScoreDetails {
+  const normGuess = guess.toLowerCase()
+  const normExpected = expected.toLowerCase()
+  let score = 0
+  const tips: string[] = []
+
+  const tokens = normExpected.split(/\W+/).filter(Boolean)
+  const overlap = tokens.filter(t => normGuess.includes(t))
+  const hasOverlap = overlap.length >= Math.max(1, Math.floor(tokens.length / 2))
+  if (hasOverlap) {
+    score += 10
+  } else if (tokens.length) {
+    tips.push(`Include key words like "${tokens[0]}"`)
+  }
+
+  const contextMatch = CONTEXT_REGEX.exec(normExpected)
+  const hasContext = contextMatch && normGuess.includes(contextMatch[0])
+  if (hasContext) {
+    score += 10
+  } else if (contextMatch) {
+    tips.push(`Mention "${contextMatch[0]}"`)
+  }
+
+  const hasAction = ACTION_WORDS.some(w => normGuess.includes(w))
+  if (hasAction) {
+    score += 5
+  } else {
+    tips.push('Start with an action word like "write" or "describe"')
+  }
+
+  if (DESCRIPTIVE.test(normGuess)) {
+    score += 5
+  }
+
+  return { score, tips }
+}


### PR DESCRIPTION
## Summary
- improve scoring feedback for guess-based escape games
- add reusable `scorePrompt` utility

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684579d94ac8832fa4bfdc7b44fc3a1f