### PR TITLE
Randomize prompt order in darts game

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -289,9 +289,6 @@ export default function ClarityEscapeRoom() {
               {message && (
                 <p className={`feedback ${status}`}>{status === 'success' ? '✔️' : '⚠️'} {message}</p>
               )}
-              {roomDescription && (
-                <p className="room-desc" aria-live="polite">{roomDescription}</p>
-              )}
               {showNext && (
                 <div className="next-area">
                   <button className="btn-primary" onClick={nextChallenge}>Next Challenge</button>

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -268,8 +268,8 @@ export default function PromptDartsGame() {
   const [round, setRound] = useState(0)
 
   const [choice, setChoice] = useState<number | null>(null)
-  const [order, setOrder] = useState<number[]>(() =>
-    rounds.length ? shuffle(rounds[0].options.map((_, i) => i)) : []
+  const [choices, setChoices] = useState<string[]>(() =>
+    rounds.length ? shuffle([...rounds[0].options]) : []
   )
 
   const [score, setScoreState] = useState(0)
@@ -294,7 +294,7 @@ export default function PromptDartsGame() {
   useEffect(() => {
     setTimeLeft(TOTAL_TIME)
     setPointsLeft(MAX_POINTS)
-    setOrder(shuffle(rounds[round].options.map((_, i) => i)))
+    setChoices(shuffle([...rounds[round].options]))
 
 
   }, [round, TOTAL_TIME, MAX_POINTS])
@@ -317,8 +317,9 @@ export default function PromptDartsGame() {
   }, [timeLeft, choice])
 
   function handleSelect(index: number) {
-    setChoice(index)
-    if (checkChoice(current, index)) {
+    const originalIndex = current.options.indexOf(choices[index])
+    setChoice(originalIndex)
+    if (checkChoice(current, originalIndex)) {
       setScoreState(s => s + pointsLeft + streakBonus(streak + 1))
       setStreak(s => s + 1)
       setPenaltyMsg('')
@@ -335,7 +336,7 @@ export default function PromptDartsGame() {
     if (round + 1 < rounds.length) {
       setRound(r => r + 1)
       setChoice(null)
-      setOrder(shuffle(rounds[round + 1].options.map((_, i) => i)))
+      setChoices(shuffle([...rounds[round + 1].options]))
       setTimeLeft(TOTAL_TIME)
       setPointsLeft(MAX_POINTS)
     } else {
@@ -393,14 +394,14 @@ export default function PromptDartsGame() {
           <div className="options">
 
 
-            {order.map(i => (
+            {choices.map((text, i) => (
               <button
                 key={i}
                 className="btn-primary"
                 onClick={() => handleSelect(i)}
                 disabled={choice !== null}
               >
-                {highlightPrompt(current.options[i])}
+                {highlightPrompt(text)}
 
               </button>
             ))}


### PR DESCRIPTION
## Summary
- randomize the prompt options using a `choices` state array
- fix undefined variable in `ClarityEscapeRoom` tests

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845962ee7fc832fbb591cf6d5c63c75