### PR TITLE
Add hint penalty messaging

### DIFF
--- a/learning-games/src/components/ui/IntroOverlay.tsx
+++ b/learning-games/src/components/ui/IntroOverlay.tsx
@@ -12,8 +12,8 @@ export default function IntroOverlay({ onClose }: IntroOverlayProps) {
         <ul>
           <li>Objective: guess the original prompt that led to the AI response.</li>
           <li>Time limit: 30 seconds per door.</li>
-          <li>Use the Hint button or press "H" for clues, each one costs points.</li>
-          <li>Earn points for clear prompts and speed; hints reduce your score.</li>
+          <li>Use the Hint button or press "H" for clues; each hint deducts 2 points.</li>
+          <li>Earn points for clear prompts and speed — hints subtract from your score.</li>
         </ul>
         <button className="btn-primary" onClick={onClose}>Start</button>
       </div>

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
+import { toast } from 'react-hot-toast'
 import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import InstructionBanner from '../components/ui/InstructionBanner'
@@ -156,6 +157,7 @@ export default function ClarityEscapeRoom() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
+        toast('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
+import { toast } from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import Tooltip from '../components/ui/Tooltip'
@@ -166,6 +167,7 @@ export default function PromptGuessEscape() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
+        toast('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }

--- a/nextjs-app/src/components/ui/IntroOverlay.tsx
+++ b/nextjs-app/src/components/ui/IntroOverlay.tsx
@@ -12,8 +12,8 @@ export default function IntroOverlay({ onClose }: IntroOverlayProps) {
         <ul>
           <li>Objective: guess the original prompt that led to the AI response.</li>
           <li>Time limit: 30 seconds per door.</li>
-          <li>Use the Hint button or press "H" for clues, each one costs points.</li>
-          <li>Earn points for clear prompts and speed; hints reduce your score.</li>
+          <li>Use the Hint button or press "H" for clues; each hint deducts 2 points.</li>
+          <li>Earn points for clear prompts and speed — hints subtract from your score.</li>
         </ul>
         <button className="btn-primary" onClick={onClose}>Start</button>
       </div>

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
+import { toast } from 'react-hot-toast'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import InstructionBanner from '../../components/ui/InstructionBanner'
@@ -160,6 +161,7 @@ export default function ClarityEscapeRoom() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
+        toast('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
+import { toast } from 'react-hot-toast'
 import { useRouter } from 'next/router'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import Tooltip from '../../components/ui/Tooltip'
@@ -167,6 +168,7 @@ export default function PromptGuessEscape() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
+        toast('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }


### PR DESCRIPTION
## Summary
- mention the two‑point hint penalty in the IntroOverlay for the escape room
- show a toast when a hint is revealed in both React and Next.js games

## Testing
- `npm run lint` *(fails: setScore assigned a value but never used, etc.)*
- `npm test` *(fails: TypeError cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7befc24832f8e4054719e1db6d0