### PR TITLE
Fix darts leaderboard entry

### DIFF
--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -174,7 +174,7 @@ export default function DragDropGame() {
           totalPoints={totalPoints}
           badgesEarned={badgesEarned}
           goalPoints={300}
-          topScores={[{ name: 'You', points: user.scores['tone'] ?? 0 }]}
+          topScores={[{ name: 'You', points: user.scores['darts'] ?? 0 }]}
         />
       </div>
       <div className="next-area">


### PR DESCRIPTION
## Summary
- ensure darts score is displayed in DragDrop game sidebar

## Testing
- `npm test` *(fails: roomDescription is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684596355228832fa2201167704cc7f9