### PR TITLE
Add completion modal to learning games

### DIFF
--- a/learning-games/src/components/ui/CompletionModal.css
+++ b/learning-games/src/components/ui/CompletionModal.css
@@ -1,0 +1,30 @@
+.completion-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.completion-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  max-height: 80vh;
+  overflow-y: auto;
+  text-align: center;
+}
+
+.completion-img {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+}

--- a/learning-games/src/components/ui/CompletionModal.tsx
+++ b/learning-games/src/components/ui/CompletionModal.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+import './CompletionModal.css'
+
+export interface CompletionModalProps {
+  imageSrc: string
+  buttonHref: string
+  buttonLabel: string
+  children?: React.ReactNode
+}
+
+export default function CompletionModal({
+  imageSrc,
+  buttonHref,
+  buttonLabel,
+  children,
+}: CompletionModalProps) {
+  return (
+    <div className="completion-overlay">
+      <div className="completion-modal" role="dialog" aria-modal="true">
+        <img src={imageSrc} alt="Completion image" className="completion-img" />
+        {children}
+        <Link to={buttonHref} className="btn-primary" style={{ display: 'block', marginTop: '0.5rem' }}>
+          {buttonLabel}
+        </Link>
+        <a
+          className="coffee-link"
+          href="https://coff.ee/strawberrytech"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ☕ Buy me a coffee
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
+import CompletionModal from '../components/ui/CompletionModal'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import ProgressBar from '../components/ui/ProgressBar'
 import DoorAnimation from '../components/DoorAnimation'
@@ -303,23 +304,14 @@ export default function ClarityEscapeRoom() {
         <ProgressSidebar />
       </div>
       {showSummary && (
-        <div className="summary-overlay" onClick={() => setShowSummary(false)}>
-          <div className="summary-modal" onClick={e => e.stopPropagation()}>
-            <h3>Round Summary</h3>
-            <ul>
-              {rounds.map((r, i) => (
-                <li key={i}>
-                  <p><strong>Your Prompt:</strong> {r.prompt || '(none)'}</p>
-                  <p><strong>Expected:</strong> {r.expected}</p>
-                  <p className="tip"><strong>Tip:</strong> {r.tip}</p>
-                </li>
-              ))}
-            </ul>
-            <button className="btn-primary" onClick={() => navigate('/leaderboard')}>
-              View Leaderboard
-            </button>
-          </div>
-        </div>
+        <CompletionModal
+          imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+          buttonHref="/games/recipe"
+          buttonLabel="Play Prompt Builder"
+        >
+          <h3>Escape Complete!</h3>
+          <p className="final-score">Score: {points}</p>
+        </CompletionModal>
       )}
     </div>
   )

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import ProgressBar from '../components/ui/ProgressBar'
@@ -104,7 +103,6 @@ const TOTAL_STEPS = 4
 
 
 export default function ClarityEscapeRoom() {
-  const navigate = useNavigate()
   const { setScore } = useContext(UserContext)
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
@@ -120,7 +118,6 @@ export default function ClarityEscapeRoom() {
 
   const [aiHint, setAiHint] = useState('')
   const startRef = useRef(Date.now())
-  const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
   const [showSummary, setShowSummary] = useState(false)
 
   const clue = doors[index]
@@ -225,9 +222,8 @@ export default function ClarityEscapeRoom() {
   }
 
   function nextChallenge() {
-    const { tips } = scorePrompt(clue.expectedPrompt, input.trim())
-    const tip = tips[0] || 'Aim for a clearer prompt next time.'
-    setRounds(r => [...r, { prompt: input.trim(), expected: clue.expectedPrompt, tip }])
+    // Previously we recorded each prompt and tip for a summary modal. The new
+    // completion modal omits that detail, so we simply advance the round.
     if (index + 1 < TOTAL_STEPS) {
       setIndex(i => i + 1)
       setInput('')

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -5,6 +5,7 @@ import { scorePrompt } from '../utils/scorePrompt'
 
 import InstructionBanner from '../components/ui/InstructionBanner'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import CompletionModal from '../components/ui/CompletionModal'
 import { UserContext } from '../context/UserContext'
 import './ComposeTweetGame.css'
 
@@ -109,6 +110,7 @@ export default function ComposeTweetGame() {
   }
 
   return (
+    <>
     <div className="compose-page clearfix">
       <InstructionBanner>Guess the Prompt</InstructionBanner>
       <div className="compose-wrapper">
@@ -184,5 +186,18 @@ export default function ComposeTweetGame() {
         <ProgressSidebar />
       </div>
     </div>
+    {showNext && round + 1 >= pairs.length && (
+      <CompletionModal
+        imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_29%20PM.png"
+        buttonHref="/leaderboard"
+        buttonLabel="View Leaderboard"
+      >
+        <h3>All prompts complete!</h3>
+        {score !== null && (
+          <p className="final-score" aria-live="polite">Your score: {score}</p>
+        )}
+      </CompletionModal>
+    )}
+  </>
   )
 }

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -1,5 +1,6 @@
 import { useState, useContext, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import CompletionModal from '../components/ui/CompletionModal'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import TimerBar from '../components/ui/TimerBar'
@@ -414,30 +415,14 @@ export default function PromptDartsGame() {
   if (round >= rounds.length) {
     return (
       <div className="darts-page">
-        <div className="congrats-overlay">
-          <div className="congrats-modal" role="dialog" aria-modal="true">
-            <h3>Congratulations!</h3>
-            <p className="final-score">Your score: {score}</p>
-            <p>Would you like to play the next game or support us?</p>
-            <iframe
-              className="congrats-video"
-              src={CONGRATS_VIDEO_URL}
-              title="Celebration video"
-              allowFullScreen
-            />
-            <Link to="/games/compose" className="btn-primary" style={{ display: 'block', marginTop: '0.5rem' }}>
-              Play Compose Tweet
-            </Link>
-            <a
-              className="coffee-link"
-              href="https://coff.ee/strawberrytech"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              ☕️ Buy me a coffee
-            </a>
-          </div>
-        </div>
+        <CompletionModal
+          imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png"
+          buttonHref="/games/compose"
+          buttonLabel="Play Compose Tweet"
+        >
+          <h3>Congratulations!</h3>
+          <p className="final-score">Your score: {score}</p>
+        </CompletionModal>
       </div>
     )
   }

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -1,5 +1,4 @@
 import { useState, useContext, useEffect } from 'react'
-import { Link } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
@@ -8,8 +7,6 @@ import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import { getTimeLimit } from '../utils/time'
 import './PromptDartsGame.css'
-
-const CONGRATS_VIDEO_URL = 'https://www.youtube.com/embed/dQw4w9WgXcQ'
 
 const KEYWORDS = [
   'list',

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useContext } from 'react'
-import { Link } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import { motion } from 'framer-motion'
 import confetti from 'canvas-confetti'

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useContext } from 'react'
 import { Link } from 'react-router-dom'
+import CompletionModal from '../components/ui/CompletionModal'
 import { motion } from 'framer-motion'
 import confetti from 'canvas-confetti'
 import { toast } from 'react-hot-toast'
@@ -417,13 +418,14 @@ export default function PromptRecipeGame() {
 
   if (finished) {
     return (
-      <div className="recipe-page">
-        <InstructionBanner>You finished Prompt Builder!</InstructionBanner>
+      <CompletionModal
+        imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
+        buttonHref="/games/darts"
+        buttonLabel="Play Prompt Darts"
+      >
+        <h3>You finished Prompt Builder!</h3>
         <p className="final-score">Your score: {score}</p>
-        <p style={{ marginTop: '1rem' }}>
-          <Link to="/leaderboard">Return to Progress</Link>
-        </p>
-      </div>
+      </CompletionModal>
     )
   }
 

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -3,6 +3,7 @@ import ProgressSidebar from '../components/layout/ProgressSidebar'
 import { motion } from 'framer-motion'
 import { toast } from 'react-hot-toast'
 import { Link, useNavigate } from 'react-router-dom'
+import CompletionModal from '../components/ui/CompletionModal'
 import { UserContext } from '../context/UserContext'
 import './QuizGame.css'
 import InstructionBanner from '../components/ui/InstructionBanner'
@@ -127,6 +128,7 @@ export default function QuizGame() {
   const [score, setScoreState] = useState(0)
   const [played, setPlayed] = useState(0)
   const [streak, setStreak] = useState(0)
+  const [finished, setFinished] = useState(false)
   const NUM_STATEMENTS = 3
 
   const current = ROUNDS[round]
@@ -161,10 +163,7 @@ export default function QuizGame() {
         addBadge('quiz-whiz')
       }
       toast.success(`You scored ${newScore} out of ${ROUNDS.length}`)
-      setScoreState(0)
-      setPlayed(0)
-      setChoice(null)
-      setRound(0)
+      setFinished(true)
       return
     }
     setChoice(null)
@@ -190,6 +189,7 @@ export default function QuizGame() {
   }, [])
 
   return (
+    <>
     <div className="quiz-page">
       <ChallengeBanner />
       <InstructionBanner>
@@ -268,5 +268,16 @@ export default function QuizGame() {
         </div>
       </div>
     </div>
+    {finished && (
+      <CompletionModal
+        imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_51_28%20PM.png"
+        buttonHref="/games/escape"
+        buttonLabel="Play Escape Room"
+      >
+        <h3>You finished the quiz!</h3>
+        <p className="final-score">Your score: {score}</p>
+      </CompletionModal>
+    )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add reusable CompletionModal component for learning-games
- display CompletionModal after completing each game
- wire up navigation between games via CompletionModal buttons

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint config missing)*


------
https://chatgpt.com/codex/tasks/task_e_68461349fa14832f87590c6741dd65ae