### PR TITLE
Adjust difficulty scaling for Prompt Darts

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -9,7 +9,6 @@ import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './ClarityEscapeRoom.css'
 import { scorePrompt } from '../utils/scorePrompt'
-import { generateRoomDescription } from '../utils/generateRoomDescription'
 
 interface Clue {
   aiResponse: string
@@ -288,9 +287,6 @@ export default function ClarityEscapeRoom() {
               )}
               {message && (
                 <p className={`feedback ${status}`}>{status === 'success' ? '✔️' : '⚠️'} {message}</p>
-              )}
-              {roomDescription && (
-                <p className="room-desc" aria-live="polite">{roomDescription}</p>
               )}
               {showNext && (
                 <div className="next-area">

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -279,10 +279,19 @@ export default function PromptDartsGame() {
   const PENALTY = 2
 
 
-  const TOTAL_TIME =
-    user.difficulty === 'easy' ? 20 : user.difficulty === 'hard' ? 10 : 15
-  const MAX_POINTS =
-    user.difficulty === 'easy' ? 8 : user.difficulty === 'hard' ? 12 : 10
+  const TIME_BY_DIFFICULTY = {
+    easy: 30,
+    medium: 20,
+    hard: 10,
+  } as const
+  const POINTS_BY_DIFFICULTY = {
+    easy: 8,
+    medium: 10,
+    hard: 12,
+  } as const
+
+  const TOTAL_TIME = TIME_BY_DIFFICULTY[user.difficulty]
+  const MAX_POINTS = POINTS_BY_DIFFICULTY[user.difficulty]
 
   const [timeLeft, setTimeLeft] = useState(TOTAL_TIME)
   const [pointsLeft, setPointsLeft] = useState(MAX_POINTS)


### PR DESCRIPTION
## Summary
- map difficulty to new timing constants in Prompt Darts
- scale available points by difficulty
- clean up unused code in Clarity Escape Room

## Testing
- `npm --prefix learning-games run lint`
- `npm --prefix learning-games test`


------
https://chatgpt.com/codex/tasks/task_e_6845964ec904832f8f96b9a091674e31