### PR TITLE
Fix prompt builder instructions

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -146,9 +146,9 @@ async function generateCards(): Promise<Card[]> {
           {
             role: 'system',
             content:
-              'Return four short phrases representing the action, context, format and constraints in that order, each on its own line. Do not include the words Action, Context, Format or Constraints.',
+              'Provide four short phrases that clearly fit the labels Action, Context, Format and Constraints. Output exactly four lines in that order and prefix each line with the matching label followed by a colon. Example:\nAction: Write a thank you note\nContext: to a colleague\nFormat: as a short poem\nConstraints: under 50 words.',
           },
-          { role: 'user', content: 'Provide the phrases.' },
+          { role: 'user', content: 'Provide the labeled phrases.' },
         ],
         max_tokens: 50,
         temperature: 0.8,


### PR DESCRIPTION
## Summary
- clarify Prompt Recipe Builder's system instructions so that generated cards contain an action, context, format and constraint
- update user message accordingly

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68457c848b8c832fb8b781f90071b42b