### PR TITLE
Remove unused imports in Match3Game

### DIFF
--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -8,16 +8,6 @@ import { UserContext } from "../context/UserContext";
 import RobotChat from "../components/RobotChat";
 import InstructionBanner from "../components/ui/InstructionBanner";
 import WhyCard from "../components/layout/WhyCard";
-import {
-  type Tile,
-  type Flavor,
-  flavors,
-  colors,
-  createTile,
-  createGrid,
-  type MatchResult,
-  checkMatches,
-} from "./match3Helpers";
 
 const quotes = [
   "Prompting is like seasoning \u2013 a single word changes the flavor.",


### PR DESCRIPTION
## Summary
- clean up unused helper imports from `Match3Game.tsx`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6847010930b0832f8ca912540965bba8