### PR TITLE
Move theme toggle to profile pages

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -366,7 +366,6 @@
   top: 0;
   z-index: 100;
   display: flex;
-  justify-content: space-between;
   align-items: center;
   background: var(--color-brand);
   padding: 1rem 2rem;
@@ -393,6 +392,7 @@
   display: flex;
   gap: 1.25rem;
   margin: 0;
+  margin-left: auto;
   padding: 0;
   font-size: 1.1rem;
 }

--- a/learning-games/src/components/layout/NavBar.tsx
+++ b/learning-games/src/components/layout/NavBar.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import Tooltip from '../ui/Tooltip'
-import ThemeToggle from './ThemeToggle'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
@@ -30,9 +29,6 @@ export default function NavBar() {
         />
         StrawberryTech
       </div>
-      <Tooltip message="Improve readability">
-        <ThemeToggle />
-      </Tooltip>
       <button
         className="menu-toggle"
         aria-label="Toggle navigation"

--- a/learning-games/src/pages/ProfilePage.tsx
+++ b/learning-games/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { toast } from 'react-hot-toast'
 import { UserContext } from '../context/UserContext'
+import ThemeToggle from '../components/layout/ThemeToggle'
 import './ProfilePage.css'
 
 export default function ProfilePage() {
@@ -55,6 +56,7 @@ export default function ProfilePage() {
           <option value="medium">Medium</option>
           <option value="hard">Hard</option>
         </select>
+        <ThemeToggle />
         <button type="submit">Save</button>
         <Link to="/leaderboard" className="return-link">
           Return to Progress

--- a/nextjs-app/src/components/layout/NavBar.tsx
+++ b/nextjs-app/src/components/layout/NavBar.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Tooltip from '../ui/Tooltip'
-import ThemeToggle from './ThemeToggle'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
@@ -30,9 +29,6 @@ export default function NavBar() {
         />
         StrawberryTech
       </div>
-      <Tooltip message="Improve readability">
-        <ThemeToggle />
-      </Tooltip>
       <button
         className="menu-toggle"
         aria-label="Toggle navigation"

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -2,6 +2,7 @@ import { useContext, useState } from 'react'
 import Link from 'next/link'
 import { toast } from 'react-hot-toast'
 import { UserContext } from '../context/UserContext'
+import ThemeToggle from '../components/layout/ThemeToggle'
 import '../styles/ProfilePage.css'
 
 export default function ProfilePage() {
@@ -55,6 +56,7 @@ export default function ProfilePage() {
           <option value="medium">Medium</option>
           <option value="hard">Hard</option>
         </select>
+        <ThemeToggle />
         <button type="submit">Save</button>
         <Link href="/leaderboard" className="return-link">
           Return to Progress

--- a/nextjs-app/src/styles/App.css
+++ b/nextjs-app/src/styles/App.css
@@ -366,7 +366,6 @@
   top: 0;
   z-index: 100;
   display: flex;
-  justify-content: space-between;
   align-items: center;
   background: var(--color-brand);
   padding: 1rem 2rem;
@@ -393,6 +392,7 @@
   display: flex;
   gap: 1.25rem;
   margin: 0;
+  margin-left: auto;
   padding: 0;
   font-size: 1.1rem;
 }


### PR DESCRIPTION
## Summary
- clean up navbar by removing the theme toggle
- allow users to change contrast on profile pages
- adjust navbar layout so links align with flexbox
- update matching styles in learning-games

## Testing
- `npm test` *(fails: Missing script: "test" in `nextjs-app`)*
- `npm test` in `learning-games`

------
https://chatgpt.com/codex/tasks/task_e_68462db3bcdc832fb48f5819898e9ba3