### PR TITLE
Fix progress sidebar scoreboard

### DIFF
--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -32,7 +32,7 @@ export default function ProgressSidebar() {
   }, [])
 
   const leaderboard = scores
-    .concat({ name: user.name ?? 'You', score: user.scores['tone'] ?? 0 })
+    .concat({ name: user.name ?? 'You', score: user.scores['darts'] ?? 0 })
     .sort((a, b) => b.score - a.score)
     .slice(0, 3)
 


### PR DESCRIPTION
## Summary
- show darts scores on the progress sidebar leaderboard

## Testing
- `npm --prefix learning-games run lint`
- `npm --prefix learning-games run test`
- `npm --prefix learning-games run build`


------
https://chatgpt.com/codex/tasks/task_e_68457e3fbc6c832f98339742deba4a6f