### PR TITLE
Add intro overlay to Clarity Escape Room

### DIFF
--- a/learning-games/src/components/ui/IntroOverlay.css
+++ b/learning-games/src/components/ui/IntroOverlay.css
@@ -1,0 +1,33 @@
+.intro-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.intro-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  text-align: left;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.intro-modal ul {
+  padding-left: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.intro-modal li {
+  margin-bottom: 0.5rem;
+}

--- a/learning-games/src/components/ui/IntroOverlay.tsx
+++ b/learning-games/src/components/ui/IntroOverlay.tsx
@@ -1,0 +1,22 @@
+import './IntroOverlay.css'
+
+export interface IntroOverlayProps {
+  onClose: () => void
+}
+
+export default function IntroOverlay({ onClose }: IntroOverlayProps) {
+  return (
+    <div className="intro-overlay" role="dialog" aria-modal="true">
+      <div className="intro-modal">
+        <h2>How to Play</h2>
+        <ul>
+          <li>Objective: guess the original prompt that led to the AI response.</li>
+          <li>Time limit: 30 seconds per door.</li>
+          <li>Use the Hint button or press "H" for clues, each one costs points.</li>
+          <li>Earn points for clear prompts and speed; hints reduce your score.</li>
+        </ul>
+        <button className="btn-primary" onClick={onClose}>Start</button>
+      </div>
+    </div>
+  )
+}

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -7,6 +7,7 @@ import DoorAnimation from '../components/DoorAnimation'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import WhyCard from '../components/layout/WhyCard'
 import Tooltip from '../components/ui/Tooltip'
+import IntroOverlay from '../components/ui/IntroOverlay'
 import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './ClarityEscapeRoom.css'
@@ -121,6 +122,7 @@ export default function ClarityEscapeRoom() {
 
   const [aiHint, setAiHint] = useState('')
   const startRef = useRef(Date.now())
+  const [showIntro, setShowIntro] = useState(true)
   const [showSummary, setShowSummary] = useState(false)
 
   const clue = doors[index]
@@ -164,6 +166,18 @@ export default function ClarityEscapeRoom() {
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [revealHint])
+
+  useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setShowIntro(false)
+      }
+    }
+    if (showIntro) {
+      window.addEventListener('keydown', handleEsc)
+      return () => window.removeEventListener('keydown', handleEsc)
+    }
+  }, [showIntro])
 
   async function fetchAiHint(guess: string) {
     try {
@@ -245,7 +259,9 @@ export default function ClarityEscapeRoom() {
   }
 
   return (
-    <div className="escape-page">
+    <>
+      {showIntro && <IntroOverlay onClose={() => setShowIntro(false)} />}
+      <div className="escape-page">
       <InstructionBanner>Escape Room: Guess the Prompt</InstructionBanner>
       <div className="escape-wrapper">
         <WhyCard
@@ -327,5 +343,6 @@ export default function ClarityEscapeRoom() {
         </CompletionModal>
       )}
     </div>
+    </>
   )
 }

--- a/nextjs-app/src/components/ui/IntroOverlay.css
+++ b/nextjs-app/src/components/ui/IntroOverlay.css
@@ -1,0 +1,33 @@
+.intro-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.intro-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  text-align: left;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.intro-modal ul {
+  padding-left: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.intro-modal li {
+  margin-bottom: 0.5rem;
+}

--- a/nextjs-app/src/components/ui/IntroOverlay.tsx
+++ b/nextjs-app/src/components/ui/IntroOverlay.tsx
@@ -1,0 +1,22 @@
+import './IntroOverlay.css'
+
+export interface IntroOverlayProps {
+  onClose: () => void
+}
+
+export default function IntroOverlay({ onClose }: IntroOverlayProps) {
+  return (
+    <div className="intro-overlay" role="dialog" aria-modal="true">
+      <div className="intro-modal">
+        <h2>How to Play</h2>
+        <ul>
+          <li>Objective: guess the original prompt that led to the AI response.</li>
+          <li>Time limit: 30 seconds per door.</li>
+          <li>Use the Hint button or press "H" for clues, each one costs points.</li>
+          <li>Earn points for clear prompts and speed; hints reduce your score.</li>
+        </ul>
+        <button className="btn-primary" onClick={onClose}>Start</button>
+      </div>
+    </div>
+  )
+}

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -7,6 +7,7 @@ import DoorAnimation from '../../components/DoorAnimation'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import WhyCard from '../../components/layout/WhyCard'
 import Tooltip from '../../components/ui/Tooltip'
+import IntroOverlay from '../../components/ui/IntroOverlay'
 import { UserContext } from '../../context/UserContext'
 import shuffle from '../../utils/shuffle'
 import '../../styles/ClarityEscapeRoom.css'
@@ -124,6 +125,7 @@ export default function ClarityEscapeRoom() {
 
   const [aiHint, setAiHint] = useState('')
   const startRef = useRef(Date.now())
+  const [showIntro, setShowIntro] = useState(true)
   const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
   const [showSummary, setShowSummary] = useState(false)
 
@@ -168,6 +170,18 @@ export default function ClarityEscapeRoom() {
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [revealHint])
+
+  useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setShowIntro(false)
+      }
+    }
+    if (showIntro) {
+      window.addEventListener('keydown', handleEsc)
+      return () => window.removeEventListener('keydown', handleEsc)
+    }
+  }, [showIntro])
 
   async function fetchAiHint(guess: string) {
     try {
@@ -251,6 +265,7 @@ export default function ClarityEscapeRoom() {
 
   return (
     <>
+      {showIntro && <IntroOverlay onClose={() => setShowIntro(false)} />}
       <JsonLd
         data={{
           '@context': 'https://schema.org',


### PR DESCRIPTION
## Summary
- add new `IntroOverlay` component for both apps
- show overlay when Clarity Escape Room pages load
- close overlay with button or Esc key

## Testing
- `npm --prefix learning-games test` *(fails: TypeError in ProgressSidebar)*

------
https://chatgpt.com/codex/tasks/task_e_6846e44866c8832fba0f56dc1e317218