### PR TITLE
Add ROUNDS export for darts game

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -245,6 +245,9 @@ export const FALLBACK_ROUNDS: DartRound[] = [
   }
 ]
 
+// TODO: swap this alias for data loaded from `server/darts.json`
+export const ROUNDS: DartRound[] = FALLBACK_ROUNDS
+
 
 export function checkChoice(round: DartRound, index: number) {
   return index === round.correct

--- a/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
+++ b/learning-games/src/pages/__tests__/PromptDartsGame.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { checkChoice, ROUNDS, streakBonus } from '../PromptDartsGame'
+import { checkChoice, ROUNDS, FALLBACK_ROUNDS, streakBonus } from '../PromptDartsGame'
 
 describe('checkChoice', () => {
   it('returns true only for the clear option', () => {


### PR DESCRIPTION
## Summary
- expose `ROUNDS` constant in `PromptDartsGame` and alias to `FALLBACK_ROUNDS`
- update `PromptDartsGame` tests to import `FALLBACK_ROUNDS`

## Testing
- `npm --prefix learning-games test`

------
https://chatgpt.com/codex/tasks/task_e_68458b85504c832fbf380d34ca3c2535