### PR TITLE
Move navbar theme toggle to profile page

### DIFF
--- a/nextjs-app/src/components/layout/NavBar.tsx
+++ b/nextjs-app/src/components/layout/NavBar.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Tooltip from '../ui/Tooltip'
-import ThemeToggle from './ThemeToggle'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
@@ -30,9 +29,6 @@ export default function NavBar() {
         />
         StrawberryTech
       </div>
-      <Tooltip message="Improve readability">
-        <ThemeToggle />
-      </Tooltip>
       <button
         className="menu-toggle"
         aria-label="Toggle navigation"

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -2,6 +2,8 @@ import { useContext, useState } from 'react'
 import Link from 'next/link'
 import { toast } from 'react-hot-toast'
 import { UserContext } from '../context/UserContext'
+import ThemeToggle from '../components/layout/ThemeToggle'
+import Tooltip from '../components/ui/Tooltip'
 import '../styles/ProfilePage.css'
 
 export default function ProfilePage() {
@@ -55,6 +57,9 @@ export default function ProfilePage() {
           <option value="medium">Medium</option>
           <option value="hard">Hard</option>
         </select>
+        <Tooltip message="Improve readability">
+          <ThemeToggle />
+        </Tooltip>
         <button type="submit">Save</button>
         <Link href="/leaderboard" className="return-link">
           Return to Progress

--- a/nextjs-app/src/styles/App.css
+++ b/nextjs-app/src/styles/App.css
@@ -368,6 +368,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   background: var(--color-brand);
   padding: 1rem 2rem;
   color: #fff;
@@ -456,11 +457,13 @@
   color: #fff;
   font-size: 1.5rem;
   cursor: pointer;
+  margin-left: auto;
 }
 
 @media (max-width: 1000px) {
   .navbar {
     flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
   .menu-toggle {


### PR DESCRIPTION
## Summary
- remove `ThemeToggle` from `NavBar`
- adjust `.navbar` spacing after removing toggle
- add contrast toggle to profile page

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462c5f2cb0832fad2d2311c01be587