### PR TITLE
Fix PromptRecipeGame effect deps

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -230,7 +230,7 @@ export default function PromptRecipeGame() {
 
   useEffect(() => {
     startRound()
-  }, [])
+  }, [startRound])
 
   useEffect(() => {
     if (showPrompt) return
@@ -252,7 +252,13 @@ export default function PromptRecipeGame() {
       const text = `${dropped.Action ?? ''} ${dropped.Context ?? ''} ${dropped.Format ?? ''} ${dropped.Constraints ?? ''}`.trim()
       if (text) generateExampleOutput(text)
     }
-  }, [showPrompt])
+  }, [
+    showPrompt,
+    dropped.Action,
+    dropped.Context,
+    dropped.Format,
+    dropped.Constraints,
+  ])
 
 
   function dropSelected(slot: Slot) {


### PR DESCRIPTION
## Summary
- fix React `useEffect` hooks in PromptRecipeGame dependencies

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f09379ac832f81053b984b86f912