### PR TITLE
Add rounds to ComposeTweetGame

### DIFF
--- a/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
+++ b/learning-games/src/pages/__tests__/ComposeTweetGame.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import ComposeTweetGame from '../ComposeTweetGame'
@@ -11,11 +11,19 @@ function setup() {
   )
 }
 
+beforeEach(() => {
+  vi.spyOn(Math, 'random').mockReturnValue(0)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
 describe('ComposeTweetGame', () => {
   it('unlocks door when prompt guessed correctly', () => {
     const { getByLabelText, getByRole, getByText } = setup()
     const input = getByLabelText(/input your guess/i)
-    fireEvent.change(input, { target: { value: 'Compose a tweet about reading a new book' } })
+    fireEvent.change(input, { target: { value: 'Write a tweet announcing our summer sale starting June 1st' } })
     fireEvent.click(getByRole('button', { name: /submit your guess/i }))
     expect(getByText(/door is unlocked/i)).toBeTruthy()
   })


### PR DESCRIPTION
## Summary
- randomize ComposeTweetGame prompts using shuffle
- cycle through multiple prompt/response pairs
- update ComposeTweetGame test for new behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458f84fcec832f850b1a1b94dd030c