### PR TITLE
Add sitemap generation script

### DIFF
--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "next build && npx -y ts-node --transpile-only --compiler-options '{\"module\":\"CommonJS\"}' ../scripts/generate-sitemap.ts",
     "start": "next start",
     "lint": "next lint"
   },
@@ -24,6 +24,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "@eslint/eslintrc": "^3",
-    "@types/canvas-confetti": "^1.9.0"
+    "@types/canvas-confetti": "^1.9.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/nextjs-app/public/sitemap.xml
+++ b/nextjs-app/public/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/age</loc></url>
+  <url><loc>https://example.com/badges</loc></url>
+  <url><loc>https://example.com/community</loc></url>
+  <url><loc>https://example.com/contact</loc></url>
+  <url><loc>https://example.com/games/compose</loc></url>
+  <url><loc>https://example.com/games/darts</loc></url>
+  <url><loc>https://example.com/games/dragdrop</loc></url>
+  <url><loc>https://example.com/games/escape</loc></url>
+  <url><loc>https://example.com/games/guess</loc></url>
+  <url><loc>https://example.com/games/quiz</loc></url>
+  <url><loc>https://example.com/games/recipe</loc></url>
+  <url><loc>https://example.com/games/tone</loc></url>
+  <url><loc>https://example.com/help</loc></url>
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/leaderboard</loc></url>
+  <url><loc>https://example.com/playlist</loc></url>
+  <url><loc>https://example.com/privacy</loc></url>
+  <url><loc>https://example.com/profile</loc></url>
+  <url><loc>https://example.com/stats</loc></url>
+  <url><loc>https://example.com/terms</loc></url>
+  <url><loc>https://example.com/welcome</loc></url>
+</urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,0 +1,38 @@
+import fs from 'fs'
+import path from 'path'
+import COURSES from '../nextjs-app/src/data/courses'
+
+const SITE_URL = process.env.SITE_URL || 'https://example.com'
+const pagesDir = path.join(__dirname, '../nextjs-app/src/pages')
+const publicDir = path.join(__dirname, '../nextjs-app/public')
+
+function collectRoutes(dir: string, prefix = ''): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  let routes: string[] = []
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      routes = routes.concat(collectRoutes(path.join(dir, entry.name), `${prefix}/${entry.name}`))
+    } else if (entry.isFile()) {
+      if (!/\.(tsx|ts|js|jsx)$/.test(entry.name)) continue
+      const name = entry.name.replace(/\.(tsx|ts|js|jsx)$/, '')
+      if (name.startsWith('_') || ['404', '500'].includes(name)) continue
+
+      const route = name === 'index' ? (prefix || '/') : `${prefix}/${name}`
+      routes.push(route)
+    }
+  }
+
+  return routes
+}
+
+const staticRoutes = collectRoutes(pagesDir)
+const dynamicRoutes = COURSES.map(c => c.path)
+const routes = Array.from(new Set([...staticRoutes, ...dynamicRoutes]))
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${routes.map(r => `  <url><loc>${SITE_URL}${r}</loc></url>`).join('\n')}\n</urlset>\n`
+
+if (!fs.existsSync(publicDir)) fs.mkdirSync(publicDir, { recursive: true })
+fs.writeFileSync(path.join(publicDir, 'sitemap.xml'), xml)
+console.log(`Generated sitemap with ${routes.length} entries`) 
+


### PR DESCRIPTION
## Summary
- create `scripts/generate-sitemap.ts` for building an XML sitemap from Next.js routes
- generate `public/sitemap.xml`
- run the script after `next build`
- add `ts-node` as a dev dependency

## Testing
- `npx -y ts-node --transpile-only --compiler-options '{"module":"CommonJS"}' scripts/generate-sitemap.ts`
- `npm --prefix nextjs-app run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a532bf0c832fb39092d16d44f37f