### PR TITLE
Add end-game modal to Prompt Darts

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -112,3 +112,36 @@
     grid-template-columns: 1fr 1fr;
   }
 }
+
+.congrats-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.congrats-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  max-height: 80vh;
+  overflow-y: auto;
+  text-align: center;
+}
+
+.congrats-video {
+  width: 100%;
+  height: 215px;
+  border: none;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+}

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -8,6 +8,8 @@ import shuffle from '../utils/shuffle'
 import { getTimeLimit } from '../utils/time'
 import './PromptDartsGame.css'
 
+const CONGRATS_VIDEO_URL = 'https://www.youtube.com/embed/dQw4w9WgXcQ'
+
 const KEYWORDS = [
   'list',
   'draft',
@@ -405,11 +407,29 @@ export default function PromptDartsGame() {
   if (round >= rounds.length) {
     return (
       <div className="darts-page">
-        <InstructionBanner>You finished Prompt Darts!</InstructionBanner>
-        <p className="final-score">Your score: {score}</p>
-        <p style={{ marginTop: '1rem' }}>
-          <Link to="/leaderboard">Return to Progress</Link>
-        </p>
+        <div className="congrats-overlay">
+          <div className="congrats-modal" role="dialog" aria-modal="true">
+            <h3>Congratulations!</h3>
+            <p className="final-score">Your score: {score}</p>
+            <iframe
+              className="congrats-video"
+              src={CONGRATS_VIDEO_URL}
+              title="Celebration video"
+              allowFullScreen
+            />
+            <Link to="/games/compose" className="btn-primary" style={{ display: 'block', marginTop: '0.5rem' }}>
+              Play Compose Tweet
+            </Link>
+            <a
+              className="coffee-link"
+              href="https://coff.ee/strawberrytech"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ☕️ Buy me a coffee
+            </a>
+          </div>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- show congratulations modal after completing the Prompt Darts rounds
- include celebration video, link to Compose Tweet, and Buy Me a Coffee CTA

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459ad96930832fb93874cf006e4a88