### PR TITLE
Fix unused import in DragDropGame

### DIFF
--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -14,7 +14,7 @@ export interface ProgressSidebarProps {
 export default function ProgressSidebar({ badges }: ProgressSidebarProps = {}) {
   const { user } = useContext(UserContext)
 
-  const userScores = user.scores
+  const userScores = user.points
   const userBadges = badges ?? user.badges
 
 

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useContext, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { toast } from 'react-hot-toast'
 import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
@@ -9,7 +9,6 @@ import ProgressSidebar from '../components/layout/ProgressSidebar'
 import WhyCard from '../components/layout/WhyCard'
 import Tooltip from '../components/ui/Tooltip'
 import IntroOverlay from '../components/ui/IntroOverlay'
-import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import './ClarityEscapeRoom.css'
 import { scorePrompt } from '../utils/scorePrompt'
@@ -115,7 +114,6 @@ const EXTRA_TIME = 10
 
 
 export default function ClarityEscapeRoom() {
-  const { setScore } = useContext(UserContext)
   const navigate = useNavigate()
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)

--- a/learning-games/src/pages/DragDropGame.tsx
+++ b/learning-games/src/pages/DragDropGame.tsx
@@ -1,12 +1,8 @@
-import { useState, useContext } from 'react'
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import GamePageLayout from '../components/layout/GamePageLayout'
 import WhyCard from '../components/layout/WhyCard'
-import { UserContext } from '../context/UserContext'
-
-
-import { getTotalPoints } from '../utils/user'
 import './DragDropGame.css'
 
 const tones = [
@@ -41,7 +37,6 @@ export default function DragDropGame() {
   const [quizAnswer, setQuizAnswer] = useState<Tone | null>(null)
   const [userMessage, setUserMessage] = useState('')
   const [submitted, setSubmitted] = useState(false)
-  const { user } = useContext(UserContext)
 
   function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {
     e.dataTransfer.setData('text/plain', tone)


### PR DESCRIPTION
## Summary
- remove unused imports in `DragDropGame`
- drop unused context from `ClarityEscapeRoom`
- use `user.points` in `ProgressSidebar`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f08e89dc832fb35702f9de1c74d8