### PR TITLE
Show collapsed nav on all screens

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -367,6 +367,8 @@
   z-index: 100;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   background: var(--color-brand);
   padding: 1rem 2rem;
   color: #fff;
@@ -389,11 +391,14 @@
 
 .navbar ul {
   list-style: none;
-  display: flex;
-  gap: 1.25rem;
+  display: none;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.5rem;
   margin: 0;
-  margin-left: auto;
-  padding: 0;
+  margin-top: 0.5rem;
+  background: var(--color-brand);
+  padding: 0.5rem 0;
   font-size: 1.1rem;
 }
 .navbar li {
@@ -449,8 +454,9 @@
   height: 48px;
 }
 
+/* show hamburger toggle on all viewports */
 .menu-toggle {
-  display: none;
+  display: block;
   background: transparent;
   border: none;
   color: #fff;
@@ -458,29 +464,7 @@
   cursor: pointer;
 }
 
-@media (max-width: 1000px) {
-  .navbar {
-    flex-wrap: wrap;
-  }
 
-  .menu-toggle {
-    display: block;
-  }
-
-  .navbar ul {
-    display: none;
-    width: 100%;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-    background: var(--color-brand);
-    padding: 0.5rem 0;
-  }
-
-  .navbar ul.open {
-    display: flex;
-  }
-}
 
 @media (max-width: 480px) {
   .navbar ul {

--- a/nextjs-app/src/styles/App.css
+++ b/nextjs-app/src/styles/App.css
@@ -367,7 +367,8 @@
   z-index: 100;
   display: flex;
   align-items: center;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   background: var(--color-brand);
   padding: 0.5rem 1rem;
   color: #fff;
@@ -396,11 +397,14 @@
 
 .navbar ul {
   list-style: none;
-  display: flex;
-  gap: 1rem;
+  display: none;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.5rem;
   margin: 0;
-  margin-left: auto;
-  padding: 0 0 0 1.25rem;
+  margin-top: 0.5rem;
+  background: var(--color-brand);
+  padding: 0.5rem 0;
   font-size: 1.1rem;
 }
 .navbar li {
@@ -462,8 +466,9 @@
   height: 40px;
 }
 
+/* show hamburger toggle on all viewports */
 .menu-toggle {
-  display: none;
+  display: block;
   background: transparent;
   border: none;
   color: #fff;
@@ -472,30 +477,7 @@
   margin-left: auto;
 }
 
-@media (max-width: 1000px) {
-  .navbar {
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
 
-  .menu-toggle {
-    display: block;
-  }
-
-  .navbar ul {
-    display: none;
-    width: 100%;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-top: 0.5rem;
-    background: var(--color-brand);
-    padding: 0.5rem 0;
-  }
-
-  .navbar ul.open {
-    display: flex;
-  }
-}
 
 @media (max-width: 480px) {
   .navbar ul {


### PR DESCRIPTION
## Summary
- make menu button visible across all viewport widths
- hide full nav menu by default for mobile-style behavior on desktop

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in nextjs-app *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684637100880832fbc2cefeb6d661fcf