### PR TITLE
Add completion modal for tone puzzle

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -767,3 +767,28 @@
   border-color: var(--color-mint);
 }
 
+.congrats-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.congrats-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  max-height: 80vh;
+  overflow-y: auto;
+  text-align: center;
+}
+

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -193,7 +193,7 @@ function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) 
 
 
   useEffect(() => {
-    if (used.size === tones.length) {
+    if (used.size >= 3) {
       recordScore('tone', score)
       onComplete(score)
     }
@@ -288,6 +288,7 @@ export default function Match3Game() {
     () =>
       tips[Math.floor(Math.random() * tips.length)],
   )
+  const [showComplete, setShowComplete] = useState(false)
 
   function handleComplete(score: number) {
     const earned: string[] = [];
@@ -309,8 +310,41 @@ export default function Match3Game() {
     if (earned.length > 0) {
       confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
     }
-    toast.success(`${msg} Moving on to the quiz.`);
-    navigate("/games/quiz");
+    toast.success(msg);
+    setShowComplete(true);
+  }
+
+  if (showComplete) {
+    return (
+      <div className="match3-page">
+        <div className="congrats-overlay">
+          <div className="congrats-modal" role="dialog" aria-modal="true">
+            <img
+              src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
+              alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
+              style={{ width: '200px', display: 'block', margin: '0 auto' }}
+            />
+            <p>Great job matching tones! Ready for a quick quiz?</p>
+            <button
+              className="btn-primary"
+              onClick={() => navigate('/games/quiz')}
+              style={{ display: 'block', marginTop: '0.5rem' }}
+            >
+              Start Quiz
+            </button>
+            <a
+              className="coffee-link"
+              href="https://coff.ee/strawberrytech"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ display: 'block', marginTop: '0.5rem' }}
+            >
+              ☕ Buy me a coffee
+            </a>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/nextjs-app/src/pages/games/tone.tsx
+++ b/nextjs-app/src/pages/games/tone.tsx
@@ -195,7 +195,7 @@ function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) 
 
 
   useEffect(() => {
-    if (used.size === tones.length) {
+    if (used.size >= 3) {
       recordScore('tone', score)
       onComplete(score)
     }
@@ -282,7 +282,7 @@ function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) 
  */
 export default function Match3Game() {
   const { user, addBadge } = useContext(UserContext)
-  const navigate = useRouter()
+  const router = useRouter()
   const [sidebarQuote] = useState(
     () => quotes[Math.floor(Math.random() * quotes.length)],
   )
@@ -290,6 +290,7 @@ export default function Match3Game() {
     () =>
       tips[Math.floor(Math.random() * tips.length)],
   )
+  const [showComplete, setShowComplete] = useState(false)
 
   function handleComplete(score: number) {
     const earned: string[] = [];
@@ -311,8 +312,41 @@ export default function Match3Game() {
     if (earned.length > 0) {
       confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
     }
-    toast.success(`${msg} Moving on to the quiz.`);
-    router.push("/games/quiz");
+    toast.success(msg);
+    setShowComplete(true);
+  }
+
+  if (showComplete) {
+    return (
+      <div className="match3-page">
+        <div className="congrats-overlay">
+          <div className="congrats-modal" role="dialog" aria-modal="true">
+            <img
+              src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"
+              alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
+              style={{ width: '200px', display: 'block', margin: '0 auto' }}
+            />
+            <p>Great job matching tones! Ready for a quick quiz?</p>
+            <button
+              className="btn-primary"
+              onClick={() => router.push('/games/quiz')}
+              style={{ display: 'block', marginTop: '0.5rem' }}
+            >
+              Start Quiz
+            </button>
+            <a
+              className="coffee-link"
+              href="https://coff.ee/strawberrytech"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ display: 'block', marginTop: '0.5rem' }}
+            >
+              ☕ Buy me a coffee
+            </a>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/nextjs-app/src/styles/App.css
+++ b/nextjs-app/src/styles/App.css
@@ -767,3 +767,28 @@
   border-color: var(--color-mint);
 }
 
+.congrats-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.congrats-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  max-height: 80vh;
+  overflow-y: auto;
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- trigger `onComplete` after 3 tones instead of all six
- show completion modal in Match3Game
- include start quiz button and Buy Me a Coffee link in modal
- add shared modal styles

## Testing
- `npm test` in `learning-games`
- `npm run lint` in `nextjs-app` *(fails: various warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845b6109388832f9638897c687ed43b