### PR TITLE
Add 404 page and handle legacy routes

### DIFF
--- a/nextjs-app/next.config.ts
+++ b/nextjs-app/next.config.ts
@@ -1,7 +1,28 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/index.html",
+        destination: "/",
+        permanent: true,
+      },
+      {
+        source: "/learning-games/:path*",
+        destination: "/:path*",
+        permanent: true,
+      },
+    ];
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/prompt-builder",
+        destination: "/games/recipe",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/nextjs-app/src/pages/404.tsx
+++ b/nextjs-app/src/pages/404.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export default function NotFoundPage() {
+  return (
+    <div className="not-found-page">
+      <h2>Page Not Found</h2>
+      <img
+        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+        alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
+        className="brand-logo"
+        style={{ width: '48px' }}
+      />
+      <p>Sorry, we couldn't find that page.</p>
+      <p style={{ marginTop: '2rem' }}>
+        <Link href="/">Return Home</Link>
+      </p>
+    </div>
+  )
+}
+
+export function Head() {
+  return (
+    <>
+      <title>Page Not Found | StrawberryTech</title>
+      <meta name="description" content="The page you requested could not be found." />
+    </>
+  )
+}

--- a/server/404.html
+++ b/server/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Page Not Found - StrawberryTech</title>
+    <style>
+      body { font-family: sans-serif; text-align: center; padding: 2rem; }
+      img { width: 48px; }
+    </style>
+  </head>
+  <body>
+    <h2>Page Not Found</h2>
+    <img src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png" alt="Strawberry mascot" />
+    <p>Sorry, we couldn't find that page.</p>
+  </body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -168,6 +168,11 @@ app.post('/api/scores/:game', (req, res) => {
   res.json(data.scores[game]);
 });
 
+// Serve a friendly 404 page for any unknown route
+app.use((req, res) => {
+  res.status(404).sendFile(path.join(__dirname, '404.html'));
+});
+
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add a friendly `404` page in Next.js
- route legacy paths via rewrites/redirects in `next.config.ts`
- return the same not-found page from the Express backend for unknown routes

## Testing
- `npm run lint` *(fails: various lint errors in repo)*
- `npm run test` in `nextjs-app` *(fails: missing script)*
- `npm run test` in `server` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845adb614d4832faa8f218e6bc5ea36