### PR TITLE
Add dynamic room descriptions

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -130,7 +130,7 @@ export default function ClarityEscapeRoom() {
 
   useEffect(() => {
     generateRoomDescription().then(text => setRoomDescription(text))
-  }, [])
+  }, [index])
 
   const clue = doors[index]
 
@@ -255,8 +255,6 @@ export default function ClarityEscapeRoom() {
       setStatus('')
       setHintIndex(0)
       setHintCount(0)
-
-      generateRoomDescription().then(text => setRoomDescription(text))
 
       setAiHint('')
 

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -133,7 +133,7 @@ export default function PromptGuessEscape() {
 
   useEffect(() => {
     generateRoomDescription().then(text => setRoomDescription(text))
-  }, [])
+  }, [index])
 
   const clue = doors[index]
 
@@ -223,7 +223,6 @@ export default function PromptGuessEscape() {
       setStatus('')
       setHintIndex(0)
       setHintCount(0)
-      generateRoomDescription().then(text => setRoomDescription(text))
       setShowNext(false)
     } else {
       setPoints('escape', points)

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -134,7 +134,7 @@ export default function ClarityEscapeRoom() {
 
   useEffect(() => {
     generateRoomDescription().then(text => setRoomDescription(text))
-  }, [])
+  }, [index])
 
   const clue = doors[index]
 
@@ -261,10 +261,8 @@ export default function ClarityEscapeRoom() {
       setHintIndex(0)
       setHintCount(0)
 
-      generateRoomDescription().then(text => setRoomDescription(text))
-
       setAiHint('')
-
+      
       setShowNext(false)
     } else {
       setPoints('escape', points)

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -134,7 +134,7 @@ export default function PromptGuessEscape() {
 
   useEffect(() => {
     generateRoomDescription().then(text => setRoomDescription(text))
-  }, [])
+  }, [index])
 
   const clue = doors[index]
 
@@ -224,7 +224,6 @@ export default function PromptGuessEscape() {
       setStatus('')
       setHintIndex(0)
       setHintCount(0)
-      generateRoomDescription().then(text => setRoomDescription(text))
       setShowNext(false)
     } else {
       setPoints('escape', points)


### PR DESCRIPTION
## Summary
- refresh room descriptions when the door index changes in the Escape Room pages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7b72074832f8f512383bf4ec74c