### PR TITLE
Make community API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The community feedback page uses the same API for sentiment filtering. Set
 `OPENAI_API_KEY` in the server environment so posts can be screened before
 publishing.
 
+To point the Next.js frontend at a custom server URL set `NEXT_PUBLIC_API_BASE`
+in `nextjs-app/.env`. When omitted, the app defaults to `window.location.origin`
+so the API can be served from the same host in production.
+
 The API server now persists data in Firebase. Provide service account credentials
 by setting `FIREBASE_SERVICE_ACCOUNT` to a JSON string or path, or use
 `GOOGLE_APPLICATION_CREDENTIALS` to point to a credentials file.

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -34,9 +34,19 @@ export default function CommunityPage() {
   const [error, setError] = useState('')
   const [notice, setNotice] = useState('')
 
+  function getApiBase() {
+    if (process.env.NEXT_PUBLIC_API_BASE) {
+      return process.env.NEXT_PUBLIC_API_BASE
+    }
+    if (typeof window !== 'undefined') {
+      return window.location.origin
+    }
+    return ''
+  }
+
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/posts`)
         .then((res) => (res.ok ? res.json() : []))
         .then((data: PostData[]) => setPosts(data.length ? data : initialPosts))
@@ -51,7 +61,7 @@ export default function CommunityPage() {
   function flagPost(id: number) {
     setPosts((prev) => prev.map((p) => (p.id === id ? { ...p, flagged: true } : p)))
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' }).catch(() => {})
     }
   }
@@ -60,7 +70,7 @@ export default function CommunityPage() {
     e.preventDefault()
     if (message.trim()) {
       try {
-        const base = window.location.origin
+        const base = getApiBase()
         const resp = await fetch(`${base}/api/posts`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- support `NEXT_PUBLIC_API_BASE` in community page
- document the new variable for configuring API base URL

## Testing
- `npm run lint` *(fails: using `<img>` and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846302f6144832fabbd1caea1197d5a