### PR TITLE
Add TimerBar progress component

### DIFF
--- a/learning-games/src/components/ui/TimerBar.css
+++ b/learning-games/src/components/ui/TimerBar.css
@@ -1,0 +1,13 @@
+.timer-bar {
+  width: 100%;
+  height: 0.5rem;
+  background: var(--color-secondary);
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 0.5rem 0;
+}
+
+.timer-bar-fill {
+  height: 100%;
+  transition: width 0.3s ease;
+}

--- a/learning-games/src/components/ui/TimerBar.tsx
+++ b/learning-games/src/components/ui/TimerBar.tsx
@@ -1,0 +1,19 @@
+import './TimerBar.css'
+
+export interface TimerBarProps {
+  timeLeft: number
+  TOTAL_TIME: number
+}
+
+export default function TimerBar({ timeLeft, TOTAL_TIME }: TimerBarProps) {
+  const percent = (timeLeft / TOTAL_TIME) * 100
+  const danger = timeLeft <= 5
+  return (
+    <div className="timer-bar" role="progressbar" aria-valuemin={0} aria-valuemax={TOTAL_TIME} aria-valuenow={timeLeft}>
+      <div
+        className="timer-bar-fill"
+        style={{ width: `${percent}%`, backgroundColor: danger ? 'var(--color-deep-red)' : 'var(--color-brand)' }}
+      />
+    </div>
+  )
+}

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -2,6 +2,7 @@ import { useState, useContext, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
+import TimerBar from '../components/ui/TimerBar'
 import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './PromptDartsGame.css'
@@ -385,7 +386,7 @@ export default function PromptDartsGame() {
           />
 
           <h3>Round {round + 1} of {rounds.length}</h3>
-
+          <TimerBar timeLeft={timeLeft} TOTAL_TIME={TOTAL_TIME} />
           <p className="timer">Time: {timeLeft}s</p>
           <p className="points">Available points: {pointsLeft}</p>
 

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -7,7 +7,7 @@ import { toast } from 'react-hot-toast'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import Tooltip from '../components/ui/Tooltip'
-import ProgressBar from '../components/ui/ProgressBar'
+import TimerBar from '../components/ui/TimerBar'
 import { UserContext } from '../context/UserContext'
 import './PromptRecipeGame.css'
 
@@ -444,7 +444,7 @@ export default function PromptRecipeGame() {
             <span className="score">Score: {score}</span>
             <span className="timer">Time: {timeLeft}s</span>
           </div>
-          <ProgressBar percent={(timeLeft / TOTAL_TIME) * 100} />
+          <TimerBar timeLeft={timeLeft} TOTAL_TIME={TOTAL_TIME} />
           <div className="bowls">
             {(['Action', 'Context', 'Format', 'Constraints'] as Slot[]).map(slot => (
               <div


### PR DESCRIPTION
## Summary
- add TimerBar component with a shrinking fill color
- show TimerBar under round heading in PromptRecipeGame and PromptDartsGame

## Testing
- `npm run lint` *(fails: 'generateRoomDescription' is defined but never used)*
- `npm test` *(fails: roomDescription is not defined in ClarityEscapeRoom)*

------
https://chatgpt.com/codex/tasks/task_e_6845964432d0832facca64141d57b9ec