### PR TITLE
Add canonical links to page headers

### DIFF
--- a/nextjs-app/src/pages/age.tsx
+++ b/nextjs-app/src/pages/age.tsx
@@ -92,6 +92,7 @@ export function Head() {
         name="description"
         content="Provide your age and name to personalize the games."
       />
+      <link rel="canonical" href="https://strawberrytech.com/age" />
     </>
   )
 }

--- a/nextjs-app/src/pages/badges.tsx
+++ b/nextjs-app/src/pages/badges.tsx
@@ -55,6 +55,7 @@ export function Head() {
     <>
       <title>Badges | StrawberryTech</title>
       <meta name="description" content="View the badges you've earned from playing." />
+      <link rel="canonical" href="https://strawberrytech.com/badges" />
     </>
   )
 }

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -122,6 +122,7 @@ export function Head() {
         name="description"
         content="Read and share posts with other players."
       />
+      <link rel="canonical" href="https://strawberrytech.com/community" />
     </>
   )
 }

--- a/nextjs-app/src/pages/contact.tsx
+++ b/nextjs-app/src/pages/contact.tsx
@@ -17,6 +17,7 @@ export function Head() {
     <>
       <title>Contact Us | StrawberryTech</title>
       <meta name="description" content="Get in touch with the StrawberryTech team." />
+      <link rel="canonical" href="https://strawberrytech.com/contact" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/compose.tsx
+++ b/nextjs-app/src/pages/games/compose.tsx
@@ -195,6 +195,7 @@ export function Head() {
         name="description"
         content="Guess the hidden tweet prompt to unlock the door."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/compose" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -558,6 +558,7 @@ export function Head() {
         name="description"
         content="Choose the clearest prompt to hit the bullseye."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/darts" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -194,6 +194,7 @@ export function Head() {
         name="description"
         content="Drag adjectives to explore how tone changes a message."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/dragdrop" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -366,6 +366,7 @@ export function Head() {
         name="description"
         content="Enter the right prompt to unlock the door."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/escape" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -302,6 +302,7 @@ export function Head() {
         name="description"
         content="Deduce the prompt from the AI's reply before time runs out."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/guess" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -312,6 +312,7 @@ export function Head() {
         name="description"
         content="Spot the AI's false statement among the truths."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/quiz" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -569,6 +569,7 @@ export function Head() {
         name="description"
         content="Drag cards to craft the perfect AI prompt."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/recipe" />
     </>
   )
 }

--- a/nextjs-app/src/pages/games/tone.tsx
+++ b/nextjs-app/src/pages/games/tone.tsx
@@ -388,6 +388,7 @@ export function Head() {
         name="description"
         content="Match adjectives to explore how tone changes a message."
       />
+      <link rel="canonical" href="https://strawberrytech.com/games/tone" />
     </>
   )
 }

--- a/nextjs-app/src/pages/help.tsx
+++ b/nextjs-app/src/pages/help.tsx
@@ -24,6 +24,7 @@ export function Head() {
     <>
       <title>How to Play | StrawberryTech</title>
       <meta name="description" content="Instructions for getting started with the games." />
+      <link rel="canonical" href="https://strawberrytech.com/help" />
     </>
   )
 }

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -188,6 +188,7 @@ export function Head() {
         name="description"
         content="Explore mini games that teach AI prompting techniques."
       />
+      <link rel="canonical" href="https://strawberrytech.com/" />
     </>
   )
 }

--- a/nextjs-app/src/pages/leaderboard.tsx
+++ b/nextjs-app/src/pages/leaderboard.tsx
@@ -151,6 +151,7 @@ export function Head() {
     <>
       <title>Leaderboard | StrawberryTech</title>
       <meta name="description" content="See top scores across all games." />
+      <link rel="canonical" href="https://strawberrytech.com/leaderboard" />
     </>
   )
 }

--- a/nextjs-app/src/pages/playlist.tsx
+++ b/nextjs-app/src/pages/playlist.tsx
@@ -106,6 +106,7 @@ export function Head() {
         name="description"
         content="Share good and bad prompt pairs with the community."
       />
+      <link rel="canonical" href="https://strawberrytech.com/playlist" />
     </>
   )
 }

--- a/nextjs-app/src/pages/privacy.tsx
+++ b/nextjs-app/src/pages/privacy.tsx
@@ -23,6 +23,7 @@ export function Head() {
     <>
       <title>Privacy Policy | StrawberryTech</title>
       <meta name="description" content="Learn how StrawberryTech handles your data." />
+      <link rel="canonical" href="https://strawberrytech.com/privacy" />
     </>
   )
 }

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -69,6 +69,7 @@ export function Head() {
     <>
       <title>Your Profile | StrawberryTech</title>
       <meta name="description" content="Edit your name, age and difficulty level." />
+      <link rel="canonical" href="https://strawberrytech.com/profile" />
     </>
   )
 }

--- a/nextjs-app/src/pages/stats.tsx
+++ b/nextjs-app/src/pages/stats.tsx
@@ -100,6 +100,7 @@ export function Head() {
     <>
       <title>Site Statistics | StrawberryTech</title>
       <meta name="description" content="View visitor analytics collected by the server." />
+      <link rel="canonical" href="https://strawberrytech.com/stats" />
     </>
   )
 }

--- a/nextjs-app/src/pages/terms.tsx
+++ b/nextjs-app/src/pages/terms.tsx
@@ -23,6 +23,7 @@ export function Head() {
     <>
       <title>Terms of Service | StrawberryTech</title>
       <meta name="description" content="Review the rules for using the site." />
+      <link rel="canonical" href="https://strawberrytech.com/terms" />
     </>
   )
 }

--- a/nextjs-app/src/pages/welcome.tsx
+++ b/nextjs-app/src/pages/welcome.tsx
@@ -65,6 +65,7 @@ export function Head() {
     <>
       <title>Welcome | StrawberryTech</title>
       <meta name="description" content="Introduce yourself and start playing." />
+      <link rel="canonical" href="https://strawberrytech.com/welcome" />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- include canonical links in page `<Head>` components for better SEO

## Testing
- `npm run lint` *(fails: `next lint` found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845adafd7a8832fa7caad7d5ff3316e