### PR TITLE
Fetch prompt darts rounds

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -263,14 +263,11 @@ export function streakBonus(streak: number) {
 export default function PromptDartsGame() {
 
   const { setScore, user } = useContext(UserContext)
-  const [rounds] = useState<DartRound[]>(() => shuffle(ROUNDS))
-
+  const [rounds, setRounds] = useState<DartRound[]>([])
   const [round, setRound] = useState(0)
 
   const [choice, setChoice] = useState<number | null>(null)
-  const [order, setOrder] = useState<number[]>(() =>
-    rounds.length ? shuffle(rounds[0].options.map((_, i) => i)) : []
-  )
+  const [order, setOrder] = useState<number[]>([])
 
   const [score, setScoreState] = useState(0)
   const [streak, setStreak] = useState(0)
@@ -289,15 +286,39 @@ export default function PromptDartsGame() {
 
   const current = rounds[round]
 
+  // Load rounds from the server on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      setRounds(shuffle(ROUNDS))
+      return
+    }
+    const base = window.location.origin
+    fetch(`${base}/api/darts`)
+      .then(res => (res.ok ? res.json() : null))
+      .then(data => {
+        if (Array.isArray(data) && data.length) {
+          const fetched = data.map((r: any) => ({
+            options: r.options ?? [r.bad, r.good].filter(Boolean),
+            correct: typeof r.correct === 'number' ? r.correct : 1,
+            why: r.why ?? '',
+            response: r.response ?? ''
+          })) as DartRound[]
+          setRounds(shuffle(fetched))
+        } else {
+          setRounds(shuffle(ROUNDS))
+        }
+      })
+      .catch(() => setRounds(shuffle(ROUNDS)))
+  }, [])
+
 
 
   useEffect(() => {
+    if (!rounds.length) return
     setTimeLeft(TOTAL_TIME)
     setPointsLeft(MAX_POINTS)
     setOrder(shuffle(rounds[round].options.map((_, i) => i)))
-
-
-  }, [round, TOTAL_TIME, MAX_POINTS])
+  }, [round, TOTAL_TIME, MAX_POINTS, rounds])
 
 
 


### PR DESCRIPTION
## Summary
- load dart rounds from server if available
- initialize options after rounds load

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint package)*

------
https://chatgpt.com/codex/tasks/task_e_6845963ff050832f86177d24423c6195