### PR TITLE
Implement scoring for ComposeTweetGame

### DIFF
--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { scorePrompt } from '../utils/scorePrompt'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import './ComposeTweetGame.css'
@@ -6,6 +7,7 @@ import './ComposeTweetGame.css'
 const SAMPLE_RESPONSE =
   'Just finished reading an amazing book on technology! Highly recommend it to everyone. #BookLovers'
 const CORRECT_PROMPT = 'Compose a tweet about reading a new book'
+const SCORE_THRESHOLD = 20
 
 export default function ComposeTweetGame() {
   const [guess, setGuess] = useState('')
@@ -30,12 +32,13 @@ export default function ComposeTweetGame() {
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (guess.trim().toLowerCase() === CORRECT_PROMPT.toLowerCase()) {
+    const { score, tips } = scorePrompt(CORRECT_PROMPT, guess)
+    if (score >= SCORE_THRESHOLD) {
       setFeedback('Correct! The door is unlocked.')
       setDoorUnlocked(true)
       clearInterval(timerRef.current!)
     } else {
-      setFeedback('Incorrect guess, try again.')
+      setFeedback(tips.join(' '))
     }
     setGuess('')
   }

--- a/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
+++ b/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import ComposeTweetGame from '../ComposeTweetGame'
 
@@ -11,12 +11,24 @@ function setup() {
   )
 }
 
+afterEach(() => {
+  cleanup()
+})
+
 describe('ComposeTweetGame', () => {
-  it('unlocks door when prompt guessed correctly', () => {
+  it('unlocks door when prompt score is high enough', () => {
     const { getByLabelText, getByRole, getByText } = setup()
     const input = getByLabelText(/input your guess/i)
-    fireEvent.change(input, { target: { value: 'Compose a tweet about reading a new book' } })
+    fireEvent.change(input, { target: { value: 'Write a quick tweet about reading a new book' } })
     fireEvent.click(getByRole('button', { name: /submit your guess/i }))
     expect(getByText(/door is unlocked/i)).toBeTruthy()
+  })
+
+  it('shows tips when guess is not close enough', () => {
+    const { getByLabelText, getByRole, getByText } = setup()
+    const input = getByLabelText(/input your guess/i)
+    fireEvent.change(input, { target: { value: 'hello world' } })
+    fireEvent.click(getByRole('button', { name: /submit your guess/i }))
+    expect(getByText(/include key words/i)).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- add scoring logic with `scorePrompt` in ComposeTweetGame
- unlock the door only if score >= threshold
- provide scoring tips when guess score too low
- update tests for new scoring behaviour

## Testing
- `npm --prefix learning-games test`

------
https://chatgpt.com/codex/tasks/task_e_68458f7ff824832f976f238ecabef548