### PR TITLE
Wrap guess hint button with Tooltip

### DIFF
--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -267,9 +267,11 @@ export default function PromptGuessEscape() {
               placeholder="Type the prompt that caused this reply"
             />
             <button type="submit" className="btn-primary">Submit</button>
-            <button type="button" className="btn-primary" onClick={revealHint}>
-              Hint (H)
-            </button>
+            <Tooltip message="Reveal a hint (press H). Each hint reduces your points.">
+              <button type="button" className="btn-primary" onClick={revealHint}>
+                Hint (H)
+              </button>
+            </Tooltip>
           </form>
           <ProgressBar percent={openPercent} />
           {hintIndex > 0 && (


### PR DESCRIPTION
## Summary
- add tooltip around the Guess game hint button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7b53df0832f9791059f863a02a5