### PR TITLE
Show player rank in sidebar leaderboards

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -247,6 +247,11 @@ app.get('/api/scores', async (req, res) => {
   const snap = await scores.get();
   const data = {};
   snap.forEach(doc => (data[doc.id] = doc.data().entries || []));
+  // Ensure all known games exist in the response
+  const allGames = ['tone', 'quiz', 'darts', 'recipe', 'escape', 'compose'];
+  allGames.forEach(g => {
+    if (!data[g]) data[g] = [];
+  });
   res.json(data);
 });
 


### PR DESCRIPTION
## Summary
- ensure `/api/scores` always returns all game lists
- track all leaderboards and detect current game in ProgressSidebar
- compute a player's rank and display it under the top scores

## Testing
- `npx --yes tsc -p nextjs-app/tsconfig.json` *(fails: numerous type errors)*
- `npx --yes tsc -p learning-games/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6846c807c548832fb59ba3a0c731a300