### PR TITLE
Add loading spinner to stats page

### DIFF
--- a/nextjs-app/src/components/ui/Spinner.css
+++ b/nextjs-app/src/components/ui/Spinner.css
@@ -1,0 +1,15 @@
+.spinner {
+  border: 4px solid rgba(0, 0, 0, 0.1);
+  border-top-color: var(--color-brand);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spinner-rotate 0.8s linear infinite;
+  margin: 2rem auto;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/nextjs-app/src/components/ui/Spinner.tsx
+++ b/nextjs-app/src/components/ui/Spinner.tsx
@@ -1,0 +1,5 @@
+import './Spinner.css'
+
+export default function Spinner() {
+  return <div className="spinner" role="status" aria-label="Loading" />
+}

--- a/nextjs-app/src/pages/stats.tsx
+++ b/nextjs-app/src/pages/stats.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import Spinner from '../components/ui/Spinner'
 
 interface ViewData {
   id: number
@@ -15,14 +16,17 @@ interface ViewData {
 
 export default function StatsPage() {
   const [views, setViews] = useState<ViewData[]>([])
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const base = window.location.origin
+      setLoading(true)
       fetch(`${base}/api/views`)
         .then(res => (res.ok ? res.json() : []))
         .then(data => setViews(Array.isArray(data) ? data : []))
         .catch(() => {})
+        .finally(() => setLoading(false))
     }
   }, [])
 
@@ -72,22 +76,28 @@ export default function StatsPage() {
   return (
     <div className="stats-page">
       <h2>Site Statistics</h2>
-      <img
-        src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
-        alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
-        className="brand-logo"
-        style={{ width: '48px' }}
-      />
-      <p>Total Views: {views.length}</p>
-      <p>Unique Visitors: {uniqueVisitors}</p>
-      <p>Average Session (s): {avgDuration}</p>
-      <p>Views last hour: {viewsLastHour}</p>
-      <p>Views last day: {viewsLastDay}</p>
-      <p>Views last week: {viewsLastWeek}</p>
-      <p>Views last month: {viewsLastMonth}</p>
-      <svg width={chartWidth + 20} height={chartHeight + 20} aria-label="Views line chart">
-        <polyline points={points} fill="none" stroke="blue" strokeWidth="2" />
-      </svg>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <>
+          <img
+            src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+            alt="Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones."
+            className="brand-logo"
+            style={{ width: '48px' }}
+          />
+          <p>Total Views: {views.length}</p>
+          <p>Unique Visitors: {uniqueVisitors}</p>
+          <p>Average Session (s): {avgDuration}</p>
+          <p>Views last hour: {viewsLastHour}</p>
+          <p>Views last day: {viewsLastDay}</p>
+          <p>Views last week: {viewsLastWeek}</p>
+          <p>Views last month: {viewsLastMonth}</p>
+          <svg width={chartWidth + 20} height={chartHeight + 20} aria-label="Views line chart">
+            <polyline points={points} fill="none" stroke="blue" strokeWidth="2" />
+          </svg>
+        </>
+      )}
       <p style={{ marginTop: '2rem' }}>
         <Link href="/">Return Home</Link>
       </p>


### PR DESCRIPTION
## Summary
- create a simple `Spinner` component
- show `Spinner` during stats data fetch

## Testing
- `npm run lint` *(fails: no-html-link-for-pages and other pre-existing errors)*
- `npm run build` *(fails: build errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6846304cce98832f99207ba2c34a1fa6