### PR TITLE
Refactor PromptDartsGame to index-based choices

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -245,6 +245,8 @@ export const FALLBACK_ROUNDS: DartRound[] = [
   }
 ]
 
+export const ROUNDS: DartRound[] = FALLBACK_ROUNDS
+
 
 export function checkChoice(round: DartRound, index: number) {
   return index === round.correct
@@ -264,9 +266,9 @@ export default function PromptDartsGame() {
 
   const [round, setRound] = useState(0)
 
-  const [choice, setChoice] = useState<'bad' | 'good' | null>(null)
-  const [order, setOrder] = useState<Array<'bad' | 'good'>>(() =>
-    Math.random() < 0.5 ? ['bad', 'good'] : ['good', 'bad']
+  const [choice, setChoice] = useState<number | null>(null)
+  const [order, setOrder] = useState<number[]>(() =>
+    rounds.length ? shuffle(rounds[0].options.map((_, i) => i)) : []
   )
 
   const [score, setScoreState] = useState(0)
@@ -291,6 +293,7 @@ export default function PromptDartsGame() {
   useEffect(() => {
     setTimeLeft(TOTAL_TIME)
     setPointsLeft(MAX_POINTS)
+    setOrder(shuffle(rounds[round].options.map((_, i) => i)))
 
 
   }, [round, TOTAL_TIME, MAX_POINTS])
@@ -312,9 +315,9 @@ export default function PromptDartsGame() {
     }
   }, [timeLeft, choice])
 
-  function handleSelect(option: 'bad' | 'good') {
-    setChoice(option)
-    if (checkChoice(current, option)) {
+  function handleSelect(index: number) {
+    setChoice(index)
+    if (checkChoice(current, index)) {
       setScoreState(s => s + pointsLeft + streakBonus(streak + 1))
       setStreak(s => s + 1)
       setPenaltyMsg('')
@@ -337,7 +340,7 @@ export default function PromptDartsGame() {
     if (round + 1 < rounds.length) {
       setRound(r => r + 1)
       setChoice(null)
-      setOrder(Math.random() < 0.5 ? ['bad', 'good'] : ['good', 'bad'])
+      setOrder(shuffle(rounds[round + 1].options.map((_, i) => i)))
       setTimeLeft(TOTAL_TIME)
       setPointsLeft(MAX_POINTS)
     } else {
@@ -395,14 +398,14 @@ export default function PromptDartsGame() {
           <div className="options">
 
 
-            {order.map(opt => (
+            {order.map(i => (
               <button
-                key={opt}
+                key={i}
                 className="btn-primary"
-                onClick={() => handleSelect(opt)}
+                onClick={() => handleSelect(i)}
                 disabled={choice !== null}
               >
-                {current[opt]}
+                {highlightPrompt(current.options[i])}
 
               </button>
             ))}
@@ -412,11 +415,11 @@ export default function PromptDartsGame() {
 
             <>
               <p className="feedback">
-                {checkChoice(current, choice)
+                {checkChoice(current, choice!)
                   ? 'Correct! Clear prompts hit the bullseye.'
                   : 'Not quite. Aim for specific wording.'}
               </p>
-              {penaltyMsg && !checkChoice(current, choice) && (
+              {penaltyMsg && !checkChoice(current, choice!) && (
                 <p className="penalty">{penaltyMsg}</p>
               )}
 


### PR DESCRIPTION
## Summary
- update `PromptDartsGame` to work with `options`/`correct` data
- shuffle numeric option order each round
- update selection handling to use indexes

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68458b86ea90832fa4f01c6627c8f393