### PR TITLE
Add dynamic room text when unlocking doors

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -77,6 +77,10 @@
   font-weight: bold;
   margin-bottom: 0.5rem;
 }
+.room-desc {
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}
 
 .escape-sidebar {
   grid-area: sidebar;

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -9,6 +9,7 @@ import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './ClarityEscapeRoom.css'
 import { scorePrompt } from '../utils/scorePrompt'
+import { generateRoomDescription } from '../utils/generateRoomDescription'
 
 interface Clue {
   aiResponse: string
@@ -116,6 +117,7 @@ export default function ClarityEscapeRoom() {
   const [showNext, setShowNext] = useState(false)
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
+  const [roomDescription, setRoomDescription] = useState('')
   const startRef = useRef(Date.now())
 
   const clue = doors[index]
@@ -171,6 +173,7 @@ export default function ClarityEscapeRoom() {
       setStatus('success')
       setOpenPercent(((index + 1) / TOTAL_STEPS) * 100)
       setShowNext(true)
+      generateRoomDescription().then(setRoomDescription)
     } else {
       const tipText = tips.join(' ')
       setMessage(`Too vague. ${tipText}`)
@@ -186,6 +189,7 @@ export default function ClarityEscapeRoom() {
       setStatus('')
       setHintIndex(0)
       setHintCount(0)
+      setRoomDescription('')
       setShowNext(false)
     } else {
       setScore('escape', points)
@@ -231,6 +235,9 @@ export default function ClarityEscapeRoom() {
               )}
               {message && (
                 <p className={`feedback ${status}`}>{status === 'success' ? '✔️' : '⚠️'} {message}</p>
+              )}
+              {roomDescription && (
+                <p className="room-desc" aria-live="polite">{roomDescription}</p>
               )}
               {showNext && (
                 <div className="next-area">

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -41,7 +41,6 @@ export default function ComposeTweetGame() {
 
   const [round, setRound] = useState(0)
   const [showNext, setShowNext] = useState(false)
-  const [points, setPoints] = useState(0)
 
   const [score, setScoreState] = useState<number | null>(null)
 
@@ -80,7 +79,6 @@ export default function ComposeTweetGame() {
       setFeedback('Correct! The door is unlocked.')
       setDoorUnlocked(true)
       const earned = guessScore + timeLeft
-      setPoints(earned)
       setScoreState(earned)
       clearInterval(timerRef.current!)
       setScore('compose', earned)

--- a/learning-games/src/utils/generateRoomDescription.ts
+++ b/learning-games/src/utils/generateRoomDescription.ts
@@ -1,0 +1,32 @@
+export async function generateRoomDescription(): Promise<string> {
+  try {
+    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You create short, vivid scene descriptions for an escape room game. Keep it under 20 words.',
+          },
+          { role: 'user', content: 'Describe the next room the player enters.' },
+        ],
+        max_tokens: 40,
+        temperature: 0.7,
+      }),
+    })
+    const data = await resp.json()
+    const text: string | undefined = data?.choices?.[0]?.message?.content?.trim()
+    if (text) {
+      return text
+    }
+  } catch (err) {
+    console.error(err)
+  }
+  return 'A dim corridor leads to a chamber smelling of old parchment.'
+}


### PR DESCRIPTION
## Summary
- generate short scene text for the next room using OpenAI
- call the generator on door unlock in **ClarityEscapeRoom**
- show the new description before the next challenge
- reset the text between rounds
- fix an unused variable warning in **ComposeTweetGame**

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684593d33150832fb3c5333b564f7992