### PR TITLE
Add helper for total points

### DIFF
--- a/learning-games/pages/index.tsx
+++ b/learning-games/pages/index.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { UserContext } from '../src/context/UserContext'
+import { getTotalPoints } from '../src/utils/user'
 
 export default function HomePage() {
   const { user } = useContext(UserContext)
@@ -24,7 +25,7 @@ export default function HomePage() {
     return () => observer.disconnect()
   }, [])
 
-  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const totalPoints = getTotalPoints(user.scores)
 
   return (
     <div className="home">

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -3,11 +3,12 @@ import confetti from 'canvas-confetti'
 import { Link } from 'react-router-dom'
 import { UserContext } from '../../context/UserContext'
 import Tooltip from '../ui/Tooltip'
+import { getTotalPoints } from '../../utils/user'
 import type { ScoreEntry } from '../../pages/LeaderboardPage'
 
 export default function ProgressSidebar() {
   const { user } = useContext(UserContext)
-  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const totalPoints = getTotalPoints(user.scores)
   const GOAL_POINTS = 300
   const celebrated = useRef(false)
   const [scores, setScores] = useState<ScoreEntry[]>([])

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import ProgressSidebarSimple from '../components/layout/ProgressSidebarSimple'
 import GamePageLayout from '../components/layout/GamePageLayout'
 import { UserContext } from '../context/UserContext'
+import { getTotalPoints } from '../utils/user'
 import './DragDropGame.css'
 
 const tones = [
@@ -38,7 +39,7 @@ export default function DragDropGame() {
   const [userMessage, setUserMessage] = useState('')
   const [submitted, setSubmitted] = useState(false)
   const { user } = useContext(UserContext)
-  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const totalPoints = getTotalPoints(user.scores)
   const badgesEarned = user.badges.length
 
   function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { UserContext } from '../context/UserContext'
+import { getTotalPoints } from '../utils/user'
 import './Home.css'
 
 /**
@@ -34,7 +35,7 @@ export default function Home() {
     return () => observer.disconnect()
   }, [])
 
-  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const totalPoints = getTotalPoints(user.scores)
 
   return (
     <div className="home">

--- a/learning-games/src/utils/user.ts
+++ b/learning-games/src/utils/user.ts
@@ -1,0 +1,2 @@
+export const getTotalPoints = (scores: Record<string, number>) =>
+  Object.values(scores).reduce((a, b) => a + b, 0);

--- a/nextjs-app/src/components/layout/ProgressSidebar.tsx
+++ b/nextjs-app/src/components/layout/ProgressSidebar.tsx
@@ -2,12 +2,13 @@ import { useContext, useEffect, useRef, useState } from 'react'
 import confetti from 'canvas-confetti'
 import Link from 'next/link'
 import { UserContext } from '../../context/UserContext'
+import { getTotalPoints } from '../../utils/user'
 import Tooltip from '../ui/Tooltip'
 import type { ScoreEntry } from '../../pages/leaderboard'
 
 export default function ProgressSidebar() {
   const { user } = useContext(UserContext)
-  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const totalPoints = getTotalPoints(user.scores)
   const GOAL_POINTS = 300
   const celebrated = useRef(false)
   const [scores, setScores] = useState<ScoreEntry[]>([])

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import ProgressSidebarSimple from '../../components/layout/ProgressSidebarSimple'
 import GamePageLayout from '../../components/layout/GamePageLayout'
 import { UserContext } from '../../context/UserContext'
+import { getTotalPoints } from '../../utils/user'
 import '../../styles/DragDropGame.css'
 import JsonLd from '../../components/seo/JsonLd'
 
@@ -39,7 +40,7 @@ export default function DragDropGame() {
   const [userMessage, setUserMessage] = useState('')
   const [submitted, setSubmitted] = useState(false)
   const { user } = useContext(UserContext)
-  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const totalPoints = getTotalPoints(user.scores)
   const badgesEarned = user.badges.length
 
   function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect } from 'react'
 import HeadTag from 'next/head'
 import Link from 'next/link'; import { useRouter } from 'next/router'
 import { UserContext } from '../context/UserContext'
+import { getTotalPoints } from '../utils/user'
 import '../styles/Home.css'
 
 /**
@@ -35,7 +36,7 @@ export default function Home() {
     return () => observer.disconnect()
   }, [])
 
-  const totalPoints = Object.values(user.scores).reduce((a, b) => a + b, 0)
+  const totalPoints = getTotalPoints(user.scores)
 
   return (
     <>

--- a/nextjs-app/src/utils/user.ts
+++ b/nextjs-app/src/utils/user.ts
@@ -1,0 +1,2 @@
+export const getTotalPoints = (scores: Record<string, number>) =>
+  Object.values(scores).reduce((a, b) => a + b, 0);


### PR DESCRIPTION
## Summary
- add `getTotalPoints` utility to both apps
- refactor home pages and progress sidebars to use helper
- simplify DragDrop game pages using new function

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test script)*
- `npm run lint` in learning-games *(fails: missing ESLint packages)*
- `npm test` in learning-games *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c3af8a44832f89965890b485667a