### PR TITLE
Add tip overlay after successful prompt

### DIFF
--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -132,6 +132,9 @@ export default function PromptGuessEscape() {
   const startRef = useRef(Date.now())
   const [rounds, setRounds] = useState<{ prompt: string; expected: string; tip: string }[]>([])
   const [showSummary, setShowSummary] = useState(false)
+  const [showTip, setShowTip] = useState(false)
+  const [currentTip, setCurrentTip] = useState('')
+  const [earned, setEarned] = useState(0)
 
   useEffect(() => {
     generateRoomDescription().then(text => setRoomDescription(text))
@@ -195,10 +198,13 @@ export default function PromptGuessEscape() {
       const penalty = hintCount * 2
       const total = Math.max(0, score + 10 + timeBonus - penalty)
       setPoints(p => p + total)
-      setMessage(`Door unlocked! +${total} points`)
+      setEarned(total)
+      setCurrentTip(tips[0] || 'Keep prompts specific and action-oriented.')
       setStatus('success')
       setOpenPercent(((index + 1) / TOTAL_STEPS) * 100)
-      setShowNext(true)
+      setShowTip(true)
+      setShowNext(false)
+      setMessage('')
       setFailStreak(0)
       setScoreThreshold(BASE_SCORE)
     } else {
@@ -298,6 +304,17 @@ export default function PromptGuessEscape() {
         </div>
         <ProgressSidebar />
       </div>
+      {showTip && (
+        <div className="summary-overlay" onClick={() => {}}>
+          <div className="summary-modal" onClick={e => e.stopPropagation()}>
+            <p>You earned {earned} points!</p>
+            <p className="tip"><strong>Tip:</strong> {currentTip}</p>
+            <button className="btn-primary" onClick={() => { setShowTip(false); nextChallenge(); }}>
+              Continue
+            </button>
+          </div>
+        </div>
+      )}
       {showSummary && (
         <div className="summary-overlay" onClick={() => setShowSummary(false)}>
           <div className="summary-modal" onClick={e => e.stopPropagation()}>


### PR DESCRIPTION
## Summary
- show tips after successful guesses in the escape room

## Testing
- `npm run lint` *(fails: Do not use `<a>` element and other lint errors)*
- `npm test` *(fails: Missing script)*
- `npm run lint` in `learning-games` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846ea17656c832fab94f4e541a3a00d