### PR TITLE
Add WhyCard component and refactor sidebars

### DIFF
--- a/learning-games/src/components/layout/WhyCard.tsx
+++ b/learning-games/src/components/layout/WhyCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export interface WhyCardProps {
+  title: string
+  explanation: React.ReactNode
+  quote?: React.ReactNode
+  tip?: React.ReactNode
+  className?: string
+  children?: React.ReactNode
+}
+
+export default function WhyCard({
+  title,
+  explanation,
+  quote,
+  tip,
+  className,
+  children,
+}: WhyCardProps) {
+  return (
+    <aside className={className}>
+      <h3>{title}</h3>
+      <p>{explanation}</p>
+      {quote && <blockquote className="sidebar-quote">{quote}</blockquote>}
+      {tip && <p className="sidebar-tip">{tip}</p>}
+      {children}
+    </aside>
+  )
+}

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -5,6 +5,7 @@ import InstructionBanner from '../components/ui/InstructionBanner'
 import ProgressBar from '../components/ui/ProgressBar'
 import DoorAnimation from '../components/DoorAnimation'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import WhyCard from '../components/layout/WhyCard'
 import Tooltip from '../components/ui/Tooltip'
 import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
@@ -247,10 +248,11 @@ export default function ClarityEscapeRoom() {
     <div className="escape-page">
       <InstructionBanner>Escape Room: Guess the Prompt</InstructionBanner>
       <div className="escape-wrapper">
-        <aside className="escape-sidebar">
-          <h3>Why Clarity Matters</h3>
-          <p>Vague inputs lock AI in confusion loops; precise prompts open doors.</p>
-        </aside>
+        <WhyCard
+          className="escape-sidebar"
+          title="Why Clarity Matters"
+          explanation="Vague inputs lock AI in confusion loops; precise prompts open doors."
+        />
         <div className="room">
           <div className="room-grid">
             <div className="room-main">

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -2,6 +2,7 @@ import { useState, useContext } from 'react'
 import { Link } from 'react-router-dom'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import GamePageLayout from '../components/layout/GamePageLayout'
+import WhyCard from '../components/layout/WhyCard'
 import { UserContext } from '../context/UserContext'
 
 
@@ -74,13 +75,10 @@ export default function DragDropGame() {
           imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
           imageAlt="Tone game illustration"
           infoCardContent={
-            <>
-              <h3>Why Tone Matters</h3>
-              <p>
-                Drag the adjectives into the blank to try different tones. Swap
-                words wisely and watch your message sparkle!
-              </p>
-            </>
+            <WhyCard
+              title="Why Tone Matters"
+              explanation="Drag the adjectives into the blank to try different tones. Swap words wisely and watch your message sparkle!"
+            />
           }
           instructions="Match adjectives to explore how tone changes the meaning of a message."
           onCTAClick={() => {}}

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -7,6 +7,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { UserContext } from "../context/UserContext";
 import RobotChat from "../components/RobotChat";
 import InstructionBanner from "../components/ui/InstructionBanner";
+import WhyCard from "../components/layout/WhyCard";
 
 /** Tile element used in the grid */
 export interface Tile {
@@ -353,12 +354,13 @@ export default function Match3Game() {
         Match adjectives to explore how tone changes the meaning of a message.
       </InstructionBanner>
       <div className="match3-wrapper">
-        <aside className="match3-sidebar">
-          <h3>Why Tone Matters</h3>
-          <p>Drag the adjectives into the blank to try different tones.</p>
-          <blockquote className="sidebar-quote">{sidebarQuote}</blockquote>
-          <p className="sidebar-tip">{sidebarTip}</p>
-        </aside>
+        <WhyCard
+          className="match3-sidebar"
+          title="Why Tone Matters"
+          explanation="Drag the adjectives into the blank to try different tones."
+          quote={sidebarQuote}
+          tip={sidebarTip}
+        />
         <div className="match3-container">
           <img
             src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -2,6 +2,7 @@ import { useState, useContext, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import WhyCard from '../components/layout/WhyCard'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import TimerBar from '../components/ui/TimerBar'
 import { UserContext } from '../context/UserContext'
@@ -432,12 +433,13 @@ export default function PromptDartsGame() {
         Choose the clearer prompt that best targets the requested format.
       </InstructionBanner>
       <div className="darts-wrapper">
-        <aside className="darts-sidebar">
-          <h3>Why Clarity Matters</h3>
-          <p>The clearer your target, the better your aim. Clear prompts act like aiming sights for AI.</p>
-          <blockquote className="sidebar-quote">Why Card: Why Clarity Matters</blockquote>
-          <p className="sidebar-tip">Align prompt language with output types (teaching specificity and clarity).</p>
-        </aside>
+        <WhyCard
+          className="darts-sidebar"
+          title="Why Clarity Matters"
+          explanation="The clearer your target, the better your aim. Clear prompts act like aiming sights for AI."
+          quote="Why Card: Why Clarity Matters"
+          tip="Align prompt language with output types (teaching specificity and clarity)."
+        />
         <div className="darts-game">
           <img
             src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png"

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -5,6 +5,7 @@ import Tooltip from '../components/ui/Tooltip'
 import ProgressBar from '../components/ui/ProgressBar'
 import DoorAnimation from '../components/DoorAnimation'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import WhyCard from '../components/layout/WhyCard'
 import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './PromptGuessEscape.css'
@@ -227,10 +228,11 @@ export default function PromptGuessEscape() {
     <div className="guess-page">
       <InstructionBanner>Escape Room: Guess the Prompt</InstructionBanner>
       <div className="guess-wrapper">
-        <aside className="guess-sidebar">
-          <h3>Why Clarity Matters</h3>
-          <p>Vague inputs lock AI in confusion loops; precise prompts open doors.</p>
-        </aside>
+        <WhyCard
+          className="guess-sidebar"
+          title="Why Clarity Matters"
+          explanation="Vague inputs lock AI in confusion loops; precise prompts open doors."
+        />
         <div className="guess-game">
           <p className="ai-response"><strong>AI Response:</strong> "{clue.aiResponse}"</p>
           <p className="timer">Time left: {timeLeft}s</p>

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -6,6 +6,7 @@ import confetti from 'canvas-confetti'
 import { toast } from 'react-hot-toast'
 
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import WhyCard from '../components/layout/WhyCard'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import Tooltip from '../components/ui/Tooltip'
 import TimerBar from '../components/ui/TimerBar'
@@ -439,12 +440,13 @@ export default function PromptRecipeGame() {
         Drag each card to the category it best fits to build a clear AI prompt.
       </InstructionBanner>
       <div className="recipe-wrapper">
-        <aside className="recipe-sidebar">
-          <h3>Why Build Prompts?</h3>
-          <p>Combining action, context, format and constraints clarifies intent.</p>
-          <blockquote className="sidebar-quote">Why Card: This page has potential but needs some polish to make it intuitive, clean, and engaging.</blockquote>
-          <p className="sidebar-tip">Arrange each ingredient to craft a clear request.</p>
-        </aside>
+        <WhyCard
+          className="recipe-sidebar"
+          title="Why Build Prompts?"
+          explanation="Combining action, context, format and constraints clarifies intent."
+          quote="Why Card: This page has potential but needs some polish to make it intuitive, clean, and engaging."
+          tip="Arrange each ingredient to craft a clear request."
+        />
         <div className="recipe-game">
           <div className="status-bar">
             <span className="round-info">Round {round + 1} / {TOTAL_ROUNDS}</span>

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useContext, useMemo } from 'react'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
+import WhyCard from '../components/layout/WhyCard'
 import { motion } from 'framer-motion'
 import { toast } from 'react-hot-toast'
 import { Link, useNavigate } from 'react-router-dom'
@@ -48,16 +49,20 @@ function WhyItMatters() {
     [],
   )
   return (
-    <aside className="quiz-sidebar reveal">
-      <h3>Why It Matters</h3>
-      <p>AI hallucinations occur when the system confidently states something untrue.</p>
-      <blockquote className="sidebar-quote">{QUOTE}</blockquote>
-      <p className="sidebar-tip">{TIP}</p>
+    <WhyCard
+      className="quiz-sidebar reveal"
+      title="Why It Matters"
+      explanation="AI hallucinations occur when the system confidently states something untrue."
+      quote={QUOTE}
+      tip={TIP}
+    >
       <p className="sidebar-example">
-        Example: {example.statement}{' '}
-        <a href={example.source} target="_blank" rel="noopener noreferrer">Source</a>
+        Example: {example.statement}{" "}
+        <a href={example.source} target="_blank" rel="noopener noreferrer">
+          Source
+        </a>
       </p>
-    </aside>
+    </WhyCard>
   )
 }
 

--- a/nextjs-app/src/components/layout/WhyCard.tsx
+++ b/nextjs-app/src/components/layout/WhyCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export interface WhyCardProps {
+  title: string
+  explanation: React.ReactNode
+  quote?: React.ReactNode
+  tip?: React.ReactNode
+  className?: string
+  children?: React.ReactNode
+}
+
+export default function WhyCard({
+  title,
+  explanation,
+  quote,
+  tip,
+  className,
+  children,
+}: WhyCardProps) {
+  return (
+    <aside className={className}>
+      <h3>{title}</h3>
+      <p>{explanation}</p>
+      {quote && <blockquote className="sidebar-quote">{quote}</blockquote>}
+      {tip && <p className="sidebar-tip">{tip}</p>}
+      {children}
+    </aside>
+  )
+}

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -2,6 +2,7 @@ import { useState, useContext, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
+import WhyCard from '../../components/layout/WhyCard'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import TimerBar from '../../components/ui/TimerBar'
 import { UserContext } from '../../context/UserContext'
@@ -469,12 +470,13 @@ export default function PromptDartsGame() {
         Choose the clearer prompt that best targets the requested format.
       </InstructionBanner>
       <div className="darts-wrapper">
-        <aside className="darts-sidebar">
-          <h3>Why Clarity Matters</h3>
-          <p>The clearer your target, the better your aim. Clear prompts act like aiming sights for AI.</p>
-          <blockquote className="sidebar-quote">Why Card: Why Clarity Matters</blockquote>
-          <p className="sidebar-tip">Align prompt language with output types (teaching specificity and clarity).</p>
-        </aside>
+        <WhyCard
+          className="darts-sidebar"
+          title="Why Clarity Matters"
+          explanation="The clearer your target, the better your aim. Clear prompts act like aiming sights for AI."
+          quote="Why Card: Why Clarity Matters"
+          tip="Align prompt language with output types (teaching specificity and clarity)."
+        />
         <div className="darts-game">
           <img
             src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png"

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -2,6 +2,7 @@ import { useState, useContext } from 'react'
 import Link from 'next/link'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import GamePageLayout from '../../components/layout/GamePageLayout'
+import WhyCard from '../../components/layout/WhyCard'
 import { UserContext } from '../../context/UserContext'
 import '../../styles/DragDropGame.css'
 import JsonLd from '../../components/seo/JsonLd'
@@ -83,13 +84,10 @@ export default function DragDropGame() {
           imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
           imageAlt="Tone game illustration"
           infoCardContent={
-            <>
-              <h3>Why Tone Matters</h3>
-              <p>
-                Drag the adjectives into the blank to try different tones. Swap
-                words wisely and watch your message sparkle!
-              </p>
-            </>
+            <WhyCard
+              title="Why Tone Matters"
+              explanation="Drag the adjectives into the blank to try different tones. Swap words wisely and watch your message sparkle!"
+            />
           }
           instructions="Match adjectives to explore how tone changes the meaning of a message."
           onCTAClick={() => {}}

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -5,6 +5,7 @@ import InstructionBanner from '../../components/ui/InstructionBanner'
 import ProgressBar from '../../components/ui/ProgressBar'
 import DoorAnimation from '../../components/DoorAnimation'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
+import WhyCard from '../../components/layout/WhyCard'
 import Tooltip from '../../components/ui/Tooltip'
 import { UserContext } from '../../context/UserContext'
 import shuffle from '../../utils/shuffle'
@@ -293,10 +294,11 @@ export default function ClarityEscapeRoom() {
       <div className="escape-page">
       <InstructionBanner>Escape Room: Guess the Prompt</InstructionBanner>
       <div className="escape-wrapper">
-        <aside className="escape-sidebar">
-          <h3>Why Clarity Matters</h3>
-          <p>Vague inputs lock AI in confusion loops; precise prompts open doors.</p>
-        </aside>
+        <WhyCard
+          className="escape-sidebar"
+          title="Why Clarity Matters"
+          explanation="Vague inputs lock AI in confusion loops; precise prompts open doors."
+        />
         <div className="room">
           <div className="room-grid">
             <div className="room-main">

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -5,6 +5,7 @@ import Tooltip from '../../components/ui/Tooltip'
 import ProgressBar from '../../components/ui/ProgressBar'
 import DoorAnimation from '../../components/DoorAnimation'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
+import WhyCard from '../../components/layout/WhyCard'
 import { UserContext } from '../../context/UserContext'
 import shuffle from '../../utils/shuffle'
 import '../../styles/PromptGuessEscape.css'
@@ -239,10 +240,11 @@ export default function PromptGuessEscape() {
       <div className="guess-page">
       <InstructionBanner>Escape Room: Guess the Prompt</InstructionBanner>
       <div className="guess-wrapper">
-        <aside className="guess-sidebar">
-          <h3>Why Clarity Matters</h3>
-          <p>Vague inputs lock AI in confusion loops; precise prompts open doors.</p>
-        </aside>
+        <WhyCard
+          className="guess-sidebar"
+          title="Why Clarity Matters"
+          explanation="Vague inputs lock AI in confusion loops; precise prompts open doors."
+        />
         <div className="guess-game">
           <p className="ai-response"><strong>AI Response:</strong> "{clue.aiResponse}"</p>
           <p className="timer">Time left: {timeLeft}s</p>

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useContext, useMemo } from 'react'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
+import WhyCard from '../../components/layout/WhyCard'
 import { motion } from 'framer-motion'
 import { toast } from 'react-hot-toast'
 import Link from 'next/link'; import { useRouter } from 'next/router'
@@ -50,16 +51,20 @@ function WhyItMatters() {
     [],
   )
   return (
-    <aside className="quiz-sidebar reveal">
-      <h3>Why It Matters</h3>
-      <p>AI hallucinations occur when the system confidently states something untrue.</p>
-      <blockquote className="sidebar-quote">{QUOTE}</blockquote>
-      <p className="sidebar-tip">{TIP}</p>
+    <WhyCard
+      className="quiz-sidebar reveal"
+      title="Why It Matters"
+      explanation="AI hallucinations occur when the system confidently states something untrue."
+      quote={QUOTE}
+      tip={TIP}
+    >
       <p className="sidebar-example">
-        Example: {example.statement}{' '}
-        <a href={example.source} target="_blank" rel="noopener noreferrer">Source</a>
+        Example: {example.statement}{" "}
+        <a href={example.source} target="_blank" rel="noopener noreferrer">
+          Source
+        </a>
       </p>
-    </aside>
+    </WhyCard>
   )
 }
 

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -8,6 +8,7 @@ import { toast } from 'react-hot-toast'
 import JsonLd from '../../components/seo/JsonLd'
 
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
+import WhyCard from '../../components/layout/WhyCard'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import Tooltip from '../../components/ui/Tooltip'
 import TimerBar from '../../components/ui/TimerBar'
@@ -483,12 +484,13 @@ export default function PromptRecipeGame() {
         Drag each card to the category it best fits to build a clear AI prompt.
       </InstructionBanner>
       <div className="recipe-wrapper">
-        <aside className="recipe-sidebar">
-          <h3>Why Build Prompts?</h3>
-          <p>Combining action, context, format and constraints clarifies intent.</p>
-          <blockquote className="sidebar-quote">Why Card: This page has potential but needs some polish to make it intuitive, clean, and engaging.</blockquote>
-          <p className="sidebar-tip">Arrange each ingredient to craft a clear request.</p>
-        </aside>
+        <WhyCard
+          className="recipe-sidebar"
+          title="Why Build Prompts?"
+          explanation="Combining action, context, format and constraints clarifies intent."
+          quote="Why Card: This page has potential but needs some polish to make it intuitive, clean, and engaging."
+          tip="Arrange each ingredient to craft a clear request."
+        />
         <div className="recipe-game">
           <div className="status-bar">
             <span className="round-info">Round {round + 1} / {TOTAL_ROUNDS}</span>

--- a/nextjs-app/src/pages/games/tone.tsx
+++ b/nextjs-app/src/pages/games/tone.tsx
@@ -9,6 +9,7 @@ import JsonLd from "../../components/seo/JsonLd";
 import { UserContext } from "../../context/UserContext";
 import RobotChat from "../../components/RobotChat";
 import InstructionBanner from "../../components/ui/InstructionBanner";
+import WhyCard from "../../components/layout/WhyCard";
 
 /** Tile element used in the grid */
 export interface Tile {
@@ -396,12 +397,13 @@ export default function Match3Game() {
         Match adjectives to explore how tone changes the meaning of a message.
       </InstructionBanner>
       <div className="match3-wrapper">
-        <aside className="match3-sidebar">
-          <h3>Why Tone Matters</h3>
-          <p>Drag the adjectives into the blank to try different tones.</p>
-          <blockquote className="sidebar-quote">{sidebarQuote}</blockquote>
-          <p className="sidebar-tip">{sidebarTip}</p>
-        </aside>
+        <WhyCard
+          className="match3-sidebar"
+          title="Why Tone Matters"
+          explanation="Drag the adjectives into the blank to try different tones."
+          quote={sidebarQuote}
+          tip={sidebarTip}
+        />
         <div className="match3-container">
           <img
             src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png"


### PR DESCRIPTION
## Summary
- add reusable `WhyCard` layout component
- refactor all game pages in Next.js to use `WhyCard`
- mirror the component and updates in the Vite version

## Testing
- `npm run lint` *(fails: Do not use an `<a>` element, etc.)*
- `npm run lint` in `learning-games` *(failed: vitest not found)*
- `npm test` in `nextjs-app` *(script missing)*
- `npm test` in `learning-games` *(vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d8aefbac832faf468894f88adbd6