### PR TITLE
Embed hero images within game cards

### DIFF
--- a/learning-games/src/components/layout/GamePageLayout.tsx
+++ b/learning-games/src/components/layout/GamePageLayout.tsx
@@ -23,8 +23,10 @@ const GamePageLayout: React.FC<GamePageLayoutProps> = ({
   return (
     <div className="game-page-container">
       <aside className="left-column">
-        <img src={imageSrc} alt={imageAlt} className="game-image" />
-        <div className="info-card">{infoCardContent}</div>
+        <div className="info-card">
+          <img src={imageSrc} alt={imageAlt} className="game-image" />
+          {infoCardContent}
+        </div>
       </aside>
       <main className="right-column">
         <div className="instructions-box">{instructions}</div>

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -47,16 +47,16 @@ export default function ComposeTweetGame() {
   return (
     <div className="compose-page clearfix">
       <InstructionBanner>Guess the Prompt</InstructionBanner>
-      <img
-        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
-        alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
-        className="game-card-image"
-      />
       <div className="compose-wrapper">
         <aside className="compose-sidebar">
           <p className="timer">Time left: {timeLeft}s</p>
         </aside>
         <div className="compose-game">
+          <img
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
+            alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
+            className="game-card-image"
+          />
           <div className="ai-box" aria-live="polite">
             {SAMPLE_RESPONSE}
           </div>

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -318,12 +318,6 @@ export default function Match3Game() {
       <InstructionBanner>
         Match adjectives to explore how tone changes the meaning of a message.
       </InstructionBanner>
-      <img
-        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png"
-        alt="Earlier prompt recipe builder with similar strawberry chef and cards."
-        className="hero-img"
-        style={{ width: '200px' }}
-      />
       <div className="match3-wrapper">
         <aside className="match3-sidebar">
           <h3>Why Tone Matters</h3>
@@ -332,6 +326,12 @@ export default function Match3Game() {
           <p className="sidebar-tip">{sidebarTip}</p>
         </aside>
         <div className="match3-container">
+          <img
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png"
+            alt="Earlier prompt recipe builder with similar strawberry chef and cards."
+            className="hero-img"
+            style={{ width: '200px' }}
+          />
           <ToneMatchGame onComplete={handleComplete} />
         </div>
       </div>

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -207,12 +207,6 @@ export default function PromptDartsGame() {
       <InstructionBanner>
         Choose the clearer prompt that best targets the requested format.
       </InstructionBanner>
-      <img
-        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png"
-        alt="Strawberry throwing dart hitting 'Clear Prompt' bullseye on prompt darts target."
-        className="hero-img"
-        style={{ width: '200px' }}
-      />
       <div className="darts-wrapper">
         <aside className="darts-sidebar">
           <h3>Why Clarity Matters</h3>
@@ -221,6 +215,12 @@ export default function PromptDartsGame() {
           <p className="sidebar-tip">Align prompt language with output types (teaching specificity and clarity).</p>
         </aside>
         <div className="darts-game">
+          <img
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png"
+            alt="Strawberry throwing dart hitting 'Clear Prompt' bullseye on prompt darts target."
+            className="hero-img"
+            style={{ width: '200px' }}
+          />
 
           <h3>Round {round + 1} of {ROUNDS.length}</h3>
 


### PR DESCRIPTION
## Summary
- move hero illustrations inside their game card containers
- keep DragDropGame layout consistent by embedding the sidebar image into the info card

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68457c3b1f64832fa1c0544d1e3f16a4