### PR TITLE
Add hint button to prompt darts game

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -9,7 +9,6 @@ import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './ClarityEscapeRoom.css'
 import { scorePrompt } from '../utils/scorePrompt'
-import { generateRoomDescription } from '../utils/generateRoomDescription'
 
 interface Clue {
   aiResponse: string
@@ -288,9 +287,6 @@ export default function ClarityEscapeRoom() {
               )}
               {message && (
                 <p className={`feedback ${status}`}>{status === 'success' ? '✔️' : '⚠️'} {message}</p>
-              )}
-              {roomDescription && (
-                <p className="room-desc" aria-live="polite">{roomDescription}</p>
               )}
               {showNext && (
                 <div className="next-area">

--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -73,6 +73,15 @@
 
 }
 
+.hint-text {
+  display: inline-block;
+  background: var(--color-background);
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin: 0.5rem 0;
+}
+
 .hint-highlight {
   background: var(--color-yellow);
   padding: 0 2px;

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -276,7 +276,11 @@ export default function PromptDartsGame() {
   const [streak, setStreak] = useState(0)
   const [penaltyMsg, setPenaltyMsg] = useState('')
 
+  const [hint, setHint] = useState<string | null>(null)
+  const [hintUsed, setHintUsed] = useState(false)
+
   const PENALTY = 2
+  const HINT_PENALTY = 2
 
 
   const TOTAL_TIME =
@@ -295,9 +299,10 @@ export default function PromptDartsGame() {
     setTimeLeft(TOTAL_TIME)
     setPointsLeft(MAX_POINTS)
     setOrder(shuffle(rounds[round].options.map((_, i) => i)))
+    setHint(null)
+    setHintUsed(false)
 
-
-  }, [round, TOTAL_TIME, MAX_POINTS])
+  }, [round, TOTAL_TIME, MAX_POINTS, rounds])
 
 
 
@@ -330,6 +335,14 @@ export default function PromptDartsGame() {
     }
   }
 
+  function revealHint() {
+    if (hintUsed) return
+    const clue = current.why.split(' ').slice(0, 6).join(' ')
+    setHint(clue + (current.why.split(' ').length > 6 ? '...' : ''))
+    setHintUsed(true)
+    setPointsLeft(p => Math.max(0, p - HINT_PENALTY))
+  }
+
 
   function next() {
     if (round + 1 < rounds.length) {
@@ -338,6 +351,8 @@ export default function PromptDartsGame() {
       setOrder(shuffle(rounds[round + 1].options.map((_, i) => i)))
       setTimeLeft(TOTAL_TIME)
       setPointsLeft(MAX_POINTS)
+      setHint(null)
+      setHintUsed(false)
     } else {
       setScore('darts', score)
       setRound(r => r + 1)
@@ -406,6 +421,14 @@ export default function PromptDartsGame() {
             ))}
 
           </div>
+          <button
+            className="btn-primary"
+            onClick={revealHint}
+            disabled={hintUsed || choice !== null}
+          >
+            Hint
+          </button>
+          {hint && <p className="hint-text">{hint}</p>}
           {choice !== null && (
 
             <>


### PR DESCRIPTION
## Summary
- add hint functionality to Prompt Darts
- reduce points when a hint is used
- clean up unused code in Clarity Escape Room

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684596429c08832fb52da2c957a3d682