### PR TITLE
Add robots.txt for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ Node **18+** is recommended. Major dependencies include React 19, React Router 7
 
 ### Running Tests
 
-Before executing the test suite make sure dependencies are installed:
+Before executing the test suite, install dependencies from the repository
+root using the `--prefix` flag:
 
 ```bash
-cd learning-games
-npm install
-npm test
+npm --prefix learning-games install
+npm --prefix learning-games test
 ```
 
-Without installing the packages first the `vitest` command used by
-`npm test` will not be available and the tests will fail.
+Running the commands from the project root ensures `vitest` is available
+and prevents path errors during automated builds.
 
 ### Visitor Statistics
 

--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ Node **18+** is recommended. Major dependencies include React 19, React Router 7
 
 ### Running Tests
 
-Before executing the test suite, install dependencies from the repository
-root using the `--prefix` flag:
+Before executing the test suite make sure dependencies are installed:
 
 ```bash
-npm --prefix learning-games install
-npm --prefix learning-games test
+cd learning-games
+npm install
+npm test
 ```
 
-Running the commands from the project root ensures `vitest` is available
-and prevents path errors during automated builds.
+Without installing the packages first the `vitest` command used by
+`npm test` will not be available and the tests will fail.
 
 ### Visitor Statistics
 

--- a/nextjs-app/public/robots.txt
+++ b/nextjs-app/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+Disallow: /api/
+
+Sitemap: https://strawberry-tech.vercel.app/sitemap.xml


### PR DESCRIPTION
## Summary
- create `nextjs-app/public/robots.txt` allowing indexing and blocking `/api/`
- reference the sitemap in robots.txt

## Testing
- `npm --prefix learning-games test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a534153c832f8dad0d3cf2b66777