### PR TITLE
Limit GamePageLayout sidebar width

### DIFF
--- a/learning-games/src/components/layout/GamePageLayout.css
+++ b/learning-games/src/components/layout/GamePageLayout.css
@@ -9,6 +9,7 @@
 
 .left-column {
   flex: 0 0 28%;
+  max-width: 250px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -85,6 +86,7 @@
   .left-column {
     flex: none;
     width: 100%;
+    max-width: none;
     margin-bottom: 1.5rem;
     align-items: center;
   }

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -69,7 +69,7 @@ export default function DragDropGame() {
 
   return (
     <div className="dragdrop-page">
-      <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start' }}>
+      <div className="dragdrop-wrapper">
         <GamePageLayout
           imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
           imageAlt="Tone game illustration"

--- a/nextjs-app/src/components/layout/GamePageLayout.css
+++ b/nextjs-app/src/components/layout/GamePageLayout.css
@@ -9,6 +9,7 @@
 
 .left-column {
   flex: 0 0 28%;
+  max-width: 250px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -85,6 +86,7 @@
   .left-column {
     flex: none;
     width: 100%;
+    max-width: none;
     margin-bottom: 1.5rem;
     align-items: center;
   }

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -78,7 +78,7 @@ export default function DragDropGame() {
         }}
       />
       <div className="dragdrop-page">
-      <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'flex-start' }}>
+      <div className="dragdrop-wrapper">
         <GamePageLayout
           imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
           imageAlt="Tone game illustration"

--- a/nextjs-app/src/styles/GamePageLayout.css
+++ b/nextjs-app/src/styles/GamePageLayout.css
@@ -9,6 +9,7 @@
 
 .left-column {
   flex: 0 0 28%;
+  max-width: 250px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -85,6 +86,7 @@
   .left-column {
     flex: none;
     width: 100%;
+    max-width: none;
     margin-bottom: 1.5rem;
     align-items: center;
   }


### PR DESCRIPTION
## Summary
- cap left sidebar width in GamePageLayout styles
- drop inline flex styling from dragdrop pages

## Testing
- `npm run lint` (fails: `next: not found`)
- `npm run lint` in learning-games (fails: `Cannot find package '@eslint/js'`)
- `npm test` in learning-games (fails: `vitest: not found`)


------
https://chatgpt.com/codex/tasks/task_e_6846d8bdd394832fa44630f7ac571d69