### PR TITLE
Add page meta head components

### DIFF
--- a/learning-games/index.html
+++ b/learning-games/index.html
@@ -1,15 +1,11 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    
     <link
       rel="icon"
       type="image/png"
       href="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_24_31%20AM.png"
-    />
-    <meta
-      name="description"
-      content="StrawberryTech provides fun games to practice AI and communication skills."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,8 +23,7 @@
       href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap"
       rel="stylesheet"
     />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>StrawberryTech Learning Games</title>
+    
   </head>
   <body>
     <div id="root"></div>

--- a/nextjs-app/src/pages/_app.tsx
+++ b/nextjs-app/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from 'next/app'
+import Head from 'next/head'
 import { UserProvider } from '../context/UserProvider'
 import NavBar from '../components/layout/NavBar'
 import Footer from '../components/layout/Footer'
@@ -10,14 +11,21 @@ import '../styles/App.css'
 import '../app/globals.css'
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+  const description =
+    'Play StrawberryTech mini games to practice AI communication skills.'
   return (
-    <UserProvider>
-      <ScrollToTop />
-      <NavBar />
-      <AnalyticsTracker />
-      <Component {...pageProps} />
-      <Toaster toastOptions={{ ariaProps: { role: 'status', 'aria-live': 'polite' } }} />
-      <Footer />
-    </UserProvider>
+    <>
+      <Head>
+        <meta name="description" content={description} />
+      </Head>
+      <UserProvider>
+        <ScrollToTop />
+        <NavBar />
+        <AnalyticsTracker />
+        <Component {...pageProps} />
+        <Toaster toastOptions={{ ariaProps: { role: 'status', 'aria-live': 'polite' } }} />
+        <Footer />
+      </UserProvider>
+    </>
   )
 }

--- a/nextjs-app/src/pages/age.tsx
+++ b/nextjs-app/src/pages/age.tsx
@@ -83,3 +83,15 @@ export default function AgeInputForm({
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Enter Your Age | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Provide your age and name to personalize the games."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/badges.tsx
+++ b/nextjs-app/src/pages/badges.tsx
@@ -49,3 +49,12 @@ export default function BadgesPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Badges | StrawberryTech</title>
+      <meta name="description" content="View the badges you've earned from playing." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -113,3 +113,15 @@ export default function CommunityPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Community Board | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Read and share posts with other players."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/contact.tsx
+++ b/nextjs-app/src/pages/contact.tsx
@@ -11,3 +11,12 @@ export default function ContactPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Contact Us | StrawberryTech</title>
+      <meta name="description" content="Get in touch with the StrawberryTech team." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/compose.tsx
+++ b/nextjs-app/src/pages/games/compose.tsx
@@ -186,3 +186,15 @@ export default function ComposeTweetGame() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Compose Tweet Game | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Guess the hidden tweet prompt to unlock the door."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -516,3 +516,15 @@ export default function PromptDartsGame() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Prompt Darts | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Choose the clearest prompt to hit the bullseye."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -185,3 +185,15 @@ export default function DragDropGame() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Drag &amp; Drop Tone Game | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Drag adjectives to explore how tone changes a message."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -324,3 +324,15 @@ export default function ClarityEscapeRoom() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Clarity Escape Room | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Enter the right prompt to unlock the door."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -293,3 +293,15 @@ export default function PromptGuessEscape() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Guess the Prompt Game | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Deduce the prompt from the AI's reply before time runs out."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -270,3 +270,15 @@ export default function QuizGame() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Hallucination Quiz | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Spot the AI's false statement among the truths."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -527,3 +527,15 @@ export default function PromptRecipeGame() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Prompt Builder Game | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Drag cards to craft the perfect AI prompt."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/games/tone.tsx
+++ b/nextjs-app/src/pages/games/tone.tsx
@@ -346,3 +346,15 @@ export default function Match3Game() {
     </div>
   );
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Tone Match Game | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Match adjectives to explore how tone changes a message."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/help.tsx
+++ b/nextjs-app/src/pages/help.tsx
@@ -18,3 +18,12 @@ export default function HelpPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>How to Play | StrawberryTech</title>
+      <meta name="description" content="Instructions for getting started with the games." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -146,3 +146,15 @@ export default function Home() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>StrawberryTech Games</title>
+      <meta
+        name="description"
+        content="Explore mini games that teach AI prompting techniques."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/leaderboard.tsx
+++ b/nextjs-app/src/pages/leaderboard.tsx
@@ -145,3 +145,12 @@ export default function LeaderboardPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Leaderboard | StrawberryTech</title>
+      <meta name="description" content="See top scores across all games." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/playlist.tsx
+++ b/nextjs-app/src/pages/playlist.tsx
@@ -97,3 +97,15 @@ export default function CommunityPlaylistPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Community Playlist | StrawberryTech</title>
+      <meta
+        name="description"
+        content="Share good and bad prompt pairs with the community."
+      />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/privacy.tsx
+++ b/nextjs-app/src/pages/privacy.tsx
@@ -17,3 +17,12 @@ export default function PrivacyPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Privacy Policy | StrawberryTech</title>
+      <meta name="description" content="Learn how StrawberryTech handles your data." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -63,3 +63,12 @@ export default function ProfilePage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Your Profile | StrawberryTech</title>
+      <meta name="description" content="Edit your name, age and difficulty level." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/stats.tsx
+++ b/nextjs-app/src/pages/stats.tsx
@@ -94,3 +94,12 @@ export default function StatsPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Site Statistics | StrawberryTech</title>
+      <meta name="description" content="View visitor analytics collected by the server." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/terms.tsx
+++ b/nextjs-app/src/pages/terms.tsx
@@ -17,3 +17,12 @@ export default function TermsPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Terms of Service | StrawberryTech</title>
+      <meta name="description" content="Review the rules for using the site." />
+    </>
+  )
+}

--- a/nextjs-app/src/pages/welcome.tsx
+++ b/nextjs-app/src/pages/welcome.tsx
@@ -59,3 +59,12 @@ export default function SplashPage() {
     </div>
   )
 }
+
+export function Head() {
+  return (
+    <>
+      <title>Welcome | StrawberryTech</title>
+      <meta name="description" content="Introduce yourself and start playing." />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add default description meta tag in `_app.tsx`
- export page-specific `<Head>` components with titles and descriptions
- strip old meta tags from `learning-games/index.html`

## Testing
- `npm test` within `learning-games`
- `npm run lint` within `learning-games`
- `npm run lint` within `nextjs-app`
- `npm test` within `nextjs-app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845a500de68832f8e2199d85be0d0c9