### PR TITLE
Enhance semantic scoring

### DIFF
--- a/learning-games/src/utils/scorePrompt.ts
+++ b/learning-games/src/utils/scorePrompt.ts
@@ -7,6 +7,26 @@ const ACTION_WORDS = ['write','tell','show','give','describe','explain','summari
 const DESCRIPTIVE = /simple|quick|short|daily|weekly|fun|persuasive/
 const CONTEXT_REGEX = /\d+|teacher|teen|student|man|python|cell|water|french/
 
+function tokenize(text: string): string[] {
+  return text.toLowerCase().split(/\W+/).filter(Boolean)
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, val, i) => sum + val * (b[i] || 0), 0)
+  const magA = Math.sqrt(a.reduce((sum, val) => sum + val * val, 0))
+  const magB = Math.sqrt(b.reduce((sum, val) => sum + val * val, 0))
+  return magA && magB ? dot / (magA * magB) : 0
+}
+
+function semanticSimilarity(a: string, b: string): number {
+  const tokensA = tokenize(a)
+  const tokensB = tokenize(b)
+  const vocab = Array.from(new Set([...tokensA, ...tokensB]))
+  const vectorA = vocab.map(tok => tokensA.filter(t => t === tok).length)
+  const vectorB = vocab.map(tok => tokensB.filter(t => t === tok).length)
+  return cosineSimilarity(vectorA, vectorB)
+}
+
 export function scorePrompt(expected: string, guess: string): ScoreDetails {
   const normGuess = guess.toLowerCase()
   const normExpected = expected.toLowerCase()
@@ -35,6 +55,11 @@ export function scorePrompt(expected: string, guess: string): ScoreDetails {
     score += 5
   } else {
     tips.push('Start with an action word like "write" or "describe"')
+  }
+
+  const similarity = semanticSimilarity(normExpected, normGuess)
+  if (similarity > 0.6) {
+    score += 5
   }
 
   if (DESCRIPTIVE.test(normGuess)) {


### PR DESCRIPTION
## Summary
- add light-weight embedding and cosine similarity helpers
- award extra points for semantically similar prompts

## Testing
- `cd learning-games && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684593c0bfec832fbc58aefd77ae29ba