### PR TITLE
Add compose score tracking

### DIFF
--- a/learning-games/src/data/badges.ts
+++ b/learning-games/src/data/badges.ts
@@ -52,4 +52,10 @@ export const BADGES: BadgeDefinition[] = [
     description: 'Spot five lies in a row in the Hallucinations quiz',
     emoji: '🔎',
   },
+  {
+    id: 'speedy-composer',
+    name: 'Speedy Composer',
+    description: 'Unlock the tweet door with 20 seconds left',
+    emoji: '🚀',
+  },
 ]

--- a/learning-games/src/pages/ComposeTweetGame.css
+++ b/learning-games/src/pages/ComposeTweetGame.css
@@ -62,6 +62,11 @@
   color: var(--color-orange);
 }
 
+.final-score {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
 @media (max-width: 600px) {
   .compose-wrapper {
     grid-template-columns: 1fr;

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useContext } from 'react'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import { UserContext } from '../context/UserContext'
 import './ComposeTweetGame.css'
 
 const SAMPLE_RESPONSE =
@@ -8,10 +9,12 @@ const SAMPLE_RESPONSE =
 const CORRECT_PROMPT = 'Compose a tweet about reading a new book'
 
 export default function ComposeTweetGame() {
+  const { setScore, addBadge, user } = useContext(UserContext)
   const [guess, setGuess] = useState('')
   const [feedback, setFeedback] = useState('')
   const [doorUnlocked, setDoorUnlocked] = useState(false)
   const [timeLeft, setTimeLeft] = useState(30)
+  const [score, setScoreState] = useState<number | null>(null)
   const timerRef = useRef<number | null>(null)
 
   useEffect(() => {
@@ -31,9 +34,15 @@ export default function ComposeTweetGame() {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (guess.trim().toLowerCase() === CORRECT_PROMPT.toLowerCase()) {
-      setFeedback('Correct! The door is unlocked.')
+      const points = timeLeft
+      setFeedback(`Correct! The door is unlocked. You scored ${points} points.`)
       setDoorUnlocked(true)
+      setScoreState(points)
       clearInterval(timerRef.current!)
+      setScore('compose', points)
+      if (points >= 20 && !user.badges.includes('speedy-composer')) {
+        addBadge('speedy-composer')
+      }
     } else {
       setFeedback('Incorrect guess, try again.')
     }
@@ -82,6 +91,11 @@ export default function ComposeTweetGame() {
             </button>
           </form>
           {feedback && <p className="feedback">{feedback}</p>}
+          {score !== null && (
+            <p className="final-score" aria-live="polite">
+              Your score: {score}
+            </p>
+          )}
           <div className="door-area">
             <img
               src={doorUnlocked ? '/images/door-open.png' : '/images/door-closed.png'}

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -20,6 +20,11 @@ export default function LeaderboardPage() {
 
   const [scores, setScores] = useState<Record<string, ScoreEntry[]>>({})
   const [game, setGame] = useState('tone')
+  const tabs = useMemo(() => {
+    const base = ['tone', 'quiz', 'darts', 'recipe', 'escape', 'compose']
+    const dynamic = Object.keys(scores)
+    return Array.from(new Set([...base, ...dynamic]))
+  }, [scores])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -63,7 +68,7 @@ export default function LeaderboardPage() {
         <h2>Leaderboard</h2>
         <section className="leaderboard-card">
           <div className="game-tabs">
-            {Object.keys(scores).map(key => (
+            {tabs.map(key => (
               <button
                 key={key}
                 className={game === key ? 'active' : undefined}

--- a/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
+++ b/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
@@ -2,11 +2,14 @@ import { describe, it, expect } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import ComposeTweetGame from '../ComposeTweetGame'
+import { UserProvider } from '../../context/UserProvider'
 
 function setup() {
   return render(
     <MemoryRouter>
-      <ComposeTweetGame />
+      <UserProvider>
+        <ComposeTweetGame />
+      </UserProvider>
     </MemoryRouter>
   )
 }


### PR DESCRIPTION
## Summary
- award a new `speedy-composer` badge
- track and show a score in `ComposeTweetGame`
- include compose game in leaderboard tabs
- update unit test for new context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458f81e4c8832f9bf4681144c7949b