### PR TITLE
Wrap hint buttons with Tooltip

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -267,9 +267,11 @@ export default function ClarityEscapeRoom() {
                   placeholder="Type the prompt that caused this reply"
                 />
                 <button type="submit" className="btn-primary">Submit</button>
-                <button type="button" className="btn-primary" onClick={revealHint}>
-                  Hint (H)
-                </button>
+                <Tooltip message="Reveal a hint (press H). Each hint reduces your points.">
+                  <button type="button" className="btn-primary" onClick={revealHint}>
+                    Hint (H)
+                  </button>
+                </Tooltip>
               </form>
               <ProgressBar percent={openPercent} />
               {hintIndex > 0 && (

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -313,9 +313,11 @@ export default function ClarityEscapeRoom() {
                   placeholder="Type the prompt that caused this reply"
                 />
                 <button type="submit" className="btn-primary">Submit</button>
-                <button type="button" className="btn-primary" onClick={revealHint}>
-                  Hint (H)
-                </button>
+                <Tooltip message="Reveal a hint (press H). Each hint reduces your points.">
+                  <button type="button" className="btn-primary" onClick={revealHint}>
+                    Hint (H)
+                  </button>
+                </Tooltip>
               </form>
               <ProgressBar percent={openPercent} />
               {hintIndex > 0 && (


### PR DESCRIPTION
## Summary
- use Tooltip for the hint button in ClarityEscapeRoom
- wrap the same button in Next.js escape game

## Testing
- `npm test` *(fails: Cannot convert undefined or null to object)*
- `npm run lint` in `nextjs-app` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e4b68068832fa02406572326fab0