### PR TITLE
Add streak scoring in Prompt Darts

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -143,12 +143,20 @@ export function checkChoice(_round: DartRound, choice: 'bad' | 'good') {
   return choice === 'good'
 }
 
+export const STREAK_THRESHOLD = 3
+export const STREAK_BONUS = 5
+
+export function streakBonus(streak: number) {
+  return streak > 0 && streak % STREAK_THRESHOLD === 0 ? STREAK_BONUS : 0
+}
+
 export default function PromptDartsGame() {
   const { setScore } = useContext(UserContext)
   const [rounds] = useState<DartRound[]>(() => shuffle(ROUNDS))
   const [round, setRound] = useState(0)
   const [choice, setChoice] = useState<'bad' | 'good' | null>(null)
   const [score, setScoreState] = useState(0)
+  const [streak, setStreak] = useState(0)
 
   const TOTAL_TIME = 15
   const MAX_POINTS = 10
@@ -171,10 +179,21 @@ export default function PromptDartsGame() {
     return () => clearTimeout(id)
   }, [timeLeft, choice])
 
+  useEffect(() => {
+    if (timeLeft === 0 && choice === null) {
+      setStreak(0)
+    }
+  }, [timeLeft, choice])
+
   function handleSelect(option: 'bad' | 'good') {
     setChoice(option)
     if (checkChoice(current, option)) {
-      setScoreState(s => s + pointsLeft)
+      const nextStreak = streak + 1
+      setStreak(nextStreak)
+      const bonus = streakBonus(nextStreak)
+      setScoreState(s => s + pointsLeft + bonus)
+    } else {
+      setStreak(0)
     }
   }
 

--- a/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
+++ b/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { checkChoice, ROUNDS } from '../PromptDartsGame'
+import { checkChoice, ROUNDS, streakBonus } from '../PromptDartsGame'
 
 describe('checkChoice', () => {
   it('returns true only for the clear option', () => {
@@ -13,5 +13,17 @@ describe('checkChoice', () => {
       expect(round.response).toBeDefined()
       expect(typeof round.response).toBe('string')
     }
+  })
+})
+
+describe('streakBonus', () => {
+  it('rewards bonus on streak multiples', () => {
+    expect(streakBonus(3)).toBeGreaterThan(0)
+    expect(streakBonus(6)).toBeGreaterThan(0)
+  })
+
+  it('returns 0 otherwise', () => {
+    expect(streakBonus(1)).toBe(0)
+    expect(streakBonus(2)).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- add streak bonus constants and helper in PromptDartsGame
- reset streak on wrong answer or timeout
- award bonus points every three correct answers
- test streakBonus helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68457e35bc3c832fbff57457af0e20a8