### PR TITLE
Redesign community page into moderated testimonials

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
 - A dedicated Badges page lets you track all achievements.
 - A hidden `/stats` page displays live visitor analytics collected on the server.
 - A community playlist page lets everyone share bad and good prompt pairs.
+- A testimonials page highlights positive feedback from players.
 
 ## Getting Started
 1. Install dependencies and start the dev server:
@@ -33,7 +34,7 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
    npm run dev
    ```
 2. In a separate terminal start the API server to persist user info,
-   community posts and shared high scores:
+  testimonial posts and shared high scores:
    ```bash
    cd server
    npm install
@@ -75,6 +76,10 @@ RobotChat and the Prompt Recipe Builder use the OpenAI API. Create a `.env` file
 ```bash
 VITE_OPENAI_API_KEY=your-key
 ```
+
+The community testimonial page uses the same API for sentiment filtering. Set
+`OPENAI_API_KEY` in the server environment so posts can be screened before
+publishing.
 
 Without this key, the RobotChat and recipe features will not work.
 

--- a/nextjs-app/src/components/Post.tsx
+++ b/nextjs-app/src/components/Post.tsx
@@ -10,6 +10,12 @@ export interface PostData {
   date: string
   /** Whether a post has been flagged by a user */
   flagged?: boolean
+  /** Sentiment score from -1 to 1 */
+  sentiment?: number
+  /** Approval status */
+  status?: 'approved' | 'pending'
+  /** Number of likes */
+  likes?: number
 }
 
 export interface PostProps {

--- a/nextjs-app/src/components/layout/NavBar.tsx
+++ b/nextjs-app/src/components/layout/NavBar.tsx
@@ -76,7 +76,7 @@ export default function NavBar() {
         </li>
         <li>
           <Tooltip message="Hover here for a surprise!">
-            <Link href="/community">Community</Link>
+            <Link href="/testimonials">Testimonials</Link>
           </Tooltip>
         </li>
         <li>

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -85,12 +85,12 @@ export default function Home() {
           Play Now
         </button>
         <button
-          onClick={() => router.push('/community')}
+          onClick={() => router.push('/testimonials')}
           className="btn-primary"
           style={{ marginLeft: '1rem' }}
-          aria-label="Visit community forum"
+          aria-label="Read testimonials"
         >
-          Community
+          Testimonials
         </button>
         <button
           onClick={() => router.push('/playlist')}

--- a/nextjs-app/src/pages/testimonials.tsx
+++ b/nextjs-app/src/pages/testimonials.tsx
@@ -4,7 +4,7 @@ import Post from '../components/Post'
 import type { PostData } from '../components/Post'
 import { UserContext } from '../context/UserContext'
 
-const STORAGE_KEY = 'community_posts'
+const STORAGE_KEY = 'testimonial_posts'
 
 const initialPosts: PostData[] = [
   {
@@ -12,10 +12,12 @@ const initialPosts: PostData[] = [
     author: 'Admin',
     content: 'Welcome to the new message board!',
     date: '2025-01-01T00:00:00Z',
+    sentiment: 1,
+    status: 'approved',
   },
 ]
 
-export default function CommunityPage() {
+export default function TestimonialsPage() {
   const { user } = useContext(UserContext)
   const [posts, setPosts] = useState<PostData[]>(() => {
     const saved = localStorage.getItem(STORAGE_KEY)
@@ -30,6 +32,7 @@ export default function CommunityPage() {
   })
   const [message, setMessage] = useState('')
   const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -53,7 +56,7 @@ export default function CommunityPage() {
     }
   }
 
-  function addPost(e: React.FormEvent) {
+  async function addPost(e: React.FormEvent) {
     e.preventDefault()
     if (message.trim()) {
       const newPost: PostData = {
@@ -66,25 +69,37 @@ export default function CommunityPage() {
         setError('Limit reached: only one post per user')
         return
       }
-      setPosts((prev) => [...prev, newPost])
-      if (typeof window !== 'undefined') {
+      try {
         const base = window.location.origin
-        fetch(`${base}/api/posts`, {
+        const resp = await fetch(`${base}/api/posts`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(newPost),
-        }).catch(() => {})
+        })
+        const data = await resp.json()
+        if (!resp.ok) {
+          setError(data.error || 'Failed to post')
+          return
+        }
+        if (data.status === 'approved') {
+          setPosts(prev => [...prev, data])
+          setNotice('Thanks for sharing your testimonial!')
+        } else {
+          setNotice('Thanks! Your testimonial is awaiting review.')
+        }
+        setError('')
+        setMessage('')
+      } catch {
+        setError('Failed to post')
       }
-      setError('')
-      setMessage('')
     }
   }
 
   return (
     <div className="community-page">
-      <h2>Community</h2>
+      <h2>Testimonials</h2>
       <form onSubmit={addPost} style={{ marginBottom: '1rem' }}>
-        <label htmlFor="message">Share your thoughts:</label>
+        <label htmlFor="message">Share a positive experience:</label>
         <textarea
           id="message"
           value={message}
@@ -99,6 +114,11 @@ export default function CommunityPage() {
       {error && (
         <p role="alert" style={{ color: 'red' }}>
           {error}
+        </p>
+      )}
+      {notice && (
+        <p role="status" style={{ color: 'green' }}>
+          {notice}
         </p>
       )}
       {posts
@@ -117,14 +137,14 @@ export default function CommunityPage() {
 export function Head() {
   return (
     <>
-      <title>Community Board | StrawberryTech</title>
+      <title>Testimonials | StrawberryTech</title>
       <meta
         name="description"
-        content="Read and share posts with other players."
+        content="Read uplifting testimonials from other players."
       />
-      <link rel="canonical" href="https://strawberrytech.com/community" />
+      <link rel="canonical" href="https://strawberrytech.com/testimonials" />
     </>
   )
 }
 
-export const getStaticProps = async () => ({ props: {} });
+export const getStaticProps = async () => ({ props: {} })


### PR DESCRIPTION
## Summary
- add sentiment analysis helper to server and filter posts
- enforce positive-only posts and mark borderline posts pending
- introduce `/api/sentiment` endpoint
- create testimonials page replacing the old community board
- update navigation and landing page button to new testimonials page
- extend `PostData` with sentiment metadata
- document new `OPENAI_API_KEY` environment variable

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6abc4e4832fb95d3d66505a992e