### PR TITLE
Apply sidebar max-width and clean inline styles

### DIFF
--- a/learning-games/src/components/layout/GamePageLayout.css
+++ b/learning-games/src/components/layout/GamePageLayout.css
@@ -27,6 +27,7 @@
   background-color: #ffe5d9;
   border-radius: 8px;
   padding: 1rem;
+  max-width: 250px;
   font-weight: 600;
   font-size: 0.9rem;
   color: #3a3a3a;

--- a/learning-games/src/pages/DragDropGame.css
+++ b/learning-games/src/pages/DragDropGame.css
@@ -27,6 +27,7 @@
 
 .next-area {
   grid-area: next;
+  text-align: center;
 }
 
 .sentence {

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -174,7 +174,7 @@ export default function DragDropGame() {
         <ProgressSidebar />
       </div>
       <div className="next-area">
-        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+        <p>
           <Link to="/leaderboard">Return to Progress</Link>
         </p>
       </div>

--- a/nextjs-app/src/components/layout/GamePageLayout.css
+++ b/nextjs-app/src/components/layout/GamePageLayout.css
@@ -27,6 +27,7 @@
   background-color: #ffe5d9;
   border-radius: 8px;
   padding: 1rem;
+  max-width: 250px;
   font-weight: 600;
   font-size: 0.9rem;
   color: #3a3a3a;

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -183,7 +183,7 @@ export default function DragDropGame() {
         <ProgressSidebar />
       </div>
       <div className="next-area">
-        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+        <p>
           <Link href="/leaderboard">Return to Progress</Link>
         </p>
       </div>

--- a/nextjs-app/src/styles/DragDropGame.css
+++ b/nextjs-app/src/styles/DragDropGame.css
@@ -27,6 +27,7 @@
 
 .next-area {
   grid-area: next;
+  text-align: center;
 }
 
 .sentence {

--- a/nextjs-app/src/styles/GamePageLayout.css
+++ b/nextjs-app/src/styles/GamePageLayout.css
@@ -27,6 +27,7 @@
   background-color: #ffe5d9;
   border-radius: 8px;
   padding: 1rem;
+  max-width: 250px;
   font-weight: 600;
   font-size: 0.9rem;
   color: #3a3a3a;


### PR DESCRIPTION
## Summary
- limit info-card width in `GamePageLayout`
- center Next link with CSS instead of inline style
- remove inline style from `dragdrop.tsx`

## Testing
- `npm run lint` *(fails: Failed to load SWC binary)*

------
https://chatgpt.com/codex/tasks/task_e_6846db27ff68832f82212b384936f87b