### PR TITLE
Increase base font size and add tooltip

### DIFF
--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import Tooltip from '../ui/Tooltip'
+import ThemeToggle from './ThemeToggle'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
@@ -15,6 +16,9 @@ export default function NavBar() {
         />
         StrawberryTech
       </div>
+      <Tooltip message="Improve readability">
+        <ThemeToggle />
+      </Tooltip>
       <button
         className="menu-toggle"
         aria-label="Toggle navigation"

--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -54,6 +54,7 @@ body {
   min-height: 100vh;
   padding: 0 1rem;
   font-family: 'Roboto', sans-serif;
+  font-size: 18px;
 }
 
 h1,

--- a/learning-games/src/pages/SplashPage.css
+++ b/learning-games/src/pages/SplashPage.css
@@ -26,7 +26,7 @@
 .start-btn {
   font-family: 'Roboto', sans-serif;
   font-weight: bold;
-  font-size: 16px;
+  font-size: 1rem;
   background: var(--color-accent);
   min-width: 44px;
   min-height: 44px;


### PR DESCRIPTION
## Summary
- enlarge default body font in `index.css`
- adjust `SplashPage` button size to use rem units
- show a tooltip around the `ThemeToggle` in the nav bar

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845963def94832f862337dd2bb98a51