### PR TITLE
Add door unlocked modal

### DIFF
--- a/nextjs-app/src/components/ui/DoorUnlockedModal.css
+++ b/nextjs-app/src/components/ui/DoorUnlockedModal.css
@@ -1,0 +1,26 @@
+.door-unlocked-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.door-unlocked-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 320px;
+  text-align: center;
+}
+
+.door-unlocked-modal button {
+  margin-top: 0.5rem;
+}

--- a/nextjs-app/src/components/ui/DoorUnlockedModal.tsx
+++ b/nextjs-app/src/components/ui/DoorUnlockedModal.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import './DoorUnlockedModal.css'
+
+export interface DoorUnlockedModalProps {
+  points: number
+  remaining: number
+  onNext: () => void
+}
+
+export default function DoorUnlockedModal({ points, remaining, onNext }: DoorUnlockedModalProps) {
+  useEffect(() => {
+    const id = setTimeout(onNext, 3000)
+    return () => clearTimeout(id)
+  }, [onNext])
+
+  return (
+    <div className="door-unlocked-overlay" role="dialog" aria-modal="true">
+      <div className="door-unlocked-modal">
+        <h3>Door Unlocked!</h3>
+        <p className="modal-points">+{points} points</p>
+        <p className="modal-remaining">{remaining} doors remaining</p>
+        <button className="btn-primary" onClick={onNext}>
+          Next Challenge
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import ProgressBar from '../../components/ui/ProgressBar'
 import DoorAnimation from '../../components/DoorAnimation'
+import DoorUnlockedModal from '../../components/ui/DoorUnlockedModal'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import WhyCard from '../../components/layout/WhyCard'
 import Tooltip from '../../components/ui/Tooltip'
@@ -122,6 +123,7 @@ export default function ClarityEscapeRoom() {
   const [hintIndex, setHintIndex] = useState(0)
   const [hintCount, setHintCount] = useState(0)
   const [showNext, setShowNext] = useState(false)
+  const [roundPoints, setRoundPoints] = useState(0)
   const [timeLeft, setTimeLeft] = useState(30)
   const [openPercent, setOpenPercent] = useState(0)
 
@@ -149,6 +151,7 @@ export default function ClarityEscapeRoom() {
           clearInterval(id)
           setMessage("Time's up! The door remains closed.")
           setStatus('error')
+          setRoundPoints(0)
           setShowNext(true)
           return 0
         }
@@ -236,6 +239,7 @@ export default function ClarityEscapeRoom() {
       const total = Math.max(0, score + 10 + timeBonus - penalty)
       setPoints(p => p + total)
       setMessage(`Door unlocked! +${total} points`)
+      setRoundPoints(total)
       setStatus('success')
       setOpenPercent(((index + 1) / TOTAL_STEPS) * 100)
       setShowNext(true)
@@ -365,9 +369,11 @@ export default function ClarityEscapeRoom() {
                 <p className={`feedback ${status}`}>{status === 'success' ? '✔️' : '⚠️'} {message}</p>
               )}
               {showNext && (
-                <div className="next-area">
-                  <button className="btn-primary" onClick={nextChallenge}>Next Challenge</button>
-                </div>
+                <DoorUnlockedModal
+                  points={roundPoints}
+                  remaining={TOTAL_STEPS - (index + 1)}
+                  onNext={nextChallenge}
+                />
               )}
               <p className="score">Score: {points}</p>
             </div>

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -5,6 +5,7 @@ import InstructionBanner from '../../components/ui/InstructionBanner'
 import Tooltip from '../../components/ui/Tooltip'
 import ProgressBar from '../../components/ui/ProgressBar'
 import DoorAnimation from '../../components/DoorAnimation'
+import DoorUnlockedModal from '../../components/ui/DoorUnlockedModal'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import WhyCard from '../../components/layout/WhyCard'
 import { UserContext } from '../../context/UserContext'
@@ -124,6 +125,7 @@ export default function PromptGuessEscape() {
   const [hintIndex, setHintIndex] = useState(0)
   const [hintCount, setHintCount] = useState(0)
   const [showNext, setShowNext] = useState(false)
+  const [roundPoints, setRoundPoints] = useState(0)
   const [timeLeft, setTimeLeft] = useState(BASE_TIME)
   const [openPercent, setOpenPercent] = useState(0)
   const [failStreak, setFailStreak] = useState(0)
@@ -149,6 +151,7 @@ export default function PromptGuessEscape() {
           clearInterval(id)
           setMessage("Time's up! The door remains closed.")
           setStatus('error')
+          setRoundPoints(0)
           setShowNext(true)
           setFailStreak(fs => {
             const next = fs + 1
@@ -196,6 +199,7 @@ export default function PromptGuessEscape() {
       const total = Math.max(0, score + 10 + timeBonus - penalty)
       setPoints(p => p + total)
       setMessage(`Door unlocked! +${total} points`)
+      setRoundPoints(total)
       setStatus('success')
       setOpenPercent(((index + 1) / TOTAL_STEPS) * 100)
       setShowNext(true)
@@ -288,9 +292,11 @@ export default function PromptGuessEscape() {
             <p className={`feedback ${status}`}>{status === 'success' ? '✔️' : '⚠️'} {message}</p>
           )}
           {showNext && (
-            <div className="next-area">
-              <button className="btn-primary" onClick={nextChallenge}>Next Challenge</button>
-            </div>
+            <DoorUnlockedModal
+              points={roundPoints}
+              remaining={TOTAL_STEPS - (index + 1)}
+              onNext={nextChallenge}
+            />
           )}
         </div>
         <div className="door-area">


### PR DESCRIPTION
## Summary
- create `DoorUnlockedModal` with auto close behavior
- show the modal during Guess and Escape games when progressing

## Testing
- `npm run lint` *(fails: next not found before install, runs after install with many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea16a6d0832f91a48985c6c22e24