### PR TITLE
Adjust timers based on age

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
 ## Age‑Adaptive Features
 - Players enter their age and name on first visit.
 - Games read the stored age to tweak difficulty and show tailored tips.
+- On easy difficulty, older players automatically receive extra time for tasks
+  (5s at 40+, 10s at 50+, 15s at 60+).
 - Scores and badges now sync to a small server so progress follows you across devices.
 - High contrast theme preference persists via `ThemeToggle`.
 - A unified leaderboard with tabs displays top scores for every game.

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -4,6 +4,7 @@ import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
+import { getTimeLimit } from '../utils/time'
 import './PromptDartsGame.css'
 
 const KEYWORDS = [
@@ -279,8 +280,11 @@ export default function PromptDartsGame() {
   const PENALTY = 2
 
 
-  const TOTAL_TIME =
-    user.difficulty === 'easy' ? 20 : user.difficulty === 'hard' ? 10 : 15
+  const TOTAL_TIME = getTimeLimit(user, {
+    easy: 20,
+    medium: 15,
+    hard: 10,
+  })
   const MAX_POINTS =
     user.difficulty === 'easy' ? 8 : user.difficulty === 'hard' ? 12 : 10
 

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -9,6 +9,7 @@ import InstructionBanner from '../components/ui/InstructionBanner'
 import Tooltip from '../components/ui/Tooltip'
 import ProgressBar from '../components/ui/ProgressBar'
 import { UserContext } from '../context/UserContext'
+import { getTimeLimit } from '../utils/time'
 import './PromptRecipeGame.css'
 
 export type Slot = 'Action' | 'Context' | 'Format' | 'Constraints'
@@ -172,8 +173,11 @@ async function generateCards(): Promise<Card[]> {
 export default function PromptRecipeGame() {
   const { setScore, addBadge, user } = useContext(UserContext)
   const TOTAL_ROUNDS = 5
-  const TOTAL_TIME =
-    user.difficulty === 'easy' ? 45 : user.difficulty === 'hard' ? 20 : 30
+  const TOTAL_TIME = getTimeLimit(user, {
+    easy: 45,
+    medium: 30,
+    hard: 20,
+  })
   const SCORE_MULT =
     user.difficulty === 'easy' ? 1 : user.difficulty === 'hard' ? 2 : 1.5
   const [cards, setCards] = useState<Card[]>([])

--- a/learning-games/src/utils/time.ts
+++ b/learning-games/src/utils/time.ts
@@ -1,0 +1,14 @@
+export function getTimeLimit(
+  user: { age: number | null; difficulty: 'easy' | 'medium' | 'hard' },
+  base: { easy: number; medium: number; hard: number },
+): number {
+  const baseTime = base[user.difficulty]
+  if (user.difficulty !== 'easy') {
+    return baseTime
+  }
+  const age = user.age ?? 0
+  if (age >= 60) return baseTime + 15
+  if (age >= 50) return baseTime + 10
+  if (age >= 40) return baseTime + 5
+  return baseTime
+}


### PR DESCRIPTION
## Summary
- compute time limit using difficulty and age
- extend easy mode timers for older players in Prompt Recipe and Darts games
- document age-based time bonuses in README

## Testing
- `npm test` *(fails: roomDescription is not defined)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684596465ef0832f955b1b923cbf7d98