### PR TITLE
Improve Prompt Darts touch targets

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -47,10 +47,15 @@
 }
 
 .options {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
   margin-bottom: 1rem;
+}
+
+.options button {
+  width: 100%;
+  padding-block: 1rem;
 }
 
 .feedback {
@@ -93,5 +98,8 @@
   }
   .progress-sidebar {
     max-width: none;
+  }
+  .options {
+    grid-template-columns: 1fr 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- expand `.options` layout in Prompt Darts for better touch targets
- switch to grid layout for automatic two-column mode on wider screens

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684596489ba8832f90711455c3dce966