### PR TITLE
Add JSON-LD helper and schema for game pages

### DIFF
--- a/nextjs-app/src/components/seo/JsonLd.tsx
+++ b/nextjs-app/src/components/seo/JsonLd.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+export interface JsonLdProps {
+  data: Record<string, any>
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <Head>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+      />
+    </Head>
+  )
+}

--- a/nextjs-app/src/pages/games/compose.tsx
+++ b/nextjs-app/src/pages/games/compose.tsx
@@ -6,6 +6,7 @@ import { scorePrompt } from '../../utils/scorePrompt'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import { UserContext } from '../../context/UserContext'
+import JsonLd from '../../components/seo/JsonLd'
 import '../../styles/ComposeTweetGame.css'
 
 const SAMPLE_RESPONSE =
@@ -109,7 +110,18 @@ export default function ComposeTweetGame() {
   }
 
   return (
-    <div className="compose-page clearfix">
+    <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Compose Tweet Game',
+          description: 'Guess the hidden tweet prompt to unlock the door.',
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png',
+        }}
+      />
+      <div className="compose-page clearfix">
       <InstructionBanner>Guess the Prompt</InstructionBanner>
       <div className="compose-wrapper">
         <aside className="compose-sidebar">
@@ -184,6 +196,7 @@ export default function ComposeTweetGame() {
         <ProgressSidebar />
       </div>
     </div>
+    </>
   )
 }
 

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -8,6 +8,7 @@ import shuffle from '../../utils/shuffle'
 import { getTimeLimit } from '../../utils/time'
 import '../../styles/PromptDartsGame.css'
 import Head from 'next/head'
+import JsonLd from '../../components/seo/JsonLd'
 
 const CONGRATS_VIDEO_URL = 'https://www.youtube.com/embed/dQw4w9WgXcQ'
 
@@ -402,8 +403,9 @@ export default function PromptDartsGame() {
       <div className="darts-page">
         <InstructionBanner>Loading rounds...</InstructionBanner>
       </div>
-    )
-  }
+    </>
+  )
+}
 
   if (round >= rounds.length) {
     return (
@@ -437,6 +439,16 @@ export default function PromptDartsGame() {
 
   return (
     <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Prompt Darts',
+          description: 'Choose the clearer prompt to hit the bullseye and earn points.',
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png',
+        }}
+      />
       <Head>
         <title>Prompt Darts - StrawberryTech</title>
         <meta property="og:title" content="Prompt Darts - StrawberryTech" />

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -4,6 +4,7 @@ import ProgressSidebarSimple from '../../components/layout/ProgressSidebarSimple
 import GamePageLayout from '../../components/layout/GamePageLayout'
 import { UserContext } from '../../context/UserContext'
 import '../../styles/DragDropGame.css'
+import JsonLd from '../../components/seo/JsonLd'
 
 const tones = [
   'Polite',
@@ -67,7 +68,18 @@ export default function DragDropGame() {
   }
 
   return (
-    <div className="dragdrop-page">
+    <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Drag & Drop Tone Game',
+          description: 'Drag adjectives to explore how tone changes a message.',
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png',
+        }}
+      />
+      <div className="dragdrop-page">
       <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start' }}>
         <GamePageLayout
           imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
@@ -183,6 +195,7 @@ export default function DragDropGame() {
         </p>
       </div>
     </div>
+    </>
   )
 }
 

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -10,6 +10,7 @@ import shuffle from '../../utils/shuffle'
 import '../../styles/ClarityEscapeRoom.css'
 import { scorePrompt } from '../../utils/scorePrompt'
 import Head from 'next/head'
+import JsonLd from '../../components/seo/JsonLd'
 
 interface Clue {
   aiResponse: string
@@ -247,6 +248,16 @@ export default function ClarityEscapeRoom() {
 
   return (
     <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Clarity Escape Room',
+          description: 'Enter the right prompt to unlock the door.',
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png',
+        }}
+      />
       <Head>
         <title>Clarity Escape Room - StrawberryTech</title>
         <meta property="og:title" content="Clarity Escape Room - StrawberryTech" />

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -9,6 +9,7 @@ import { UserContext } from '../../context/UserContext'
 import shuffle from '../../utils/shuffle'
 import '../../styles/PromptGuessEscape.css'
 import { scorePrompt } from '../../utils/scorePrompt'
+import JsonLd from '../../components/seo/JsonLd'
 
 interface Clue {
   aiResponse: string
@@ -224,7 +225,18 @@ export default function PromptGuessEscape() {
   }
 
   return (
-    <div className="guess-page">
+    <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Guess the Prompt Game',
+          description: "Deduce the prompt from the AI's reply before time runs out.",
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png',
+        }}
+      />
+      <div className="guess-page">
       <InstructionBanner>Escape Room: Guess the Prompt</InstructionBanner>
       <div className="guess-wrapper">
         <aside className="guess-sidebar">
@@ -290,7 +302,8 @@ export default function PromptGuessEscape() {
           </div>
         </div>
       )}
-    </div>
+      </div>
+    </>
   )
 }
 

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -9,6 +9,7 @@ import '../../styles/QuizGame.css'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import { HALLUCINATION_EXAMPLES } from '../../data/hallucinationExamples'
 import { H_ROUNDS } from '../../data/hallucinationRounds'
+import JsonLd from '../../components/seo/JsonLd'
 
 interface StatementSet {
   statements: string[]
@@ -192,6 +193,16 @@ export default function QuizGame() {
 
   return (
     <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Hallucination Quiz',
+          description: "Spot the AI's false statement among the truths.",
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_51_28%20PM.png',
+        }}
+      />
       <Head>
         <title>Hallucinations Quiz - StrawberryTech</title>
         <meta property="og:title" content="Hallucinations Quiz - StrawberryTech" />

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head'
 import { motion } from 'framer-motion'
 import confetti from 'canvas-confetti'
 import { toast } from 'react-hot-toast'
+import JsonLd from '../../components/seo/JsonLd'
 
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import InstructionBanner from '../../components/ui/InstructionBanner'
@@ -433,6 +434,16 @@ export default function PromptRecipeGame() {
 
   return (
     <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Prompt Builder Game',
+          description: 'Drag cards to craft the perfect AI prompt.',
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png',
+        }}
+      />
       <Head>
         <title>Prompt Recipe Builder - StrawberryTech</title>
         <meta property="og:title" content="Prompt Recipe Builder - StrawberryTech" />

--- a/nextjs-app/src/pages/games/tone.tsx
+++ b/nextjs-app/src/pages/games/tone.tsx
@@ -4,6 +4,7 @@ import confetti from "canvas-confetti";
 
 import Link from "next/link"; import { useRouter } from "next/router";
 import Head from "next/head";
+import JsonLd from "../../components/seo/JsonLd";
 
 import { UserContext } from "../../context/UserContext";
 import RobotChat from "../../components/RobotChat";
@@ -316,6 +317,16 @@ export default function Match3Game() {
 
   return (
     <>
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Game',
+          name: 'Tone Puzzle',
+          description: 'Swap adjectives to see how wording changes the mood and earn points.',
+          image:
+            'https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png',
+        }}
+      />
       <Head>
         <title>Tone Puzzle - StrawberryTech</title>
         <meta property="og:title" content="Tone Puzzle - StrawberryTech" />


### PR DESCRIPTION
## Summary
- add a `JsonLd` helper component for structured data
- embed `schema.org/Game` information on each game page

## Testing
- `npm run lint` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845adb1b1bc832f8dafc0b705f19e1b