### PR TITLE
Update game navigation sequence

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import ProgressBar from '../components/ui/ProgressBar'
@@ -104,6 +105,7 @@ const TOTAL_STEPS = 4
 
 export default function ClarityEscapeRoom() {
   const { setScore } = useContext(UserContext)
+  const navigate = useNavigate()
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')
@@ -298,6 +300,19 @@ export default function ClarityEscapeRoom() {
           </div>
         </div>
         <ProgressSidebar />
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => navigate('/games/recipe')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link to="/games/recipe">Skip to Prompt Builder</Link>
+          </p>
+        </div>
       </div>
       {showSummary && (
         <CompletionModal

--- a/learning-games/src/pages/ComposeTweetGame.css
+++ b/learning-games/src/pages/ComposeTweetGame.css
@@ -3,7 +3,8 @@
   display: grid;
   grid-template-columns: 200px 1fr 200px;
   grid-template-areas:
-    'sidebar game progress';
+    'sidebar game progress'
+    'next    next  next';
   gap: 1rem;
   align-items: start;
 }
@@ -73,12 +74,18 @@
   font-weight: bold;
 }
 
+.next-area {
+  grid-area: next;
+  text-align: center;
+}
+
 @media (max-width: 600px) {
   .compose-wrapper {
     grid-template-columns: 1fr;
     grid-template-areas:
       'game'
       'sidebar'
-      'progress';
+      'progress'
+      'next';
   }
 }

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect, useRef, useContext } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { scorePrompt } from '../utils/scorePrompt'
 
@@ -34,6 +35,7 @@ const pairs: PromptPair[] = [
 
 export default function ComposeTweetGame() {
   const { setScore, addBadge, user } = useContext(UserContext)
+  const navigate = useNavigate()
   const [guess, setGuess] = useState('')
   const [feedback, setFeedback] = useState('')
   const [doorUnlocked, setDoorUnlocked] = useState(false)
@@ -184,6 +186,19 @@ export default function ComposeTweetGame() {
           )}
         </div>
         <ProgressSidebar />
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => navigate('/leaderboard')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link to="/leaderboard">Return to Progress</Link>
+          </p>
+        </div>
       </div>
     </div>
     {showNext && round + 1 >= pairs.length && (

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -1,4 +1,5 @@
 import { useState, useContext, useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import InstructionBanner from '../components/ui/InstructionBanner'
@@ -274,6 +275,7 @@ export function streakBonus(streak: number) {
 export default function PromptDartsGame() {
 
   const { setScore, user } = useContext(UserContext)
+  const navigate = useNavigate()
   const [rounds, setRounds] = useState<DartRound[]>([])
   const [round, setRound] = useState(0)
 
@@ -499,8 +501,21 @@ export default function PromptDartsGame() {
         <ProgressSidebar />
         <div className="next-area">
           {choice !== null && (
-            <button className="btn-primary" onClick={next}>{round + 1 < rounds.length ? 'Next Round' : 'Finish'}</button>
+            <button className="btn-primary" onClick={next}>
+              {round + 1 < rounds.length ? 'Next Round' : 'Finish'}
+            </button>
           )}
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => navigate('/games/compose')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link to="/games/compose">Skip to Compose</Link>
+          </p>
         </div>
       </div>
     </div>

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useContext } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import { motion } from 'framer-motion'
 import confetti from 'canvas-confetti'
@@ -172,6 +173,7 @@ async function generateCards(): Promise<Card[]> {
 
 export default function PromptRecipeGame() {
   const { setScore, addBadge, user } = useContext(UserContext)
+  const navigate = useNavigate()
   const TOTAL_ROUNDS = 5
   const TOTAL_TIME = getTimeLimit(user, {
     easy: 45,
@@ -524,6 +526,19 @@ export default function PromptRecipeGame() {
             <button className="btn-primary" onClick={nextRound}>Next Recipe</button>
           </div>
         )}
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => navigate('/games/darts')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link to="/games/darts">Skip to Prompt Darts</Link>
+          </p>
+        </div>
       </div>
     </div>
   )

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -260,7 +260,12 @@ export default function QuizGame() {
         <ProgressSidebar />
         <div className="next-area">
           <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-            <button className="btn-primary" onClick={() => navigate('/leaderboard')}>Next</button>
+            <button
+              className="btn-primary"
+              onClick={() => navigate('/games/escape')}
+            >
+              Next
+            </button>
           </p>
           <p style={{ marginTop: '1rem', textAlign: 'center' }}>
             <Link to="/leaderboard">Return to Progress</Link>

--- a/nextjs-app/src/pages/games/compose.tsx
+++ b/nextjs-app/src/pages/games/compose.tsx
@@ -1,5 +1,7 @@
 
 import { useState, useEffect, useRef, useContext } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 import { scorePrompt } from '../../utils/scorePrompt'
 
@@ -35,6 +37,7 @@ const pairs: PromptPair[] = [
 
 export default function ComposeTweetGame() {
   const { setScore, addBadge, user } = useContext(UserContext)
+  const router = useRouter()
   const [guess, setGuess] = useState('')
   const [feedback, setFeedback] = useState('')
   const [doorUnlocked, setDoorUnlocked] = useState(false)
@@ -196,6 +199,19 @@ export default function ComposeTweetGame() {
           )}
         </div>
         <ProgressSidebar />
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => router.push('/leaderboard')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link href="/leaderboard">Return to Progress</Link>
+          </p>
+        </div>
       </div>
     </div>
     {finished && (

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -1,5 +1,6 @@
 import { useState, useContext, useEffect } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import TimerBar from '../../components/ui/TimerBar'
@@ -270,6 +271,7 @@ export function streakBonus(streak: number) {
 export default function PromptDartsGame() {
 
   const { setScore, user } = useContext(UserContext)
+  const router = useRouter()
   const [rounds, setRounds] = useState<DartRound[]>([])
   const [round, setRound] = useState(0)
 
@@ -537,8 +539,21 @@ export default function PromptDartsGame() {
         <ProgressSidebar />
         <div className="next-area">
           {choice !== null && (
-            <button className="btn-primary" onClick={next}>{round + 1 < rounds.length ? 'Next Round' : 'Finish'}</button>
+            <button className="btn-primary" onClick={next}>
+              {round + 1 < rounds.length ? 'Next Round' : 'Finish'}
+            </button>
           )}
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => router.push('/games/compose')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link href="/games/compose">Skip to Compose</Link>
+          </p>
         </div>
       </div>
     </div>

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import ProgressBar from '../../components/ui/ProgressBar'
 import DoorAnimation from '../../components/DoorAnimation'
@@ -345,6 +346,19 @@ export default function ClarityEscapeRoom() {
           </div>
         </div>
         <ProgressSidebar />
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => router.push('/games/recipe')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link href="/games/recipe">Skip to Prompt Builder</Link>
+          </p>
+        </div>
       </div>
       {showSummary && (
         <CompletionModal

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -302,7 +302,12 @@ export default function QuizGame() {
         <ProgressSidebar />
         <div className="next-area">
           <p style={{ marginTop: '1rem', textAlign: 'center' }}>
-            <button className="btn-primary" onClick={() => router.push('/leaderboard')}>Next</button>
+            <button
+              className="btn-primary"
+              onClick={() => router.push('/games/escape')}
+            >
+              Next
+            </button>
           </p>
           <p style={{ marginTop: '1rem', textAlign: 'center' }}>
             <Link href="/leaderboard">Return to Progress</Link>

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useContext } from 'react'
 import Link from 'next/link'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import { motion } from 'framer-motion'
 import confetti from 'canvas-confetti'
 import { toast } from 'react-hot-toast'
@@ -175,6 +176,7 @@ async function generateCards(): Promise<Card[]> {
 
 export default function PromptRecipeGame() {
   const { setScore, addBadge, user } = useContext(UserContext)
+  const router = useRouter()
   const TOTAL_ROUNDS = 5
   const TOTAL_TIME = getTimeLimit(user, {
     easy: 45,
@@ -568,6 +570,19 @@ export default function PromptRecipeGame() {
             <button className="btn-primary" onClick={nextRound}>Next Recipe</button>
           </div>
         )}
+        <div className="next-area">
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <button
+              className="btn-primary"
+              onClick={() => router.push('/games/darts')}
+            >
+              Next
+            </button>
+          </p>
+          <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+            <Link href="/games/darts">Skip to Prompt Darts</Link>
+          </p>
+        </div>
       </div>
     </div>
     </>

--- a/nextjs-app/src/styles/ComposeTweetGame.css
+++ b/nextjs-app/src/styles/ComposeTweetGame.css
@@ -3,7 +3,8 @@
   display: grid;
   grid-template-columns: 200px 1fr 200px;
   grid-template-areas:
-    'sidebar game progress';
+    'sidebar game progress'
+    'next    next  next';
   gap: 1rem;
   align-items: start;
 }
@@ -73,12 +74,18 @@
   font-weight: bold;
 }
 
+.next-area {
+  grid-area: next;
+  text-align: center;
+}
+
 @media (max-width: 600px) {
   .compose-wrapper {
     grid-template-columns: 1fr;
     grid-template-areas:
       'game'
       'sidebar'
-      'progress';
+      'progress'
+      'next';
   }
 }


### PR DESCRIPTION
## Summary
- change quiz next button to go to escape game
- add next buttons for each game to form a chain: escape -> builder -> darts -> compose -> leaderboard
- style compose twitter page to include next-area

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in nextjs-app *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68461c21f918832f9f78d4e8795b14b3