### PR TITLE
Remove NavBar inline style

### DIFF
--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -21,7 +21,7 @@ export default function NavBar() {
   }, [open])
 
   return (
-    <nav className="navbar" style={{ position: 'sticky', top: 0 }} aria-label="Main navigation">
+    <nav className="navbar" aria-label="Main navigation">
       <div className="brand">
         <img
           src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"

--- a/nextjs-app/src/components/layout/NavBar.tsx
+++ b/nextjs-app/src/components/layout/NavBar.tsx
@@ -21,7 +21,7 @@ export default function NavBar() {
   }, [open])
 
   return (
-    <nav className="navbar" style={{ position: 'sticky', top: 0 }} aria-label="Main navigation">
+    <nav className="navbar" aria-label="Main navigation">
       <div className="brand">
         <img
           src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"


### PR DESCRIPTION
## Summary
- rely on CSS for sticky NavBar instead of inline style

## Testing
- `npm test` in `learning-games`
- `npm run lint` in `learning-games`
- `npm install` and `npm run lint` in `nextjs-app`

------
https://chatgpt.com/codex/tasks/task_e_684626e36244832fb1dab76a8e2a7eb6