### PR TITLE
Add accessible prompt tips

### DIFF
--- a/learning-games/src/pages/ComposeTweetGame.css
+++ b/learning-games/src/pages/ComposeTweetGame.css
@@ -57,6 +57,12 @@
   text-align: center;
 }
 
+.prompt-tip {
+  font-weight: bold;
+  color: var(--color-accent);
+  margin-top: 0.5rem;
+}
+
 .timer {
   font-weight: bold;
   color: var(--color-orange);

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -7,10 +7,19 @@ const SAMPLE_RESPONSE =
   'Just finished reading an amazing book on technology! Highly recommend it to everyone. #BookLovers'
 const CORRECT_PROMPT = 'Compose a tweet about reading a new book'
 
+const PROMPT_TIPS = [
+  'Be specific about what you want the AI to do.',
+  'Provide context so the AI understands your request.',
+  'Break complex tasks into clear steps.',
+  'State the desired length or format.',
+  'Offer examples to show the style you expect.',
+]
+
 export default function ComposeTweetGame() {
   const [guess, setGuess] = useState('')
   const [feedback, setFeedback] = useState('')
   const [doorUnlocked, setDoorUnlocked] = useState(false)
+  const [tipIndex, setTipIndex] = useState(0)
   const [timeLeft, setTimeLeft] = useState(30)
   const timerRef = useRef<number | null>(null)
 
@@ -33,6 +42,7 @@ export default function ComposeTweetGame() {
     if (guess.trim().toLowerCase() === CORRECT_PROMPT.toLowerCase()) {
       setFeedback('Correct! The door is unlocked.')
       setDoorUnlocked(true)
+      setTipIndex(i => (i + 1) % PROMPT_TIPS.length)
       clearInterval(timerRef.current!)
     } else {
       setFeedback('Incorrect guess, try again.')
@@ -96,6 +106,11 @@ export default function ComposeTweetGame() {
                 className="hero-img"
                 style={{ width: '200px' }}
               />
+            )}
+            {doorUnlocked && (
+              <p className="prompt-tip" role="status" aria-live="polite">
+                {PROMPT_TIPS[tipIndex]}
+              </p>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show a new prompt tip message beneath the unlocked door image
- style the new tip text

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68458f824fe4832f98fb5ba3c5de245d