### PR TITLE
Add dynamic escape room descriptions

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -11,6 +11,7 @@ import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './ClarityEscapeRoom.css'
 import { scorePrompt } from '../utils/scorePrompt'
+import { generateRoomDescription } from '../utils/generateRoomDescription'
 
 interface Clue {
   aiResponse: string
@@ -119,9 +120,15 @@ export default function ClarityEscapeRoom() {
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
 
+  const [roomDescription, setRoomDescription] = useState('')
+
   const [aiHint, setAiHint] = useState('')
   const startRef = useRef(Date.now())
   const [showSummary, setShowSummary] = useState(false)
+
+  useEffect(() => {
+    generateRoomDescription().then(text => setRoomDescription(text))
+  }, [])
 
   const clue = doors[index]
 
@@ -235,6 +242,8 @@ export default function ClarityEscapeRoom() {
       setHintIndex(0)
       setHintCount(0)
 
+      generateRoomDescription().then(text => setRoomDescription(text))
+
       setAiHint('')
 
       setShowNext(false)
@@ -256,6 +265,9 @@ export default function ClarityEscapeRoom() {
         <div className="room">
           <div className="room-grid">
             <div className="room-main">
+              {roomDescription && (
+                <p className="room-description">{roomDescription}</p>
+              )}
               <p className="ai-response"><strong>AI Response:</strong> "{clue.aiResponse}"</p>
               <p className="timer">Time left: {timeLeft}s</p>
               <form onSubmit={handleSubmit} className="prompt-form">

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -10,6 +10,7 @@ import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './PromptGuessEscape.css'
 import { scorePrompt } from '../utils/scorePrompt'
+import { generateRoomDescription } from '../utils/generateRoomDescription'
 
 interface Clue {
   aiResponse: string
@@ -125,9 +126,14 @@ export default function PromptGuessEscape() {
   const [openPercent, setOpenPercent] = useState(0)
   const [failStreak, setFailStreak] = useState(0)
   const [scoreThreshold, setScoreThreshold] = useState(BASE_SCORE)
+  const [roomDescription, setRoomDescription] = useState('')
   const startRef = useRef(Date.now())
   const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
   const [showSummary, setShowSummary] = useState(false)
+
+  useEffect(() => {
+    generateRoomDescription().then(text => setRoomDescription(text))
+  }, [])
 
   const clue = doors[index]
 
@@ -217,6 +223,7 @@ export default function PromptGuessEscape() {
       setStatus('')
       setHintIndex(0)
       setHintCount(0)
+      generateRoomDescription().then(text => setRoomDescription(text))
       setShowNext(false)
     } else {
       setPoints('escape', points)
@@ -234,6 +241,9 @@ export default function PromptGuessEscape() {
           explanation="Vague inputs lock AI in confusion loops; precise prompts open doors."
         />
         <div className="guess-game">
+          {roomDescription && (
+            <p className="room-description">{roomDescription}</p>
+          )}
           <p className="ai-response"><strong>AI Response:</strong> "{clue.aiResponse}"</p>
           <p className="timer">Time left: {timeLeft}s</p>
           <form onSubmit={handleSubmit} className="prompt-form">

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -12,6 +12,7 @@ import shuffle from '../../utils/shuffle'
 import '../../styles/ClarityEscapeRoom.css'
 import CompletionModal from '../../components/ui/CompletionModal'
 import { scorePrompt } from '../../utils/scorePrompt'
+import { generateRoomDescription } from '../../utils/generateRoomDescription'
 import HeadTag from 'next/head'
 import JsonLd from '../../components/seo/JsonLd'
 
@@ -122,10 +123,16 @@ export default function ClarityEscapeRoom() {
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
 
+  const [roomDescription, setRoomDescription] = useState('')
+
   const [aiHint, setAiHint] = useState('')
   const startRef = useRef(Date.now())
   const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
   const [showSummary, setShowSummary] = useState(false)
+
+  useEffect(() => {
+    generateRoomDescription().then(text => setRoomDescription(text))
+  }, [])
 
   const clue = doors[index]
 
@@ -240,6 +247,8 @@ export default function ClarityEscapeRoom() {
       setHintIndex(0)
       setHintCount(0)
 
+      generateRoomDescription().then(text => setRoomDescription(text))
+
       setAiHint('')
 
       setShowNext(false)
@@ -302,6 +311,9 @@ export default function ClarityEscapeRoom() {
         <div className="room">
           <div className="room-grid">
             <div className="room-main">
+              {roomDescription && (
+                <p className="room-description">{roomDescription}</p>
+              )}
               <p className="ai-response"><strong>AI Response:</strong> "{clue.aiResponse}"</p>
               <p className="timer">Time left: {timeLeft}s</p>
               <form onSubmit={handleSubmit} className="prompt-form">

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -10,6 +10,7 @@ import { UserContext } from '../../context/UserContext'
 import shuffle from '../../utils/shuffle'
 import '../../styles/PromptGuessEscape.css'
 import { scorePrompt } from '../../utils/scorePrompt'
+import { generateRoomDescription } from '../../utils/generateRoomDescription'
 import JsonLd from '../../components/seo/JsonLd'
 
 interface Clue {
@@ -126,9 +127,14 @@ export default function PromptGuessEscape() {
   const [openPercent, setOpenPercent] = useState(0)
   const [failStreak, setFailStreak] = useState(0)
   const [scoreThreshold, setScoreThreshold] = useState(BASE_SCORE)
+  const [roomDescription, setRoomDescription] = useState('')
   const startRef = useRef(Date.now())
   const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
   const [showSummary, setShowSummary] = useState(false)
+
+  useEffect(() => {
+    generateRoomDescription().then(text => setRoomDescription(text))
+  }, [])
 
   const clue = doors[index]
 
@@ -218,6 +224,7 @@ export default function PromptGuessEscape() {
       setStatus('')
       setHintIndex(0)
       setHintCount(0)
+      generateRoomDescription().then(text => setRoomDescription(text))
       setShowNext(false)
     } else {
       setPoints('escape', points)
@@ -246,6 +253,9 @@ export default function PromptGuessEscape() {
           explanation="Vague inputs lock AI in confusion loops; precise prompts open doors."
         />
         <div className="guess-game">
+          {roomDescription && (
+            <p className="room-description">{roomDescription}</p>
+          )}
           <p className="ai-response"><strong>AI Response:</strong> "{clue.aiResponse}"</p>
           <p className="timer">Time left: {timeLeft}s</p>
           <form onSubmit={handleSubmit} className="prompt-form">


### PR DESCRIPTION
## Summary
- display new room descriptions for each door
- generate descriptions at game start and when the player advances

## Testing
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_6846e4b90a38832fa18f0ffac2c23f10