### PR TITLE
Update API base docs and add env examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
    npm install
    npm start
    ```
-3. Create a `.env` file inside `learning-games` with your
+3. Copy `.env.example` to `.env` inside `learning-games` and fill in
    `VITE_OPENAI_API_KEY=<your key>` for the Robot chat and recipe features.
 4. Open the printed URL in your browser.
 
@@ -81,9 +81,12 @@ The community feedback page uses the same API for sentiment filtering. Set
 `OPENAI_API_KEY` in the server environment so posts can be screened before
 publishing.
 
-To point the Next.js frontend at a custom server URL set `NEXT_PUBLIC_API_BASE`
-in `nextjs-app/.env`. When omitted, the app defaults to `window.location.origin`
-so the API can be served from the same host in production.
+To point either frontend at a custom server URL set `NEXT_PUBLIC_API_BASE`
+in `nextjs-app/.env` or `VITE_API_BASE` in `learning-games/.env`. These must
+be the backend URL when the frontend and API run on different hosts. If these
+variables are omitted each app falls back to `window.location.origin`, which only
+works when the API is served from the same host.
+Sample `.env.example` files in each app illustrate this configuration.
 
 The API server now persists data in Firebase. Provide service account credentials
 by setting `FIREBASE_SERVICE_ACCOUNT` to a JSON string or path, or use

--- a/learning-games/.env.example
+++ b/learning-games/.env.example
@@ -1,0 +1,6 @@
+# Base URL of the backend API
+# Example: https://api.example.com
+VITE_API_BASE=
+
+# OpenAI key for RobotChat and recipes
+VITE_OPENAI_API_KEY=

--- a/nextjs-app/.env.example
+++ b/nextjs-app/.env.example
@@ -1,0 +1,3 @@
+# Base URL of the backend API
+# Example: https://api.example.com
+NEXT_PUBLIC_API_BASE=

--- a/nextjs-app/.gitignore
+++ b/nextjs-app/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,9 @@
+# OpenAI API key used for sentiment filtering
+OPENAI_API_KEY=
+
+# Firebase credentials
+FIREBASE_SERVICE_ACCOUNT=
+GOOGLE_APPLICATION_CREDENTIALS=
+
+# Port the server runs on
+PORT=3001


### PR DESCRIPTION
## Summary
- document that the frontend must set `NEXT_PUBLIC_API_BASE` or `VITE_API_BASE` when the API is on a different host
- mention provided `.env.example` files
- tweak setup instructions for copying the sample env file
- allow `.env.example` to be committed in `nextjs-app`
- add example env files for each app

## Testing
- `npm install --silent` and `npm test --silent` in `learning-games`

------
https://chatgpt.com/codex/tasks/task_e_6847089185d8832f8b0cb7e67c5674fe