### PR TITLE
Add collapsible menus to NavBar

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -400,6 +400,33 @@
   padding: 0.5rem 0.5rem;
 }
 
+.submenu-toggle {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.submenu-toggle:hover {
+  color: var(--color-lime);
+}
+
+.submenu ul {
+  display: none;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 1rem;
+  gap: 0.25rem;
+  background: var(--color-brand);
+}
+
+.submenu ul.open {
+  display: flex;
+}
+
 .navbar a {
   color: #fff;
   font-weight: 600;

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -1,10 +1,24 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import Tooltip from '../ui/Tooltip'
 import ThemeToggle from './ThemeToggle'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
+  const [gamesOpen, setGamesOpen] = useState(false)
+  const [progressOpen, setProgressOpen] = useState(false)
+  const [accountOpen, setAccountOpen] = useState(false)
+  const [communityOpen, setCommunityOpen] = useState(false)
+
+  // Close submenus when hamburger menu closes
+  useEffect(() => {
+    if (!open) {
+      setGamesOpen(false)
+      setProgressOpen(false)
+      setAccountOpen(false)
+      setCommunityOpen(false)
+    }
+  }, [open])
 
   return (
     <nav className="navbar" style={{ position: 'sticky', top: 0 }} aria-label="Main navigation">
@@ -26,73 +40,157 @@ export default function NavBar() {
       >
         ☰
       </button>
-      <ul className={open ? 'open' : undefined} onClick={() => setOpen(false)}>
+      <ul className={open ? 'open' : undefined}>
         <li>
           <Tooltip message="Hover here for a surprise!">
-            <Link to="/">Home</Link>
+            <Link to="/" onClick={() => setOpen(false)}>
+              Home
+            </Link>
           </Tooltip>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/games/tone">Tone</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={gamesOpen}
+            aria-controls="games-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setGamesOpen(o => !o)
+            }}
+          >
+            Games
+          </button>
+          <ul id="games-submenu" className={gamesOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/games/tone" onClick={() => setOpen(false)}>
+                  Tone
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/games/quiz" onClick={() => setOpen(false)}>
+                  Hallucinations
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/games/escape" onClick={() => setOpen(false)}>
+                  Escape Room
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/games/recipe" onClick={() => setOpen(false)}>
+                  Prompt Builder
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/games/darts" onClick={() => setOpen(false)}>
+                  Prompt Darts
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/games/compose" onClick={() => setOpen(false)}>
+                  Compose Tweet
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/games/quiz">Hallucinations</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={progressOpen}
+            aria-controls="progress-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setProgressOpen(o => !o)
+            }}
+          >
+            Progress
+          </button>
+          <ul id="progress-submenu" className={progressOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/leaderboard" onClick={() => setOpen(false)}>
+                  Leaderboard
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/badges" onClick={() => setOpen(false)}>
+                  Badges
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-
-            <Link to="/games/escape">Escape Room</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={accountOpen}
+            aria-controls="account-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setAccountOpen(o => !o)
+            }}
+          >
+            Account &amp; Help
+          </button>
+          <ul id="account-submenu" className={accountOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/profile" onClick={() => setOpen(false)}>
+                  Profile
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/help" onClick={() => setOpen(false)}>
+                  Help
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-
-            <Link to="/games/recipe">Prompt Builder</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/games/darts">Prompt Darts</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/games/compose">Compose Tweet</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/leaderboard">Progress</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/badges">Badges</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/community">Community</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/playlist">Playlist</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/help">Help</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link to="/profile">Profile</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={communityOpen}
+            aria-controls="community-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setCommunityOpen(o => !o)
+            }}
+          >
+            Community
+          </button>
+          <ul id="community-submenu" className={communityOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/community" onClick={() => setOpen(false)}>
+                  Community Home
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link to="/playlist" onClick={() => setOpen(false)}>
+                  Playlist
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
       </ul>
     </nav>

--- a/nextjs-app/src/components/layout/NavBar.tsx
+++ b/nextjs-app/src/components/layout/NavBar.tsx
@@ -1,10 +1,24 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Tooltip from '../ui/Tooltip'
 import ThemeToggle from './ThemeToggle'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
+  const [gamesOpen, setGamesOpen] = useState(false)
+  const [progressOpen, setProgressOpen] = useState(false)
+  const [accountOpen, setAccountOpen] = useState(false)
+  const [communityOpen, setCommunityOpen] = useState(false)
+
+  // Close submenus when hamburger menu closes
+  useEffect(() => {
+    if (!open) {
+      setGamesOpen(false)
+      setProgressOpen(false)
+      setAccountOpen(false)
+      setCommunityOpen(false)
+    }
+  }, [open])
 
   return (
     <nav className="navbar" style={{ position: 'sticky', top: 0 }} aria-label="Main navigation">
@@ -26,73 +40,157 @@ export default function NavBar() {
       >
         ☰
       </button>
-      <ul className={open ? 'open' : undefined} onClick={() => setOpen(false)}>
+      <ul className={open ? 'open' : undefined}>
         <li>
           <Tooltip message="Hover here for a surprise!">
-            <Link href="/">Home</Link>
+            <Link href="/" onClick={() => setOpen(false)}>
+              Home
+            </Link>
           </Tooltip>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/games/tone">Tone</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={gamesOpen}
+            aria-controls="games-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setGamesOpen(o => !o)
+            }}
+          >
+            Games
+          </button>
+          <ul id="games-submenu" className={gamesOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/games/tone" onClick={() => setOpen(false)}>
+                  Tone
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/games/quiz" onClick={() => setOpen(false)}>
+                  Hallucinations
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/games/escape" onClick={() => setOpen(false)}>
+                  Escape Room
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/games/recipe" onClick={() => setOpen(false)}>
+                  Prompt Builder
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/games/darts" onClick={() => setOpen(false)}>
+                  Prompt Darts
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/games/compose" onClick={() => setOpen(false)}>
+                  Compose Tweet
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/games/quiz">Hallucinations</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={progressOpen}
+            aria-controls="progress-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setProgressOpen(o => !o)
+            }}
+          >
+            Progress
+          </button>
+          <ul id="progress-submenu" className={progressOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/leaderboard" onClick={() => setOpen(false)}>
+                  Leaderboard
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/badges" onClick={() => setOpen(false)}>
+                  Badges
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-
-            <Link href="/games/escape">Escape Room</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={accountOpen}
+            aria-controls="account-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setAccountOpen(o => !o)
+            }}
+          >
+            Account &amp; Help
+          </button>
+          <ul id="account-submenu" className={accountOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/profile" onClick={() => setOpen(false)}>
+                  Profile
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/help" onClick={() => setOpen(false)}>
+                  Help
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-
-            <Link href="/games/recipe">Prompt Builder</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/games/darts">Prompt Darts</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/games/compose">Compose Tweet</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/leaderboard">Progress</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/badges">Badges</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/community">Community</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/playlist">Playlist</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/help">Help</Link>
-          </Tooltip>
-        </li>
-        <li>
-          <Tooltip message="Hover here for a surprise!">
-            <Link href="/profile">Profile</Link>
-          </Tooltip>
+        <li className="submenu">
+          <button
+            className="submenu-toggle"
+            aria-expanded={communityOpen}
+            aria-controls="community-submenu"
+            onClick={e => {
+              e.stopPropagation()
+              setCommunityOpen(o => !o)
+            }}
+          >
+            Community
+          </button>
+          <ul id="community-submenu" className={communityOpen ? 'open' : undefined}>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/community" onClick={() => setOpen(false)}>
+                  Community Home
+                </Link>
+              </Tooltip>
+            </li>
+            <li>
+              <Tooltip message="Hover here for a surprise!">
+                <Link href="/playlist" onClick={() => setOpen(false)}>
+                  Playlist
+                </Link>
+              </Tooltip>
+            </li>
+          </ul>
         </li>
       </ul>
     </nav>

--- a/nextjs-app/src/styles/App.css
+++ b/nextjs-app/src/styles/App.css
@@ -400,6 +400,33 @@
   padding: 0.5rem 0.5rem;
 }
 
+.submenu-toggle {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.submenu-toggle:hover {
+  color: var(--color-lime);
+}
+
+.submenu ul {
+  display: none;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 1rem;
+  gap: 0.25rem;
+  background: var(--color-brand);
+}
+
+.submenu ul.open {
+  display: flex;
+}
+
 .navbar a {
   color: #fff;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- group navigation items into collapsible submenus
- style submenus with theme colors

## Testing
- `npm run lint` in nextjs-app *(fails: various lint errors)*
- `npm run lint` in learning-games *(passes with warnings)*
- `npm test` in learning-games

------
https://chatgpt.com/codex/tasks/task_e_684624ff56b8832fb091f98272c35e60