### PR TITLE
Implement mobile navbar styles

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -455,6 +455,23 @@
   }
 }
 
+@media (max-width: 480px) {
+  .navbar ul {
+    font-size: 0.9rem;
+    padding: 0.25rem 0;
+    flex-wrap: wrap;
+  }
+
+  .menu-toggle {
+    font-size: 1.25rem;
+  }
+
+  .brand-logo {
+    width: 36px;
+    height: 36px;
+  }
+}
+
 .hero {
   background: linear-gradient(135deg, var(--color-blue), var(--color-brand));
   background-size: 200% 200%;

--- a/nextjs-app/src/styles/App.css
+++ b/nextjs-app/src/styles/App.css
@@ -455,6 +455,23 @@
   }
 }
 
+@media (max-width: 480px) {
+  .navbar ul {
+    font-size: 0.9rem;
+    padding: 0.25rem 0;
+    flex-wrap: wrap;
+  }
+
+  .menu-toggle {
+    font-size: 1.25rem;
+  }
+
+  .brand-logo {
+    width: 36px;
+    height: 36px;
+  }
+}
+
 .hero {
   background: linear-gradient(135deg, var(--color-blue), var(--color-brand));
   background-size: 200% 200%;


### PR DESCRIPTION
## Summary
- tweak navigation bar styling for max-width 480px
- reduce menu size, allow wrapping, and scale menu toggle/brand logo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846250577d0832fb116dd0d5dbb0a57