### PR TITLE
Handle errors when community posts fail

### DIFF
--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
+import { toast } from 'react-hot-toast'
 import { Link } from 'react-router-dom'
 import Post from '../components/Post'
 import type { PostData } from '../components/Post'
@@ -44,7 +45,10 @@ export default function CommunityPage() {
         .then((data: PostData[]) =>
           setPosts(data.length ? prunePosts(data) : initialPosts)
         )
-        .catch(() => {})
+        .catch(() => {
+          setError('Failed to load posts')
+          toast.error('Failed to load posts')
+        })
     }
   }, [])
 
@@ -57,7 +61,11 @@ export default function CommunityPage() {
     setPosts((prev) => prev.map((p) => (p.id === id ? { ...p, flagged: true } : p)))
     if (typeof window !== 'undefined') {
       const base = window.location.origin
-      fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' }).catch(() => {})
+      fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' })
+        .catch(() => {
+          setError('Failed to flag post')
+          toast.error('Failed to flag post')
+        })
     }
   }
 
@@ -81,7 +89,10 @@ export default function CommunityPage() {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(newPost),
-        }).catch(() => {})
+        }).catch(() => {
+          setError('Failed to post')
+          toast.error('Failed to post')
+        })
       }
       setError('')
       setMessage('')

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
+import { toast } from 'react-hot-toast'
 import Link from 'next/link'
 import Post from '../components/Post'
 import type { PostData } from '../components/Post'
@@ -51,7 +52,10 @@ export default function CommunityPage() {
       fetch(`${base}/api/posts`)
         .then((res) => (res.ok ? res.json() : []))
         .then((data: PostData[]) => setPosts(data.length ? data : initialPosts))
-        .catch(() => {})
+        .catch(() => {
+          setError('Failed to load posts')
+          toast.error('Failed to load posts')
+        })
     }
   }, [])
 
@@ -63,7 +67,11 @@ export default function CommunityPage() {
     setPosts((prev) => prev.map((p) => (p.id === id ? { ...p, flagged: true } : p)))
     if (typeof window !== 'undefined') {
       const base = getApiBase()
-      fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' }).catch(() => {})
+      fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' })
+        .catch(() => {
+          setError('Failed to flag post')
+          toast.error('Failed to flag post')
+        })
     }
   }
 


### PR DESCRIPTION
## Summary
- update community pages to surface errors
- show toast messages when posts fail to load or flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68463203d2e8832f959211f54c0aaa98