### PR TITLE
Fix Prompt Darts end screen

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -45,6 +45,15 @@ export interface DartRound {
   response: string
 }
 
+interface DartRoundApi {
+  options?: string[]
+  bad?: string
+  good?: string
+  correct?: number
+  why?: string
+  response?: string
+}
+
 
 export const FALLBACK_ROUNDS: DartRound[] = [
   {
@@ -313,7 +322,7 @@ export default function PromptDartsGame() {
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
         if (Array.isArray(data) && data.length) {
-          const fetched = data.map((r: any) => ({
+          const fetched = data.map((r: DartRoundApi) => ({
             options: r.options ?? [r.bad, r.good].filter(Boolean),
             correct: typeof r.correct === 'number' ? r.correct : 1,
             why: r.why ?? '',
@@ -330,11 +339,9 @@ export default function PromptDartsGame() {
 
 
   useEffect(() => {
-    if (!rounds.length) return
+    if (!rounds.length || round >= rounds.length) return
     setTimeLeft(TOTAL_TIME)
     setPointsLeft(MAX_POINTS)
-
-
     setChoices(shuffle([...rounds[round].options]))
 
 
@@ -411,6 +418,7 @@ export default function PromptDartsGame() {
           <div className="congrats-modal" role="dialog" aria-modal="true">
             <h3>Congratulations!</h3>
             <p className="final-score">Your score: {score}</p>
+            <p>Would you like to play the next game or support us?</p>
             <iframe
               className="congrats-video"
               src={CONGRATS_VIDEO_URL}

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -331,11 +331,9 @@ export default function PromptDartsGame() {
 
 
   useEffect(() => {
-    if (!rounds.length) return
+    if (!rounds.length || round >= rounds.length) return
     setTimeLeft(TOTAL_TIME)
     setPointsLeft(MAX_POINTS)
-
-
     setChoices(shuffle([...rounds[round].options]))
 
 
@@ -412,6 +410,7 @@ export default function PromptDartsGame() {
           <div className="congrats-modal" role="dialog" aria-modal="true">
             <h3>Congratulations!</h3>
             <p className="final-score">Your score: {score}</p>
+            <p>Would you like to play the next game or support us?</p>
             <iframe
               className="congrats-video"
               src={CONGRATS_VIDEO_URL}


### PR DESCRIPTION
## Summary
- prevent out-of-bounds access when rounds end
- update endgame overlay wording with prompt to continue

## Testing
- `npm test` in `learning-games`
- `npm run lint` in `learning-games`


------
https://chatgpt.com/codex/tasks/task_e_6845b1a55cc8832fbe6023ee5d377ad2