### PR TITLE
Fix swapped images for Tone and tweet games

### DIFF
--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -53,8 +53,8 @@ export default function ComposeTweetGame() {
         </aside>
         <div className="compose-game">
           <img
-            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
-            alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png"
+            alt="Earlier prompt recipe builder with similar strawberry chef and cards."
             className="game-card-image"
           />
           <div className="ai-box" aria-live="polite">

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -327,8 +327,8 @@ export default function Match3Game() {
         </aside>
         <div className="match3-container">
           <img
-            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png"
-            alt="Earlier prompt recipe builder with similar strawberry chef and cards."
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
+            alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
             className="hero-img"
             style={{ width: '200px' }}
           />

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -330,12 +330,6 @@ export default function PromptDartsGame() {
     }
   }
 
-  function handleHint() {
-    if (hintUsed) return
-    setHintUsed(true)
-    setShowHint(true)
-    setPointsLeft(p => Math.max(0, p - 2))
-  }
 
   function next() {
     if (round + 1 < rounds.length) {


### PR DESCRIPTION
## Summary
- swap hero images between ComposeTweetGame and Match3Game
- remove unused `handleHint` to satisfy lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68458d933690832f902ada1508050966