### PR TITLE
Add escape room round summaries

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -167,3 +167,37 @@
     max-width: none;
   }
 }
+
+.summary-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.summary-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+.summary-modal ul {
+  list-style: none;
+  padding: 0;
+}
+.summary-modal li {
+  margin-bottom: 1rem;
+}
+.summary-modal .tip {
+  font-style: italic;
+}

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -117,6 +117,8 @@ export default function ClarityEscapeRoom() {
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
   const startRef = useRef(Date.now())
+  const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
+  const [showSummary, setShowSummary] = useState(false)
 
   const clue = doors[index]
 
@@ -179,6 +181,9 @@ export default function ClarityEscapeRoom() {
   }
 
   function nextChallenge() {
+    const { tips } = scorePrompt(clue.expectedPrompt, input.trim())
+    const tip = tips[0] || 'Aim for a clearer prompt next time.'
+    setRounds(r => [...r, { prompt: input.trim(), expected: clue.expectedPrompt, tip }])
     if (index + 1 < TOTAL_STEPS) {
       setIndex(i => i + 1)
       setInput('')
@@ -189,7 +194,7 @@ export default function ClarityEscapeRoom() {
       setShowNext(false)
     } else {
       setScore('escape', points)
-      navigate('/leaderboard')
+      setShowSummary(true)
     }
   }
 
@@ -246,6 +251,25 @@ export default function ClarityEscapeRoom() {
         </div>
         <ProgressSidebar />
       </div>
+      {showSummary && (
+        <div className="summary-overlay" onClick={() => setShowSummary(false)}>
+          <div className="summary-modal" onClick={e => e.stopPropagation()}>
+            <h3>Round Summary</h3>
+            <ul>
+              {rounds.map((r, i) => (
+                <li key={i}>
+                  <p><strong>Your Prompt:</strong> {r.prompt || '(none)'}</p>
+                  <p><strong>Expected:</strong> {r.expected}</p>
+                  <p className="tip"><strong>Tip:</strong> {r.tip}</p>
+                </li>
+              ))}
+            </ul>
+            <button className="btn-primary" onClick={() => navigate('/leaderboard')}>
+              View Leaderboard
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -41,7 +41,6 @@ export default function ComposeTweetGame() {
 
   const [round, setRound] = useState(0)
   const [showNext, setShowNext] = useState(false)
-  const [points, setPoints] = useState(0)
 
   const [score, setScoreState] = useState<number | null>(null)
 
@@ -80,7 +79,6 @@ export default function ComposeTweetGame() {
       setFeedback('Correct! The door is unlocked.')
       setDoorUnlocked(true)
       const earned = guessScore + timeLeft
-      setPoints(earned)
       setScoreState(earned)
       clearInterval(timerRef.current!)
       setScore('compose', earned)

--- a/learning-games/src/pages/PromptGuessEscape.css
+++ b/learning-games/src/pages/PromptGuessEscape.css
@@ -93,3 +93,37 @@
       'progress';
   }
 }
+
+.summary-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.summary-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+.summary-modal ul {
+  list-style: none;
+  padding: 0;
+}
+.summary-modal li {
+  margin-bottom: 1rem;
+}
+.summary-modal .tip {
+  font-style: italic;
+}

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -117,6 +117,8 @@ export default function PromptGuessEscape() {
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
   const startRef = useRef(Date.now())
+  const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
+  const [showSummary, setShowSummary] = useState(false)
 
   const clue = doors[index]
 
@@ -179,6 +181,9 @@ export default function PromptGuessEscape() {
   }
 
   function nextChallenge() {
+    const { tips } = scorePrompt(clue.expectedPrompt, input.trim())
+    const tip = tips[0] || 'Aim for a clearer prompt next time.'
+    setRounds(r => [...r, { prompt: input.trim(), expected: clue.expectedPrompt, tip }])
     if (index + 1 < TOTAL_STEPS) {
       setIndex(i => i + 1)
       setInput('')
@@ -189,7 +194,7 @@ export default function PromptGuessEscape() {
       setShowNext(false)
     } else {
       setScore('escape', points)
-      navigate('/leaderboard')
+      setShowSummary(true)
     }
   }
 
@@ -241,6 +246,25 @@ export default function PromptGuessEscape() {
         </div>
         <ProgressSidebar />
       </div>
+      {showSummary && (
+        <div className="summary-overlay" onClick={() => setShowSummary(false)}>
+          <div className="summary-modal" onClick={e => e.stopPropagation()}>
+            <h3>Round Summary</h3>
+            <ul>
+              {rounds.map((r, i) => (
+                <li key={i}>
+                  <p><strong>Your Prompt:</strong> {r.prompt || '(none)'}</p>
+                  <p><strong>Expected:</strong> {r.expected}</p>
+                  <p className="tip"><strong>Tip:</strong> {r.tip}</p>
+                </li>
+              ))}
+            </ul>
+            <button className="btn-primary" onClick={() => navigate('/leaderboard')}>
+              View Leaderboard
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- capture the player's prompt, expected prompt, and a short tip after each door
- show a modal summary when all doors are finished
- tweak ComposeTweetGame to remove unused state

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684593d4e808832f929c9e6cf1ec2079