### PR TITLE
Standardize sidebar widths

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.css
+++ b/learning-games/src/pages/ClarityEscapeRoom.css
@@ -1,7 +1,7 @@
 .escape-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr 260px;
+  grid-template-columns: 250px 1fr 250px;
   grid-template-areas:
     'sidebar room progress'
     'sidebar next progress';
@@ -84,7 +84,7 @@
 
 .escape-sidebar {
   grid-area: sidebar;
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;

--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -109,13 +109,13 @@
 
 @media (min-width: 600px) {
   .dragdrop-wrapper {
-    grid-template-columns: 1fr 260px;
+    grid-template-columns: 1fr 250px;
     grid-template-areas:
       "sidebar progress"
       "game progress"
       "next progress";
   }
   .progress-sidebar {
-    max-width: 260px;
+    max-width: 250px;
   }
 }

--- a/learning-games/src/pages/PromptDartsGame.css
+++ b/learning-games/src/pages/PromptDartsGame.css
@@ -25,7 +25,7 @@
 }
 
 .darts-sidebar {
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;
@@ -100,7 +100,7 @@
 
 @media (min-width: 600px) {
   .darts-wrapper {
-    grid-template-columns: 260px 1fr;
+    grid-template-columns: 250px 1fr;
     grid-template-areas:
       "why game"
       "progress next";

--- a/learning-games/src/pages/PromptGuessEscape.css
+++ b/learning-games/src/pages/PromptGuessEscape.css
@@ -1,7 +1,7 @@
 .guess-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 220px 1fr 160px 260px;
+  grid-template-columns: 250px 1fr 160px 250px;
   grid-template-areas:
     'sidebar game door progress'
     'sidebar game door progress';
@@ -12,7 +12,7 @@
 
 .guess-sidebar {
   grid-area: sidebar;
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;

--- a/learning-games/src/pages/PromptRecipeGame.css
+++ b/learning-games/src/pages/PromptRecipeGame.css
@@ -23,7 +23,7 @@
 .recipe-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr 260px;
+  grid-template-columns: 250px 1fr 250px;
   grid-template-areas:
     'sidebar game progress'
     'next    next next';
@@ -49,7 +49,7 @@
 
 .recipe-sidebar {
   grid-area: sidebar;
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;

--- a/nextjs-app/src/styles/ClarityEscapeRoom.css
+++ b/nextjs-app/src/styles/ClarityEscapeRoom.css
@@ -1,7 +1,7 @@
 .escape-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr 260px;
+  grid-template-columns: 250px 1fr 250px;
   grid-template-areas:
     'sidebar room progress'
     'sidebar next progress';
@@ -84,7 +84,7 @@
 
 .escape-sidebar {
   grid-area: sidebar;
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;

--- a/nextjs-app/src/styles/DragDropGame.css
+++ b/nextjs-app/src/styles/DragDropGame.css
@@ -109,13 +109,13 @@
 
 @media (min-width: 600px) {
   .dragdrop-wrapper {
-    grid-template-columns: 1fr 260px;
+    grid-template-columns: 1fr 250px;
     grid-template-areas:
       "sidebar progress"
       "game progress"
       "next progress";
   }
   .progress-sidebar {
-    max-width: 260px;
+    max-width: 250px;
   }
 }

--- a/nextjs-app/src/styles/PromptDartsGame.css
+++ b/nextjs-app/src/styles/PromptDartsGame.css
@@ -25,7 +25,7 @@
 }
 
 .darts-sidebar {
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;
@@ -100,7 +100,7 @@
 
 @media (min-width: 600px) {
   .darts-wrapper {
-    grid-template-columns: 260px 1fr;
+    grid-template-columns: 250px 1fr;
     grid-template-areas:
       "why game"
       "progress next";

--- a/nextjs-app/src/styles/PromptGuessEscape.css
+++ b/nextjs-app/src/styles/PromptGuessEscape.css
@@ -1,7 +1,7 @@
 .guess-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 220px 1fr 160px 260px;
+  grid-template-columns: 250px 1fr 160px 250px;
   grid-template-areas:
     'sidebar game door progress'
     'sidebar game door progress';
@@ -12,7 +12,7 @@
 
 .guess-sidebar {
   grid-area: sidebar;
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;

--- a/nextjs-app/src/styles/PromptRecipeGame.css
+++ b/nextjs-app/src/styles/PromptRecipeGame.css
@@ -23,7 +23,7 @@
 .recipe-wrapper {
   width: 100%;
   display: grid;
-  grid-template-columns: 260px 1fr 260px;
+  grid-template-columns: 250px 1fr 250px;
   grid-template-areas:
     'sidebar game progress'
     'next    next next';
@@ -49,7 +49,7 @@
 
 .recipe-sidebar {
   grid-area: sidebar;
-  max-width: 240px;
+  max-width: 250px;
   background: var(--color-background);
   color: var(--color-text-dark);
   padding: 1rem;


### PR DESCRIPTION
## Summary
- normalize sidebar widths in both Next.js app and learning games stylesheets
- update grid templates and sidebar max widths to 250px

## Testing
- `npm ci` *(fails: 0 vulnerabilities)*
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, react errors)*
- `npm test` *(fails: scores is not defined)*
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846d5d5518c832f83b6b32703109ec9