### PR TITLE
Show points & leaderboard on profile

### DIFF
--- a/nextjs-app/src/styles/ProfilePage.css
+++ b/nextjs-app/src/styles/ProfilePage.css
@@ -1,5 +1,7 @@
 .profile-page {
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
   justify-content: center;
   align-items: center;
   min-height: 80vh;
@@ -65,6 +67,38 @@
 
 .return-link:hover {
   color: var(--color-deep-red);
+}
+
+.stats-card {
+  background: #fff;
+  color: var(--color-text-dark);
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  margin-top: 1rem;
+  width: 320px;
+  max-width: 100%;
+}
+
+.score-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+.score-table th,
+.score-table td {
+  text-align: left;
+  padding: 0.25rem 0.5rem;
+}
+
+.score-table th {
+  background: var(--color-brand);
+  color: #fff;
+}
+
+.score-table tbody tr:nth-child(odd) {
+  background: #f7f7f7;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- display progress stats on the profile page
- style new progress card

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c829de4c832fbe80f30579189d26