### PR TITLE
Add AI hints to Clarity Escape Room

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -116,6 +116,7 @@ export default function ClarityEscapeRoom() {
   const [showNext, setShowNext] = useState(false)
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
+  const [aiHint, setAiHint] = useState('')
   const startRef = useRef(Date.now())
 
   const clue = doors[index]
@@ -123,6 +124,7 @@ export default function ClarityEscapeRoom() {
   useEffect(() => {
     setTimeLeft(30)
     startRef.current = Date.now()
+    setAiHint('')
     const id = setInterval(() => {
       setTimeLeft(t => {
         if (t <= 1) {
@@ -159,6 +161,41 @@ export default function ClarityEscapeRoom() {
     return () => window.removeEventListener('keydown', onKey)
   }, [revealHint])
 
+  async function fetchAiHint(guess: string) {
+    try {
+      const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'Provide a single short hint referencing the user\'s guess without revealing the answer.',
+            },
+            {
+              role: 'user',
+              content: `The correct prompt is "${clue.expectedPrompt}". The user guessed "${guess}". Give a helpful hint in under 15 words.`,
+            },
+          ],
+          max_tokens: 30,
+          temperature: 0.7,
+        }),
+      })
+      const data = await resp.json()
+      const hintText: string | undefined = data?.choices?.[0]?.message?.content
+      if (hintText) {
+        setAiHint(hintText.trim())
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     const { score, tips } = scorePrompt(clue.expectedPrompt, input.trim())
@@ -171,10 +208,13 @@ export default function ClarityEscapeRoom() {
       setStatus('success')
       setOpenPercent(((index + 1) / TOTAL_STEPS) * 100)
       setShowNext(true)
+      setAiHint('')
     } else {
       const tipText = tips.join(' ')
       setMessage(`Too vague. ${tipText}`)
       setStatus('error')
+      setAiHint('')
+      fetchAiHint(input.trim())
     }
   }
 
@@ -186,6 +226,7 @@ export default function ClarityEscapeRoom() {
       setStatus('')
       setHintIndex(0)
       setHintCount(0)
+      setAiHint('')
       setShowNext(false)
     } else {
       setScore('escape', points)
@@ -227,6 +268,11 @@ export default function ClarityEscapeRoom() {
                       <span className="hint-text">{h}</span>
                     </Tooltip>
                   ))}
+                  {aiHint && (
+                    <Tooltip message={aiHint}>
+                      <span className="hint-text">{aiHint}</span>
+                    </Tooltip>
+                  )}
                 </div>
               )}
               {message && (

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -41,7 +41,6 @@ export default function ComposeTweetGame() {
 
   const [round, setRound] = useState(0)
   const [showNext, setShowNext] = useState(false)
-  const [points, setPoints] = useState(0)
 
   const [score, setScoreState] = useState<number | null>(null)
 
@@ -80,7 +79,6 @@ export default function ComposeTweetGame() {
       setFeedback('Correct! The door is unlocked.')
       setDoorUnlocked(true)
       const earned = guessScore + timeLeft
-      setPoints(earned)
       setScoreState(earned)
       clearInterval(timerRef.current!)
       setScore('compose', earned)


### PR DESCRIPTION
## Summary
- fetch a short hint from OpenAI when guesses score under 20
- show the hint in the tooltip area
- clear AI hints when progressing to the next challenge
- fix lint error in `ComposeTweetGame`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684593d1c0ec832f9cf5d561c88ad6b0