### PR TITLE
Switch score labels to points

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
 - Games read the stored age to tweak difficulty and show tailored tips.
 - On easy difficulty, older players automatically receive extra time for tasks
   (5s at 40+, 10s at 50+, 15s at 60+).
-- Scores and badges now sync to a small server so progress follows you across devices.
+- Points and badges now sync to a small server so progress follows you across devices.
 - High contrast theme preference persists via `ThemeToggle`.
-- A unified leaderboard with tabs displays top scores for every game.
+- A unified leaderboard with tabs displays top points for every game.
 - A dedicated Badges page lets you track all achievements.
 - A hidden `/stats` page displays live visitor analytics collected on the server.
 - A community playlist page lets everyone share bad and good prompt pairs.
@@ -34,7 +34,7 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
    npm run dev
    ```
 2. In a separate terminal start the API server to persist user info,
-  community posts and shared high scores:
+  community posts and shared high points:
    ```bash
    cd server
    npm install

--- a/docs/Hallucinations_Enhancements.md
+++ b/docs/Hallucinations_Enhancements.md
@@ -7,7 +7,7 @@ The existing "Hallucinations" quiz challenges players to spot a single AI-genera
 1. **Adaptive Difficulty** – Adjust the number of statements or complexity of facts based on the player's score or age.
 2. **Timed Rounds** – Introduce a countdown to increase pressure and urgency.
 3. **Streak Bonuses** – Reward consecutive correct answers with multiplier points.
-4. **Leaderboards** – Display global rankings so players can compare scores.
+4. **Leaderboards** – Display global rankings so players can compare points.
 5. **Hint System** – Offer limited hints that narrow down options but reduce potential points.
 6. **Daily Challenges** – Provide a new set of questions every day to encourage repeat visits.
 7. **Score Sharing** – Allow users to share results on social media.

--- a/learning-games/pages/index.tsx
+++ b/learning-games/pages/index.tsx
@@ -27,7 +27,7 @@ export default function HomePage() {
     return () => observer.disconnect()
   }, [])
 
-  const totalPoints = getTotalPoints(user.scores)
+  const totalPoints = getTotalPoints(user.points)
 
   return (
     <div className="home">

--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -298,27 +298,27 @@
   }
 }
 
-.top-scores-title {
+.top-points-title {
   margin-top: 1rem;
 }
-.top-scores-card {
+.top-points-card {
   background: var(--color-background);
   padding: 0.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
-.top-scores-list {
+.top-points-list {
   list-style: none;
   padding-left: 0;
   margin: 0;
 }
-.top-scores-list li {
+.top-points-list li {
   display: flex;
   justify-content: space-between;
   padding: 0.25rem 0;
   font-size: 0.9rem;
 }
-.top-scores-list li.top {
+.top-points-list li.top {
   color: var(--color-brand);
   font-weight: bold;
 }

--- a/learning-games/src/components/CourseOverview.tsx
+++ b/learning-games/src/components/CourseOverview.tsx
@@ -9,7 +9,7 @@ export default function CourseOverview() {
   return (
     <div className="course-grid">
       {COURSES.map((course) => {
-        const progress = Math.min(user.scores[course.id] ?? 0, 100)
+        const progress = Math.min(user.points[course.id] ?? 0, 100)
         const content = (
           <Card className="course-card" style={{ padding: '0.75rem' }}>
             {course.meme && (

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -21,7 +21,7 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
   const GOAL_POINTS = 300
 
   const celebrated = useRef(false)
-  const [scoreEntries, setScoreEntries] = useState<PointsEntry[]>([])
+  const [pointsEntries, setPointsEntries] = useState<PointsEntry[]>([])
 
   useEffect(() => {
     if (totalPoints >= GOAL_POINTS && !celebrated.current) {
@@ -36,13 +36,13 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
       fetch(`${base}/api/scores`)
         .then((res) => (res.ok ? res.json() : {}))
         .then((data: Record<string, PointsEntry[]>) => {
-          setScoreEntries(Array.isArray(data.darts) ? data.darts : [])
+          setPointsEntries(Array.isArray(data.darts) ? data.darts : [])
         })
         .catch(() => {})
     }
   }, [])
 
-  const leaderboard = scoreEntries
+  const leaderboard = pointsEntries
     .concat({ name: user.name ?? 'You', points: (points ?? user.points)['darts'] ?? 0 })
     .sort((a, b) => b.points - a.points)
     .slice(0, 3)
@@ -64,9 +64,9 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
         ))}
         {userBadges.length === 0 && <span>No badges yet.</span>}
       </div>
-      <h4 className="top-scores-title">Top Points</h4>
-      <div className="top-scores-card">
-        <ol className="top-scores-list">
+      <h4 className="top-points-title">Top Points</h4>
+      <div className="top-points-card">
+        <ol className="top-points-list">
           {leaderboard.map((entry, idx) => (
             <li key={entry.name} className={idx === 0 ? 'top' : undefined}>
               {idx === 0 && <span aria-hidden="true">🏆 </span>}

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -4,24 +4,24 @@ import { Link } from 'react-router-dom'
 import { UserContext } from '../../context/UserContext'
 import Tooltip from '../ui/Tooltip'
 import { getTotalPoints } from '../../utils/user'
-import type { ScoreEntry } from '../../pages/LeaderboardPage'
+import type { PointsEntry } from '../../pages/LeaderboardPage'
 import { GOAL_POINTS } from '../../constants/progress'
 
 export interface ProgressSidebarProps {
-  scores?: Record<string, number>
+  points?: Record<string, number>
   badges?: string[]
 }
 
-export default function ProgressSidebar({ scores, badges }: ProgressSidebarProps = {}) {
+export default function ProgressSidebar({ points, badges }: ProgressSidebarProps = {}) {
   const { user } = useContext(UserContext)
 
 
 
-  const totalPoints = getTotalPoints(user.scores)
+  const totalPoints = getTotalPoints(user.points)
   const GOAL_POINTS = 300
 
   const celebrated = useRef(false)
-  const [scoreEntries, setScoreEntries] = useState<ScoreEntry[]>([])
+  const [scoreEntries, setScoreEntries] = useState<PointsEntry[]>([])
 
   useEffect(() => {
     if (totalPoints >= GOAL_POINTS && !celebrated.current) {
@@ -35,7 +35,7 @@ export default function ProgressSidebar({ scores, badges }: ProgressSidebarProps
       const base = window.location.origin
       fetch(`${base}/api/scores`)
         .then((res) => (res.ok ? res.json() : {}))
-        .then((data: Record<string, ScoreEntry[]>) => {
+        .then((data: Record<string, PointsEntry[]>) => {
           setScoreEntries(Array.isArray(data.darts) ? data.darts : [])
         })
         .catch(() => {})
@@ -43,8 +43,8 @@ export default function ProgressSidebar({ scores, badges }: ProgressSidebarProps
   }, [])
 
   const leaderboard = scoreEntries
-    .concat({ name: user.name ?? 'You', score: userScores['darts'] ?? 0 })
-    .sort((a, b) => b.score - a.score)
+    .concat({ name: user.name ?? 'You', points: (points ?? user.points)['darts'] ?? 0 })
+    .sort((a, b) => b.points - a.points)
     .slice(0, 3)
 
   return (
@@ -64,13 +64,13 @@ export default function ProgressSidebar({ scores, badges }: ProgressSidebarProps
         ))}
         {userBadges.length === 0 && <span>No badges yet.</span>}
       </div>
-      <h4 className="top-scores-title">Top Scores</h4>
+      <h4 className="top-scores-title">Top Points</h4>
       <div className="top-scores-card">
         <ol className="top-scores-list">
           {leaderboard.map((entry, idx) => (
             <li key={entry.name} className={idx === 0 ? 'top' : undefined}>
               {idx === 0 && <span aria-hidden="true">🏆 </span>}
-              {entry.name}: {entry.score}
+              {entry.name}: {entry.points}
             </li>
           ))}
         </ol>

--- a/learning-games/src/context/UserContext.ts
+++ b/learning-games/src/context/UserContext.ts
@@ -5,7 +5,7 @@ export const defaultUser: UserData = {
   name: null,
   age: null,
   difficulty: 'medium',
-  scores: {},
+  points: {},
   badges: [],
 }
 
@@ -14,7 +14,7 @@ export const UserContext = createContext<UserContextType>({
   setUser: () => {},
   setAge: () => {},
   setName: () => {},
-  setScore: () => {},
+  setPoints: () => {},
   addBadge: () => {},
   setDifficulty: () => {},
 })

--- a/learning-games/src/context/UserProvider.tsx
+++ b/learning-games/src/context/UserProvider.tsx
@@ -52,19 +52,19 @@ export function UserProvider({ children }: { children: ReactNode }) {
     setUser(prev => ({ ...prev, difficulty: level }))
   }, [])
 
-  // Record the best score for a specific game
-  const setScore = useCallback(
-    (game: string, score: number) => {
+  // Record the best points for a specific game
+  const setPoints = useCallback(
+    (game: string, points: number) => {
       setUser(prev => {
-        const prevBest = prev.scores[game] ?? 0
-        const nextBest = Math.max(score, prevBest)
+        const prevBest = prev.points[game] ?? 0
+        const nextBest = Math.max(points, prevBest)
         if (nextBest > prevBest) {
-          toast.success(`New high score in ${game}: ${nextBest}`)
+          toast.success(`New high points in ${game}: ${nextBest}`)
         }
         return {
           ...prev,
-          scores: {
-            ...prev.scores,
+          points: {
+            ...prev.points,
             [game]: nextBest,
           },
         }
@@ -74,7 +74,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         fetch(`${base}/api/scores/${game}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: user.name ?? 'Anonymous', score }),
+          body: JSON.stringify({ name: user.name ?? 'Anonymous', score: points }),
         }).catch(err => console.error('Failed to save score', err))
       }
     },
@@ -106,7 +106,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
             name: user.name,
             age: user.age,
             badges: user.badges,
-            scores: user.scores,
+            scores: user.points,
             difficulty: user.difficulty,
           }),
         }).catch((err) => console.error('Failed to save user', err))
@@ -122,7 +122,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         setUser,
         setAge,
         setName,
-        setScore,
+        setPoints,
         addBadge,
         setDifficulty,
       }}

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -238,7 +238,7 @@ export default function ClarityEscapeRoom() {
 
       setShowNext(false)
     } else {
-      setScore('escape', points)
+      setPoints('escape', points)
       setShowSummary(true)
     }
   }
@@ -321,7 +321,7 @@ export default function ClarityEscapeRoom() {
           buttonLabel="Play Prompt Builder"
         >
           <h3>Escape Complete!</h3>
-          <p className="final-score">Score: {points}</p>
+          <p className="final-score">Points: {points}</p>
         </CompletionModal>
       )}
     </div>

--- a/learning-games/src/pages/ComposeTweetGame.tsx
+++ b/learning-games/src/pages/ComposeTweetGame.tsx
@@ -34,7 +34,7 @@ const pairs: PromptPair[] = [
 ]
 
 export default function ComposeTweetGame() {
-  const { setScore, addBadge, user } = useContext(UserContext)
+  const { setPoints, addBadge, user } = useContext(UserContext)
   const navigate = useNavigate()
   const [guess, setGuess] = useState('')
   const [feedback, setFeedback] = useState('')
@@ -45,7 +45,7 @@ export default function ComposeTweetGame() {
   const [round, setRound] = useState(0)
   const [showNext, setShowNext] = useState(false)
 
-  const [score, setScoreState] = useState<number | null>(null)
+  const [points, setPointsState] = useState<number | null>(null)
 
   const timerRef = useRef<number | null>(null)
   const pair = pairs[round]
@@ -82,9 +82,9 @@ export default function ComposeTweetGame() {
       setFeedback('Correct! The door is unlocked.')
       setDoorUnlocked(true)
       const earned = guessScore + timeLeft
-      setScoreState(earned)
+      setPointsState(earned)
       clearInterval(timerRef.current!)
-      setScore('compose', earned)
+      setPoints('compose', earned)
       if (timeLeft >= 20 && !user.badges.includes('speedy-composer')) {
         addBadge('speedy-composer')
       }
@@ -150,9 +150,9 @@ export default function ComposeTweetGame() {
             </button>
           </form>
           {feedback && <p className="feedback">{feedback}</p>}
-          {score !== null && (
+          {points !== null && (
             <p className="final-score" aria-live="polite">
-              Your score: {score}
+              Your points: {points}
             </p>
           )}
           <div className="door-area">
@@ -208,8 +208,8 @@ export default function ComposeTweetGame() {
         buttonLabel="View Leaderboard"
       >
         <h3>All prompts complete!</h3>
-        {score !== null && (
-          <p className="final-score" aria-live="polite">Your score: {score}</p>
+        {points !== null && (
+          <p className="final-score" aria-live="polite">Your points: {points}</p>
         )}
       </CompletionModal>
     )}

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -37,7 +37,7 @@ export default function Home() {
     return () => observer.disconnect()
   }, [])
 
-  const totalPoints = getTotalPoints(user.scores)
+  const totalPoints = getTotalPoints(user.points)
 
   return (
     <div className="home">

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -5,9 +5,9 @@ import { UserContext } from '../context/UserContext'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import './LeaderboardPage.css'
 
-export interface ScoreEntry {
+export interface PointsEntry {
   name: string
-  score: number
+  points: number
 }
 
 
@@ -15,32 +15,32 @@ export default function LeaderboardPage() {
   const { user } = useContext(UserContext)
 
   const [filter, setFilter] = useState('')
-  const [sortField, setSortField] = useState<'name' | 'score'>('score')
+  const [sortField, setSortField] = useState<'name' | 'points'>('points')
   const [ascending, setAscending] = useState(false)
 
-  const [scores, setScores] = useState<Record<string, ScoreEntry[]>>({})
+  const [pointsData, setPointsData] = useState<Record<string, PointsEntry[]>>({})
   const [game, setGame] = useState('tone')
   const tabs = useMemo(() => {
     const base = ['tone', 'quiz', 'darts', 'recipe', 'escape', 'compose']
-    const dynamic = Object.keys(scores)
+    const dynamic = Object.keys(pointsData)
     return Array.from(new Set([...base, ...dynamic]))
-  }, [scores])
+  }, [pointsData])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const base = window.location.origin
       fetch(`${base}/api/scores`)
         .then(res => (res.ok ? res.json() : {}))
-        .then(data => setScores(data))
+        .then(data => setPointsData(data))
         .catch(() => {})
     }
   }, [])
 
   const entries = useMemo(() => {
-    const list = (scores[game] ?? []).slice()
+    const list = (pointsData[game] ?? []).slice()
     const playerName = user.name ?? 'You'
     const existing = list.find(e => e.name === playerName)
-    if (!existing) list.push({ name: playerName, score: user.scores[game] ?? 0 })
+    if (!existing) list.push({ name: playerName, points: user.points[game] ?? 0 })
     return list
       .filter((e) => e.name.toLowerCase().includes(filter.toLowerCase()))
       .sort((a, b) => {
@@ -48,12 +48,12 @@ export default function LeaderboardPage() {
           const cmp = a.name.localeCompare(b.name)
           return ascending ? cmp : -cmp
         }
-        const cmp = a.score - b.score
+        const cmp = a.points - b.points
         return ascending ? cmp : -cmp
       })
-  }, [filter, sortField, ascending, user.name, user.scores, scores, game])
+  }, [filter, sortField, ascending, user.name, user.points, pointsData, game])
 
-  function handleSort(field: 'name' | 'score') {
+  function handleSort(field: 'name' | 'points') {
     if (sortField === field) {
       setAscending(!ascending)
     } else {
@@ -87,7 +87,7 @@ export default function LeaderboardPage() {
               onChange={(e) => setFilter(e.target.value)}
             />
           </div>
-          <h3>{game} High Scores</h3>
+          <h3>{game} High Points</h3>
           <table className="leaderboard-table">
             <thead>
               <tr>
@@ -97,8 +97,8 @@ export default function LeaderboardPage() {
                   </button>
                 </th>
                 <th>
-                  <button type="button" onClick={() => handleSort('score')}>
-                    Score {sortField === 'score' ? (ascending ? '▲' : '▼') : ''}
+                  <button type="button" onClick={() => handleSort('points')}>
+                    Points {sortField === 'points' ? (ascending ? '▲' : '▼') : ''}
                   </button>
                 </th>
               </tr>
@@ -114,7 +114,7 @@ export default function LeaderboardPage() {
                   }}
                 >
                   <td>{entry.name}</td>
-                  <td>{entry.score}</td>
+                  <td>{entry.points}</td>
                 </tr>
               ))}
             </tbody>
@@ -123,16 +123,16 @@ export default function LeaderboardPage() {
             <button
               type="button"
               onClick={() => {
-                const text = `My top score in ${game} is ${user.scores[game] ?? 0}!`
+                const text = `My top points in ${game} is ${user.points[game] ?? 0}!`
                 if (navigator.share) {
                   navigator.share({ text }).catch(() => {})
                 } else {
                   navigator.clipboard.writeText(text).catch(() => {})
-                  toast.success('Score copied to clipboard')
+                  toast.success('Points copied to clipboard')
                 }
               }}
             >
-              Share My Score
+              Share My Points
             </button>
           </p>
         </section>

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -171,7 +171,7 @@ function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) 
   const [selected, setSelected] = useState<Tone | null>(null)
   const [used, setUsed] = useState<Set<Tone>>(new Set())
   const [quizAnswer, setQuizAnswer] = useState<Tone | null>(null)
-  const [score, setScore] = useState(0)
+  const [points, setPoints] = useState(0)
 
   function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {
     e.dataTransfer.setData("text/plain", tone);
@@ -183,7 +183,7 @@ function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) 
     if (tones.includes(tone) && !used.has(tone)) {
       setSelected(tone);
       setUsed(new Set(used).add(tone));
-      setScore((s) => s + 20);
+      setPoints((s) => s + 20);
     }
   }
 
@@ -194,10 +194,10 @@ function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) 
 
   useEffect(() => {
     if (used.size >= 3) {
-      recordScore('tone', score)
-      onComplete(score)
+      recordScore('tone', points)
+      onComplete(points)
     }
-  }, [used, onComplete, score, recordScore])
+  }, [used, onComplete, points, recordScore])
 
   return (
     <div className="dragdrop-game">

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -274,7 +274,7 @@ export function streakBonus(streak: number) {
 
 export default function PromptDartsGame() {
 
-  const { setScore, user } = useContext(UserContext)
+  const { setPoints, user } = useContext(UserContext)
   const navigate = useNavigate()
   const [rounds, setRounds] = useState<DartRound[]>([])
   const [round, setRound] = useState(0)
@@ -286,7 +286,7 @@ export default function PromptDartsGame() {
   )
 
 
-  const [score, setScoreState] = useState(0)
+  const [points, setPointsState] = useState(0)
   const [streak, setStreak] = useState(0)
   const [penaltyMsg, setPenaltyMsg] = useState('')
 
@@ -368,11 +368,11 @@ export default function PromptDartsGame() {
     const originalIndex = current.options.indexOf(choices[index])
     setChoice(originalIndex)
     if (checkChoice(current, originalIndex)) {
-      setScoreState(s => s + pointsLeft + streakBonus(streak + 1))
+      setPointsState(s => s + pointsLeft + streakBonus(streak + 1))
       setStreak(s => s + 1)
       setPenaltyMsg('')
     } else {
-      setScoreState(s => Math.max(0, s - PENALTY))
+      setPointsState(s => Math.max(0, s - PENALTY))
       setStreak(0)
       setPenaltyMsg(`Incorrect! -${PENALTY} points`)
 
@@ -398,7 +398,7 @@ export default function PromptDartsGame() {
       setHint(null)
       setHintUsed(false)
     } else {
-      setScore('darts', score)
+      setPoints('darts', points)
       setRound(r => r + 1)
     }
   }
@@ -420,7 +420,7 @@ export default function PromptDartsGame() {
           buttonLabel="Play Compose Tweet"
         >
           <h3>Congratulations!</h3>
-          <p className="final-score">Your score: {score}</p>
+          <p className="final-score">Your points: {points}</p>
         </CompletionModal>
       </div>
     )

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -110,7 +110,7 @@ const EXTRA_TIME = 10
 
 export default function PromptGuessEscape() {
   const navigate = useNavigate()
-  const { setScore } = useContext(UserContext)
+  const { setPoints } = useContext(UserContext)
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')
@@ -218,7 +218,7 @@ export default function PromptGuessEscape() {
       setHintCount(0)
       setShowNext(false)
     } else {
-      setScore('escape', points)
+      setPoints('escape', points)
       setShowSummary(true)
     }
   }

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -172,7 +172,7 @@ async function generateCards(): Promise<Card[]> {
 }
 
 export default function PromptRecipeGame() {
-  const { setScore, addBadge, user } = useContext(UserContext)
+  const { setPoints, addBadge, user } = useContext(UserContext)
   const navigate = useNavigate()
   const TOTAL_ROUNDS = 5
   const TOTAL_TIME = getTimeLimit(user, {
@@ -190,7 +190,7 @@ export default function PromptRecipeGame() {
     Format: null,
     Constraints: null,
   })
-  const [score, setScoreState] = useState(0)
+  const [points, setPointsState] = useState(0)
   const [perfectRounds, setPerfectRounds] = useState(0)
   const [showPrompt, setShowPrompt] = useState(false)
   const [submitted, setSubmitted] = useState(false)
@@ -322,7 +322,7 @@ export default function PromptRecipeGame() {
       startRound()
     } else {
       setFinished(true)
-      setScore('recipe', score)
+      setPoints('recipe', points)
     }
   }
 
@@ -344,7 +344,7 @@ export default function PromptRecipeGame() {
     if (remaining.length === 0) return
     const card = remaining[Math.floor(Math.random() * remaining.length)]
     setHintSlot(card.type)
-    setScoreState(s => Math.max(0, s - 1))
+    setPointsState(s => Math.max(0, s - 1))
   }
 
   function checkAnswer() {
@@ -375,7 +375,7 @@ export default function PromptRecipeGame() {
           : 'wrong',
     })
 
-    setScoreState(s => s + finalScore)
+    setPointsState(s => s + finalScore)
     if (perfect) {
       confetti({ particleCount: 70, spread: 60, origin: { y: 0.7 } })
       setPerfectRounds(p => p + 1)
@@ -425,7 +425,7 @@ export default function PromptRecipeGame() {
         buttonLabel="Play Prompt Darts"
       >
         <h3>You finished Prompt Builder!</h3>
-        <p className="final-score">Your score: {score}</p>
+        <p className="final-score">Your points: {points}</p>
       </CompletionModal>
     )
   }
@@ -448,7 +448,7 @@ export default function PromptRecipeGame() {
         <div className="recipe-game">
           <div className="status-bar">
             <span className="round-info">Round {round + 1} / {TOTAL_ROUNDS}</span>
-            <span className="score">Score: {score}</span>
+            <span className="score">Points: {points}</span>
             <span className="timer">Time: {timeLeft}s</span>
           </div>
           <TimerBar timeLeft={timeLeft} TOTAL_TIME={TOTAL_TIME} />

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -121,11 +121,11 @@ function ChatBox() {
 }
 
 export default function QuizGame() {
-  const { user, setScore, addBadge } = useContext(UserContext)
+  const { user, setPoints, addBadge } = useContext(UserContext)
   const navigate = useNavigate()
   const [round, setRound] = useState(0)
   const [choice, setChoice] = useState<number | null>(null)
-  const [score, setScoreState] = useState(0)
+  const [points, setPointsState] = useState(0)
   const [played, setPlayed] = useState(0)
   const [streak, setStreak] = useState(0)
   const [finished, setFinished] = useState(false)
@@ -147,8 +147,8 @@ export default function QuizGame() {
 
   function nextRound() {
     const wasCorrect = correct
-    const newScore = wasCorrect ? score + 1 : score
-    setScoreState(newScore)
+    const newScore = wasCorrect ? points + 1 : points
+    setPointsState(newScore)
     setPlayed(p => p + 1)
     setStreak(wasCorrect ? streak + 1 : 0)
 
@@ -158,7 +158,7 @@ export default function QuizGame() {
 
 
     if (played + 1 === ROUNDS.length) {
-      setScore('quiz', newScore)
+      setPoints('quiz', newScore)
       if (newScore === ROUNDS.length && !user.badges.includes('quiz-whiz')) {
         addBadge('quiz-whiz')
       }
@@ -280,7 +280,7 @@ export default function QuizGame() {
         buttonLabel="Play Escape Room"
       >
         <h3>You finished the quiz!</h3>
-        <p className="final-score">Your score: {score}</p>
+        <p className="final-score">Your points: {points}</p>
       </CompletionModal>
     )}
     </>

--- a/learning-games/src/types/user.ts
+++ b/learning-games/src/types/user.ts
@@ -4,7 +4,7 @@ export interface UserData {
   age: number | null
   /** Player selected difficulty level */
   difficulty: 'easy' | 'medium' | 'hard'
-  scores: Record<string, number>
+  points: Record<string, number>
   badges: string[]
 }
 
@@ -21,10 +21,10 @@ export interface UserContextType {
    */
   setName: (name: string) => void
   /**
-   * Set the score for a specific game. Implementations typically
-   * store the best/highest score seen so far.
+   * Record points for a specific game. Implementations typically
+   * store the best/highest points seen so far.
    */
-  setScore: (game: string, score: number) => void
+  setPoints: (game: string, points: number) => void
   /**
    * Award a badge when the player reaches a milestone.
    */

--- a/learning-games/src/utils/user.ts
+++ b/learning-games/src/utils/user.ts
@@ -1,2 +1,2 @@
-export const getTotalPoints = (scores: Record<string, number>) =>
-  Object.values(scores).reduce((a, b) => a + b, 0);
+export const getTotalPoints = (pointsMap: Record<string, number>) =>
+  Object.values(pointsMap).reduce((a, b) => a + b, 0);

--- a/nextjs-app/src/components/CourseOverview.tsx
+++ b/nextjs-app/src/components/CourseOverview.tsx
@@ -9,7 +9,7 @@ export default function CourseOverview() {
   return (
     <div className="course-grid">
       {COURSES.map((course) => {
-        const progress = Math.min(user.scores[course.id] ?? 0, 100)
+        const progress = Math.min(user.points[course.id] ?? 0, 100)
         const content = (
           <Card className="course-card" style={{ padding: '0.75rem' }}>
             {course.meme && (

--- a/nextjs-app/src/components/layout/ProgressSidebar.tsx
+++ b/nextjs-app/src/components/layout/ProgressSidebar.tsx
@@ -4,23 +4,23 @@ import Link from 'next/link'
 import { UserContext } from '../../context/UserContext'
 import { getTotalPoints } from '../../utils/user'
 import Tooltip from '../ui/Tooltip'
-import type { ScoreEntry } from '../../pages/leaderboard'
+import type { PointsEntry } from '../../pages/leaderboard'
 import { GOAL_POINTS } from '../../constants/progress'
 
 export interface ProgressSidebarProps {
-  scores?: Record<string, number>
+  points?: Record<string, number>
   badges?: string[]
 }
 
-export default function ProgressSidebar({ scores, badges }: ProgressSidebarProps = {}) {
+export default function ProgressSidebar({ points, badges }: ProgressSidebarProps = {}) {
   const { user } = useContext(UserContext)
 
-  const userScores = scores ?? user.scores
+  const userScores = points ?? user.points
   const userBadges = badges ?? user.badges
 
   const totalPoints = getTotalPoints(userScores)
   const celebrated = useRef(false)
-  const [scoreEntries, setScoreEntries] = useState<ScoreEntry[]>([])
+  const [scoreEntries, setScoreEntries] = useState<PointsEntry[]>([])
 
   useEffect(() => {
     if (totalPoints >= GOAL_POINTS && !celebrated.current) {
@@ -34,7 +34,7 @@ export default function ProgressSidebar({ scores, badges }: ProgressSidebarProps
       const base = window.location.origin
       fetch(`${base}/api/scores`)
         .then((res) => (res.ok ? res.json() : {}))
-        .then((data: Record<string, ScoreEntry[]>) => {
+        .then((data: Record<string, PointsEntry[]>) => {
           setScoreEntries(Array.isArray(data.darts) ? data.darts : [])
         })
         .catch(() => {})
@@ -63,13 +63,13 @@ export default function ProgressSidebar({ scores, badges }: ProgressSidebarProps
         ))}
         {userBadges.length === 0 && <span>No badges yet.</span>}
       </div>
-      <h4 className="top-scores-title">Top Scores</h4>
+      <h4 className="top-scores-title">Top Points</h4>
       <div className="top-scores-card">
         <ol className="top-scores-list">
           {leaderboard.map((entry, idx) => (
             <li key={entry.name} className={idx === 0 ? 'top' : undefined}>
               {idx === 0 && <span aria-hidden="true">🏆 </span>}
-              {entry.name}: {entry.score}
+              {entry.name}: {entry.points}
             </li>
           ))}
         </ol>

--- a/nextjs-app/src/components/layout/ProgressSidebar.tsx
+++ b/nextjs-app/src/components/layout/ProgressSidebar.tsx
@@ -15,12 +15,12 @@ export interface ProgressSidebarProps {
 export default function ProgressSidebar({ points, badges }: ProgressSidebarProps = {}) {
   const { user } = useContext(UserContext)
 
-  const userScores = points ?? user.points
+  const userPoints = points ?? user.points
   const userBadges = badges ?? user.badges
 
-  const totalPoints = getTotalPoints(userScores)
+  const totalPoints = getTotalPoints(userPoints)
   const celebrated = useRef(false)
-  const [scoreEntries, setScoreEntries] = useState<PointsEntry[]>([])
+  const [pointsEntries, setPointsEntries] = useState<PointsEntry[]>([])
 
   useEffect(() => {
     if (totalPoints >= GOAL_POINTS && !celebrated.current) {
@@ -35,15 +35,15 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
       fetch(`${base}/api/scores`)
         .then((res) => (res.ok ? res.json() : {}))
         .then((data: Record<string, PointsEntry[]>) => {
-          setScoreEntries(Array.isArray(data.darts) ? data.darts : [])
+          setPointsEntries(Array.isArray(data.darts) ? data.darts : [])
         })
         .catch(() => {})
     }
   }, [])
 
-  const leaderboard = scoreEntries
-    .concat({ name: user.name ?? 'You', score: userScores['darts'] ?? 0 })
-    .sort((a, b) => b.score - a.score)
+  const leaderboard = pointsEntries
+    .concat({ name: user.name ?? 'You', points: userPoints['darts'] ?? 0 })
+    .sort((a, b) => b.points - a.points)
     .slice(0, 3)
 
   return (
@@ -63,9 +63,9 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
         ))}
         {userBadges.length === 0 && <span>No badges yet.</span>}
       </div>
-      <h4 className="top-scores-title">Top Points</h4>
-      <div className="top-scores-card">
-        <ol className="top-scores-list">
+      <h4 className="top-points-title">Top Points</h4>
+      <div className="top-points-card">
+        <ol className="top-points-list">
           {leaderboard.map((entry, idx) => (
             <li key={entry.name} className={idx === 0 ? 'top' : undefined}>
               {idx === 0 && <span aria-hidden="true">🏆 </span>}

--- a/nextjs-app/src/context/UserContext.ts
+++ b/nextjs-app/src/context/UserContext.ts
@@ -5,7 +5,7 @@ export const defaultUser: UserData = {
   name: null,
   age: null,
   difficulty: 'medium',
-  scores: {},
+  points: {},
   badges: [],
 }
 
@@ -14,7 +14,7 @@ export const UserContext = createContext<UserContextType>({
   setUser: () => {},
   setAge: () => {},
   setName: () => {},
-  setScore: () => {},
+  setPoints: () => {},
   addBadge: () => {},
   setDifficulty: () => {},
 })

--- a/nextjs-app/src/context/UserProvider.tsx
+++ b/nextjs-app/src/context/UserProvider.tsx
@@ -51,19 +51,19 @@ export function UserProvider({ children }: { children: ReactNode }) {
     setUser(prev => ({ ...prev, difficulty: level }))
   }, [])
 
-  // Record the best score for a specific game
-  const setScore = useCallback(
-    (game: string, score: number) => {
+  // Record the best points for a specific game
+  const setPoints = useCallback(
+    (game: string, points: number) => {
       setUser(prev => {
-        const prevBest = prev.scores[game] ?? 0
-        const nextBest = Math.max(score, prevBest)
+        const prevBest = prev.points[game] ?? 0
+        const nextBest = Math.max(points, prevBest)
         if (nextBest > prevBest) {
-          toast.success(`New high score in ${game}: ${nextBest}`)
+          toast.success(`New high points in ${game}: ${nextBest}`)
         }
         return {
           ...prev,
-          scores: {
-            ...prev.scores,
+          points: {
+            ...prev.points,
             [game]: nextBest,
           },
         }
@@ -73,7 +73,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         fetch(`${base}/api/scores/${game}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: user.name ?? 'Anonymous', score }),
+          body: JSON.stringify({ name: user.name ?? 'Anonymous', score: points }),
         }).catch(err => console.error('Failed to save score', err))
       }
     },
@@ -105,7 +105,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
             name: user.name,
             age: user.age,
             badges: user.badges,
-            scores: user.scores,
+            scores: user.points,
             difficulty: user.difficulty,
           }),
         }).catch((err) => console.error('Failed to save user', err))
@@ -121,7 +121,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         setUser,
         setAge,
         setName,
-        setScore,
+        setPoints,
         addBadge,
         setDifficulty,
       }}

--- a/nextjs-app/src/pages/api/user.ts
+++ b/nextjs-app/src/pages/api/user.ts
@@ -5,7 +5,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === 'GET') {
     const snap = await userDoc.get()
     res.status(200).json(
-      snap.exists ? snap.data() : { name: null, age: null, badges: [], scores: { darts: 0 } }
+      snap.exists ? snap.data() : { name: null, age: null, badges: [], points: { darts: 0 } }
     )
     return
   }

--- a/nextjs-app/src/pages/games/compose.tsx
+++ b/nextjs-app/src/pages/games/compose.tsx
@@ -36,7 +36,7 @@ const pairs: PromptPair[] = [
 ]
 
 export default function ComposeTweetGame() {
-  const { setScore, addBadge, user } = useContext(UserContext)
+  const { setPoints, addBadge, user } = useContext(UserContext)
   const router = useRouter()
   const [guess, setGuess] = useState('')
   const [feedback, setFeedback] = useState('')
@@ -48,7 +48,7 @@ export default function ComposeTweetGame() {
   const [showNext, setShowNext] = useState(false)
   const [finished, setFinished] = useState(false)
 
-  const [score, setScoreState] = useState<number | null>(null)
+  const [points, setPointsState] = useState<number | null>(null)
 
   const timerRef = useRef<number | null>(null)
   const pair = pairs[round]
@@ -85,9 +85,9 @@ export default function ComposeTweetGame() {
       setFeedback('Correct! The door is unlocked.')
       setDoorUnlocked(true)
       const earned = guessScore + timeLeft
-      setScoreState(earned)
+      setPointsState(earned)
       clearInterval(timerRef.current!)
-      setScore('compose', earned)
+      setPoints('compose', earned)
       if (timeLeft >= 20 && !user.badges.includes('speedy-composer')) {
         addBadge('speedy-composer')
       }
@@ -166,9 +166,9 @@ export default function ComposeTweetGame() {
             </button>
           </form>
           {feedback && <p className="feedback">{feedback}</p>}
-          {score !== null && (
+          {points !== null && (
             <p className="final-score" aria-live="polite">
-              Your score: {score}
+              Your points: {points}
             </p>
           )}
           <div className="door-area">
@@ -221,8 +221,8 @@ export default function ComposeTweetGame() {
         buttonLabel="View Leaderboard"
       >
         <h3>All prompts complete!</h3>
-        {score !== null && (
-          <p className="final-score" aria-live="polite">Your score: {score}</p>
+        {points !== null && (
+          <p className="final-score" aria-live="polite">Your points: {points}</p>
         )}
       </CompletionModal>
     )}

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -270,7 +270,7 @@ export function streakBonus(streak: number) {
 
 export default function PromptDartsGame() {
 
-  const { setScore, user } = useContext(UserContext)
+  const { setPoints, user } = useContext(UserContext)
   const router = useRouter()
   const [rounds, setRounds] = useState<DartRound[]>([])
   const [round, setRound] = useState(0)
@@ -394,7 +394,7 @@ export default function PromptDartsGame() {
       setHint(null)
       setHintUsed(false)
     } else {
-      setScore('darts', score)
+      setPoints('darts', score)
       setRound(r => r + 1)
     }
   }
@@ -416,7 +416,7 @@ export default function PromptDartsGame() {
           buttonLabel="Play Compose Tweet"
         >
           <h3>Congratulations!</h3>
-          <p className="final-score">Your score: {score}</p>
+          <p className="final-score">Your points: {score}</p>
         </CompletionModal>
       </div>
     )

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -243,7 +243,7 @@ export default function ClarityEscapeRoom() {
 
       setShowNext(false)
     } else {
-      setScore('escape', points)
+      setPoints('escape', points)
       setShowSummary(true)
     }
   }
@@ -367,7 +367,7 @@ export default function ClarityEscapeRoom() {
           buttonLabel="Play Prompt Builder"
         >
           <h3>Escape Complete!</h3>
-          <p className="final-score">Score: {points}</p>
+          <p className="final-score">Points: {points}</p>
         </CompletionModal>
       )}
     </div>

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -219,7 +219,7 @@ export default function PromptGuessEscape() {
       setHintCount(0)
       setShowNext(false)
     } else {
-      setScore('escape', points)
+      setPoints('escape', points)
       setShowSummary(true)
     }
   }

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -123,11 +123,11 @@ function ChatBox() {
 }
 
 export default function QuizGame() {
-  const { user, setScore, addBadge } = useContext(UserContext)
+  const { user, setPoints, addBadge } = useContext(UserContext)
   const navigate = useRouter()
   const [round, setRound] = useState(0)
   const [choice, setChoice] = useState<number | null>(null)
-  const [score, setScoreState] = useState(0)
+  const [points, setPointsState] = useState(0)
   const [played, setPlayed] = useState(0)
   const [streak, setStreak] = useState(0)
   const [finished, setFinished] = useState(false)
@@ -149,8 +149,8 @@ export default function QuizGame() {
 
   function nextRound() {
     const wasCorrect = correct
-    const newScore = wasCorrect ? score + 1 : score
-    setScoreState(newScore)
+    const newScore = wasCorrect ? points + 1 : points
+    setPointsState(newScore)
     setPlayed(p => p + 1)
     setStreak(wasCorrect ? streak + 1 : 0)
 
@@ -160,7 +160,7 @@ export default function QuizGame() {
 
 
     if (played + 1 === ROUNDS.length) {
-      setScore('quiz', newScore)
+      setPoints('quiz', newScore)
       if (newScore === ROUNDS.length && !user.badges.includes('quiz-whiz')) {
         addBadge('quiz-whiz')
       }
@@ -322,7 +322,7 @@ export default function QuizGame() {
         buttonLabel="Play Escape Room"
       >
         <h3>You finished the quiz!</h3>
-        <p className="final-score">Your score: {score}</p>
+        <p className="final-score">Your points: {points}</p>
       </CompletionModal>
     )}
     </>

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -175,7 +175,7 @@ async function generateCards(): Promise<Card[]> {
 }
 
 export default function PromptRecipeGame() {
-  const { setScore, addBadge, user } = useContext(UserContext)
+  const { setPoints, addBadge, user } = useContext(UserContext)
   const router = useRouter()
   const TOTAL_ROUNDS = 5
   const TOTAL_TIME = getTimeLimit(user, {
@@ -193,7 +193,7 @@ export default function PromptRecipeGame() {
     Format: null,
     Constraints: null,
   })
-  const [score, setScoreState] = useState(0)
+  const [points, setPointsState] = useState(0)
   const [perfectRounds, setPerfectRounds] = useState(0)
   const [showPrompt, setShowPrompt] = useState(false)
   const [submitted, setSubmitted] = useState(false)
@@ -325,7 +325,7 @@ export default function PromptRecipeGame() {
       startRound()
     } else {
       setFinished(true)
-      setScore('recipe', score)
+      setPoints('recipe', points)
     }
   }
 
@@ -347,7 +347,7 @@ export default function PromptRecipeGame() {
     if (remaining.length === 0) return
     const card = remaining[Math.floor(Math.random() * remaining.length)]
     setHintSlot(card.type)
-    setScoreState(s => Math.max(0, s - 1))
+    setPointsState(s => Math.max(0, s - 1))
   }
 
   function checkAnswer() {
@@ -378,7 +378,7 @@ export default function PromptRecipeGame() {
           : 'wrong',
     })
 
-    setScoreState(s => s + finalScore)
+    setPointsState(s => s + finalScore)
     if (perfect) {
       confetti({ particleCount: 70, spread: 60, origin: { y: 0.7 } })
       setPerfectRounds(p => p + 1)
@@ -428,7 +428,7 @@ export default function PromptRecipeGame() {
         buttonLabel="Play Prompt Darts"
       >
         <h3>You finished Prompt Builder!</h3>
-        <p className="final-score">Your score: {score}</p>
+        <p className="final-score">Your points: {points}</p>
       </CompletionModal>
     )
   }
@@ -492,7 +492,7 @@ export default function PromptRecipeGame() {
         <div className="recipe-game">
           <div className="status-bar">
             <span className="round-info">Round {round + 1} / {TOTAL_ROUNDS}</span>
-            <span className="score">Score: {score}</span>
+            <span className="score">Points: {points}</span>
             <span className="timer">Time: {timeLeft}s</span>
           </div>
           <TimerBar timeLeft={timeLeft} TOTAL_TIME={TOTAL_TIME} />

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -38,7 +38,7 @@ export default function Home() {
     return () => observer.disconnect()
   }, [])
 
-  const totalPoints = getTotalPoints(user.scores)
+  const totalPoints = getTotalPoints(user.points)
 
   return (
     <>

--- a/nextjs-app/src/pages/leaderboard.tsx
+++ b/nextjs-app/src/pages/leaderboard.tsx
@@ -5,9 +5,9 @@ import { UserContext } from '../context/UserContext'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import '../styles/LeaderboardPage.css'
 
-export interface ScoreEntry {
+export interface PointsEntry {
   name: string
-  score: number
+  points: number
 }
 
 
@@ -15,32 +15,32 @@ export default function LeaderboardPage() {
   const { user } = useContext(UserContext)
 
   const [filter, setFilter] = useState('')
-  const [sortField, setSortField] = useState<'name' | 'score'>('score')
+  const [sortField, setSortField] = useState<'name' | 'points'>('points')
   const [ascending, setAscending] = useState(false)
 
-  const [scores, setScores] = useState<Record<string, ScoreEntry[]>>({})
+  const [pointsData, setPointsData] = useState<Record<string, PointsEntry[]>>({})
   const [game, setGame] = useState('tone')
   const tabs = useMemo(() => {
     const base = ['tone', 'quiz', 'darts', 'recipe', 'escape', 'compose']
-    const dynamic = Object.keys(scores)
+    const dynamic = Object.keys(pointsData)
     return Array.from(new Set([...base, ...dynamic]))
-  }, [scores])
+  }, [pointsData])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const base = window.location.origin
       fetch(`${base}/api/scores`)
         .then(res => (res.ok ? res.json() : {}))
-        .then(data => setScores(data))
+        .then(data => setPointsData(data))
         .catch(() => {})
     }
   }, [])
 
   const entries = useMemo(() => {
-    const list = (scores[game] ?? []).slice()
+    const list = (pointsData[game] ?? []).slice()
     const playerName = user.name ?? 'You'
     const existing = list.find(e => e.name === playerName)
-    if (!existing) list.push({ name: playerName, score: user.scores[game] ?? 0 })
+    if (!existing) list.push({ name: playerName, points: user.points[game] ?? 0 })
     return list
       .filter((e) => e.name.toLowerCase().includes(filter.toLowerCase()))
       .sort((a, b) => {
@@ -48,12 +48,12 @@ export default function LeaderboardPage() {
           const cmp = a.name.localeCompare(b.name)
           return ascending ? cmp : -cmp
         }
-        const cmp = a.score - b.score
+        const cmp = a.points - b.points
         return ascending ? cmp : -cmp
       })
-  }, [filter, sortField, ascending, user.name, user.scores, scores, game])
+  }, [filter, sortField, ascending, user.name, user.points, pointsData, game])
 
-  function handleSort(field: 'name' | 'score') {
+  function handleSort(field: 'name' | 'points') {
     if (sortField === field) {
       setAscending(!ascending)
     } else {
@@ -87,7 +87,7 @@ export default function LeaderboardPage() {
               onChange={(e) => setFilter(e.target.value)}
             />
           </div>
-          <h3>{game} High Scores</h3>
+          <h3>{game} High Points</h3>
           <table className="leaderboard-table">
             <thead>
               <tr>
@@ -97,8 +97,8 @@ export default function LeaderboardPage() {
                   </button>
                 </th>
                 <th>
-                  <button type="button" onClick={() => handleSort('score')}>
-                    Score {sortField === 'score' ? (ascending ? '▲' : '▼') : ''}
+                  <button type="button" onClick={() => handleSort('points')}>
+                    Points {sortField === 'points' ? (ascending ? '▲' : '▼') : ''}
                   </button>
                 </th>
               </tr>
@@ -114,7 +114,7 @@ export default function LeaderboardPage() {
                   }}
                 >
                   <td>{entry.name}</td>
-                  <td>{entry.score}</td>
+                  <td>{entry.points}</td>
                 </tr>
               ))}
             </tbody>
@@ -123,16 +123,16 @@ export default function LeaderboardPage() {
             <button
               type="button"
               onClick={() => {
-                const text = `My top score in ${game} is ${user.scores[game] ?? 0}!`
+                const text = `My top points in ${game} is ${user.points[game] ?? 0}!`
                 if (navigator.share) {
                   navigator.share({ text }).catch(() => {})
                 } else {
                   navigator.clipboard.writeText(text).catch(() => {})
-                  toast.success('Score copied to clipboard')
+                  toast.success('Points copied to clipboard')
                 }
               }}
             >
-              Share My Score
+              Share My Points
             </button>
           </p>
         </section>
@@ -150,7 +150,7 @@ export function Head() {
   return (
     <>
       <title>Leaderboard | StrawberryTech</title>
-      <meta name="description" content="See top scores across all games." />
+      <meta name="description" content="See top points across all games." />
       <link rel="canonical" href="https://strawberrytech.com/leaderboard" />
     </>
   )

--- a/nextjs-app/src/styles/App.css
+++ b/nextjs-app/src/styles/App.css
@@ -298,27 +298,27 @@
   }
 }
 
-.top-scores-title {
+.top-points-title {
   margin-top: 1rem;
 }
-.top-scores-card {
+.top-points-card {
   background: var(--color-background);
   padding: 0.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
-.top-scores-list {
+.top-points-list {
   list-style: none;
   padding-left: 0;
   margin: 0;
 }
-.top-scores-list li {
+.top-points-list li {
   display: flex;
   justify-content: space-between;
   padding: 0.25rem 0;
   font-size: 0.9rem;
 }
-.top-scores-list li.top {
+.top-points-list li.top {
   color: var(--color-brand);
   font-weight: bold;
 }

--- a/nextjs-app/src/types/user.ts
+++ b/nextjs-app/src/types/user.ts
@@ -4,7 +4,7 @@ export interface UserData {
   age: number | null
   /** Player selected difficulty level */
   difficulty: 'easy' | 'medium' | 'hard'
-  scores: Record<string, number>
+  points: Record<string, number>
   badges: string[]
 }
 
@@ -21,10 +21,10 @@ export interface UserContextType {
    */
   setName: (name: string) => void
   /**
-   * Set the score for a specific game. Implementations typically
-   * store the best/highest score seen so far.
+   * Record points for a specific game. Implementations typically
+   * store the best/highest points seen so far.
    */
-  setScore: (game: string, score: number) => void
+  setPoints: (game: string, points: number) => void
   /**
    * Award a badge when the player reaches a milestone.
    */

--- a/nextjs-app/src/utils/user.ts
+++ b/nextjs-app/src/utils/user.ts
@@ -1,2 +1,2 @@
-export const getTotalPoints = (scores: Record<string, number>) =>
-  Object.values(scores).reduce((a, b) => a + b, 0);
+export const getTotalPoints = (pointsMap: Record<string, number>) =>
+  Object.values(pointsMap).reduce((a, b) => a + b, 0);

--- a/server/index.js
+++ b/server/index.js
@@ -27,7 +27,7 @@ async function loadData() {
   const userSnap = await userDoc.get();
   const user = userSnap.exists
     ? userSnap.data()
-    : { name: null, age: null, badges: [], scores: { darts: 0 } };
+    : { name: null, age: null, badges: [], points: { darts: 0 } };
   const scoresSnap = await scores.get();
   const scoreData = {};
   scoresSnap.forEach(doc => (scoreData[doc.id] = doc.data().entries || []));
@@ -139,7 +139,7 @@ app.post('/api/sentiment', async (req, res) => {
 app.get('/api/user', async (req, res) => {
   const snap = await userDoc.get();
   res.json(
-    snap.exists ? snap.data() : { name: null, age: null, badges: [], scores: { darts: 0 } }
+    snap.exists ? snap.data() : { name: null, age: null, badges: [], points: { darts: 0 } }
   );
 });
 


### PR DESCRIPTION
## Summary
- rename scoreboard interface to `PointsEntry`
- replace user `scores` with `points`
- update text and logic across games and leaderboard
- keep server API compatibility

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in nextjs-app *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846c82a6f28832fbffac9b4f5fa6923