### PR TITLE
Move image inline in Hallucinations card

### DIFF
--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -199,12 +199,6 @@ export default function QuizGame() {
       <div className="truth-game">
         <WhyItMatters />
         <div className="game-area">
-          <img
-            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_51_28%20PM.png"
-            alt="Detective-themed strawberry examining statement cards under magnifying glass to spot false claim."
-            className="hero-img"
-            style={{ width: '200px' }}
-          />
           <div className="statements">
           <div className="statement-header">
             <h2>Hallucinations</h2>
@@ -216,6 +210,12 @@ export default function QuizGame() {
             🔄
           </button>
           </div>
+          <img
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_51_28%20PM.png"
+            alt="Detective-themed strawberry examining statement cards under magnifying glass to spot false claim."
+            className="hero-img"
+            style={{ width: '150px', display: 'inline-block' }}
+          />
           <p className="header-instruction">
             Pick the hallucination from the {NUM_STATEMENTS} statements.
           </p>


### PR DESCRIPTION
## Summary
- place Hallucinations image inside the quiz card and below the header so it takes less vertical space

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459f6e8124832f938dd0d8e8ea617e