### PR TITLE
Update points setter names

### DIFF
--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -113,11 +113,11 @@ const EXTRA_TIME = 10
 
 export default function PromptGuessEscape() {
   const navigate = useNavigate()
-  const { setPoints } = useContext(UserContext)
+  const { setPoints: recordScore } = useContext(UserContext)
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')
-  const [points, setPoints] = useState(0)
+  const [points, setPointsState] = useState(0)
   const [message, setMessage] = useState('')
   const [status, setStatus] = useState<'success' | 'error' | ''>('')
   const [hintIndex, setHintIndex] = useState(0)
@@ -193,7 +193,7 @@ export default function PromptGuessEscape() {
       const timeBonus = Date.now() - startRef.current < 10000 ? 5 : 0
       const penalty = hintCount * 2
       const total = Math.max(0, score + 10 + timeBonus - penalty)
-      setPoints(p => p + total)
+      setPointsState(p => p + total)
       setMessage(`Door unlocked! +${total} points`)
       setStatus('success')
       setOpenPercent(((index + 1) / TOTAL_STEPS) * 100)
@@ -227,7 +227,7 @@ export default function PromptGuessEscape() {
       setHintCount(0)
       setShowNext(false)
     } else {
-      setPoints('escape', points)
+      recordScore('escape', points)
       setShowSummary(true)
     }
   }


### PR DESCRIPTION
## Summary
- rename local state setter to `setPointsState`
- reference `setPoints` from context as `recordScore`
- update the game logic accordingly

## Testing
- `npm test` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684701099c50832fa947afa3e6170cd9