### PR TITLE
Add API base helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ The community feedback page uses the same API for sentiment filtering. Set
 publishing.
 
 To point the Next.js frontend at a custom server URL set `NEXT_PUBLIC_API_BASE`
-in `nextjs-app/.env`. When omitted, the app defaults to `window.location.origin`
-so the API can be served from the same host in production.
+in `nextjs-app/.env`.
+For the Vite version use `VITE_API_BASE` inside `learning-games/.env`.
+When omitted, the apps default to `window.location.origin` so the API can be
+served from the same host in production.
 
 The API server now persists data in Firebase. Provide service account credentials
 by setting `FIREBASE_SERVICE_ACCOUNT` to a JSON string or path, or use

--- a/learning-games/src/components/AnalyticsTracker.tsx
+++ b/learning-games/src/components/AnalyticsTracker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useContext } from 'react'
 import { useLocation } from 'react-router-dom'
 import { UserContext } from '../context/UserContext'
+import { getApiBase } from '../utils/api'
 
 function getCookie(name: string) {
   if (typeof document === 'undefined') return null
@@ -21,7 +22,7 @@ export default function AnalyticsTracker() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const base = window.location.origin
+    const base = getApiBase()
     let visitorId = getCookie('uid')
     if (!visitorId) {
       visitorId = Math.random().toString(36).slice(2)

--- a/learning-games/src/components/AnalyticsTrackerNext.tsx
+++ b/learning-games/src/components/AnalyticsTrackerNext.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useContext } from 'react'
 import { useRouter } from 'next/router'
 import { UserContext } from '../context/UserContext'
+import { getApiBase } from '../utils/api'
 
 function getCookie(name: string) {
   if (typeof document === 'undefined') return null
@@ -21,7 +22,7 @@ export default function AnalyticsTrackerNext() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const base = window.location.origin
+    const base = getApiBase()
     let visitorId = getCookie('uid')
     if (!visitorId) {
       visitorId = Math.random().toString(36).slice(2)

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -6,6 +6,7 @@ import Tooltip from '../ui/Tooltip'
 import { getTotalPoints } from '../../utils/user'
 import { GOAL_POINTS } from '../../constants/progress'
 import type { PointsEntry } from '../../pages/LeaderboardPage'
+import { getApiBase } from '../../utils/api'
 
 export interface ProgressSidebarProps {
   points?: Record<string, number>
@@ -35,7 +36,7 @@ export default function ProgressSidebar({ badges }: ProgressSidebarProps = {}) {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/scores`)
         .then((res) => (res.ok ? res.json() : {}))
 

--- a/learning-games/src/context/UserProvider.tsx
+++ b/learning-games/src/context/UserProvider.tsx
@@ -3,6 +3,7 @@ import { toast } from 'react-hot-toast'
 import type { ReactNode } from 'react'
 import type { UserData } from '../types/user'
 import { UserContext, defaultUser } from './UserContext'
+import { getApiBase } from '../utils/api'
 
 // All progress is stored under this key in localStorage so it persists across
 // sessions. Whenever the user object changes we throttle a save to this key.
@@ -28,7 +29,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
   // Load any saved data from the server and merge it with local storage
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/user`)
         .then((res) => (res.ok ? res.json() : null))
         .then((data) => {
@@ -70,7 +71,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         }
       })
       if (typeof window !== 'undefined') {
-        const base = window.location.origin
+        const base = getApiBase()
         fetch(`${base}/api/scores/${game}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -98,7 +99,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
     const handle = setTimeout(() => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
       if (typeof window !== 'undefined') {
-        const base = window.location.origin
+        const base = getApiBase()
         fetch(`${base}/api/user`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import Post from '../components/Post'
 import type { PostData } from '../components/Post'
 import { UserContext } from '../context/UserContext'
+import { getApiBase } from '../utils/api'
 
 const STORAGE_KEY = 'community_posts'
 const MAX_POSTS = 20
@@ -39,7 +40,7 @@ export default function CommunityPage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/posts`)
         .then((res) => (res.ok ? res.json() : []))
         .then((data: PostData[]) =>
@@ -60,7 +61,7 @@ export default function CommunityPage() {
   function flagPost(id: number) {
     setPosts((prev) => prev.map((p) => (p.id === id ? { ...p, flagged: true } : p)))
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' })
         .catch(() => {
           setError('Failed to flag post')
@@ -84,7 +85,7 @@ export default function CommunityPage() {
       }
       setPosts((prev) => prunePosts([...prev, newPost]))
       if (typeof window !== 'undefined') {
-        const base = window.location.origin
+        const base = getApiBase()
         fetch(`${base}/api/posts`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/learning-games/src/pages/CommunityPlaylistPage.tsx
+++ b/learning-games/src/pages/CommunityPlaylistPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { getApiBase } from '../utils/api'
 
 export interface PromptPair {
   id: number
@@ -26,7 +27,7 @@ export default function CommunityPlaylistPage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/pairs`)
         .then(res => (res.ok ? res.json() : []))
         .then((data: PromptPair[]) => data.length && setPairs(data))
@@ -44,7 +45,7 @@ export default function CommunityPlaylistPage() {
     const pair: PromptPair = { id: Date.now(), bad: bad.trim(), good: good.trim() }
     setPairs(prev => [...prev, pair])
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/pairs`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -4,6 +4,7 @@ import { toast } from 'react-hot-toast'
 import { UserContext } from '../context/UserContext'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import './LeaderboardPage.css'
+import { getApiBase } from '../utils/api'
 
 export interface PointsEntry {
   name: string
@@ -28,7 +29,7 @@ export default function LeaderboardPage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/scores`)
         .then(res => (res.ok ? res.json() : {}))
         .then(data => setPointsData(data))

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -8,6 +8,7 @@ import TimerBar from '../components/ui/TimerBar'
 import { UserContext } from '../context/UserContext'
 import shuffle from '../utils/shuffle'
 import { getTimeLimit } from '../utils/time'
+import { getApiBase } from '../utils/api'
 import './PromptDartsGame.css'
 import {
   type DartRound,
@@ -86,7 +87,7 @@ export default function PromptDartsGame() {
       setRounds(shuffle(ROUNDS))
       return
     }
-    const base = window.location.origin
+    const base = getApiBase()
     fetch(`${base}/api/darts`)
       .then(res => (res.ok ? res.json() : null))
       .then(data => {

--- a/learning-games/src/pages/StatsPage.tsx
+++ b/learning-games/src/pages/StatsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { getApiBase } from '../utils/api'
 
 interface ViewData {
   id: number
@@ -18,7 +19,7 @@ export default function StatsPage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/views`)
         .then(res => (res.ok ? res.json() : []))
         .then(data => setViews(Array.isArray(data) ? data : []))

--- a/learning-games/src/utils/api.ts
+++ b/learning-games/src/utils/api.ts
@@ -1,0 +1,5 @@
+export function getApiBase() {
+  if (import.meta.env.VITE_API_BASE) return import.meta.env.VITE_API_BASE
+  if (typeof window !== 'undefined') return window.location.origin
+  return ''
+}

--- a/nextjs-app/src/components/AnalyticsTracker.tsx
+++ b/nextjs-app/src/components/AnalyticsTracker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useContext } from 'react'
 import { usePathname } from 'next/navigation'
 import { UserContext } from '../context/UserContext'
+import { getApiBase } from '../utils/api'
 
 function getCookie(name: string) {
   if (typeof document === 'undefined') return null
@@ -21,7 +22,7 @@ export default function AnalyticsTracker() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const base = window.location.origin
+    const base = getApiBase()
     let visitorId = getCookie('uid')
     if (!visitorId) {
       visitorId = Math.random().toString(36).slice(2)

--- a/nextjs-app/src/components/layout/ProgressSidebar.tsx
+++ b/nextjs-app/src/components/layout/ProgressSidebar.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react'
+import { getApiBase } from '../../utils/api'
 import confetti from 'canvas-confetti'
 import Link from 'next/link'
 import { UserContext } from '../../context/UserContext'
@@ -32,7 +33,7 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/scores`)
         .then((res) => (res.ok ? res.json() : {}))
 

--- a/nextjs-app/src/context/UserProvider.tsx
+++ b/nextjs-app/src/context/UserProvider.tsx
@@ -3,6 +3,7 @@ import { toast } from 'react-hot-toast'
 import type { ReactNode } from 'react'
 import type { UserData } from '../types/user'
 import { UserContext, defaultUser } from './UserContext'
+import { getApiBase } from '../utils/api'
 
 // All progress is stored under this key in localStorage so it persists across
 // sessions. Whenever the user object changes we throttle a save to this key.
@@ -27,7 +28,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
   // Load any saved data from the server and merge it with local storage
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/user`)
         .then((res) => (res.ok ? res.json() : null))
         .then((data) => {
@@ -69,7 +70,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         }
       })
       if (typeof window !== 'undefined') {
-        const base = window.location.origin
+        const base = getApiBase()
         fetch(`${base}/api/scores/${game}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -97,7 +98,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
     const handle = setTimeout(() => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
       if (typeof window !== 'undefined') {
-        const base = window.location.origin
+        const base = getApiBase()
         fetch(`${base}/api/user`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -5,6 +5,7 @@ import Post from '../components/Post'
 import type { PostData } from '../components/Post'
 import { UserContext } from '../context/UserContext'
 import styles from '../styles/CommunityPage.module.css'
+import { getApiBase } from '../utils/api'
 
 const STORAGE_KEY = 'community_posts'
 
@@ -36,15 +37,6 @@ export default function CommunityPage() {
   const [error, setError] = useState('')
   const [notice, setNotice] = useState('')
 
-  function getApiBase() {
-    if (process.env.NEXT_PUBLIC_API_BASE) {
-      return process.env.NEXT_PUBLIC_API_BASE
-    }
-    if (typeof window !== 'undefined') {
-      return window.location.origin
-    }
-    return ''
-  }
 
   useEffect(() => {
     if (typeof window !== 'undefined') {

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -12,6 +12,7 @@ import '../../styles/PromptDartsGame.css'
 import HeadTag from 'next/head'
 import JsonLd from '../../components/seo/JsonLd'
 import CompletionModal from '../../components/ui/CompletionModal'
+import { getApiBase } from '../../utils/api'
 
 const CONGRATS_VIDEO_URL = 'https://www.youtube.com/embed/dQw4w9WgXcQ'
 
@@ -314,7 +315,7 @@ export default function PromptDartsGame() {
       setRounds(shuffle(ROUNDS))
       return
     }
-    const base = window.location.origin
+    const base = getApiBase()
     fetch(`${base}/api/darts`)
       .then(res => (res.ok ? res.json() : null))
       .then(data => {

--- a/nextjs-app/src/pages/leaderboard.tsx
+++ b/nextjs-app/src/pages/leaderboard.tsx
@@ -4,6 +4,7 @@ import { toast } from 'react-hot-toast'
 import { UserContext } from '../context/UserContext'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import '../styles/LeaderboardPage.css'
+import { getApiBase } from '../utils/api'
 
 export interface PointsEntry {
   name: string
@@ -28,7 +29,7 @@ export default function LeaderboardPage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/scores`)
         .then(res => (res.ok ? res.json() : {}))
         .then(data => setPointsData(data))

--- a/nextjs-app/src/pages/playlist.tsx
+++ b/nextjs-app/src/pages/playlist.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { getApiBase } from '../utils/api'
 
 export interface PromptPair {
   id: number
@@ -26,7 +27,7 @@ export default function CommunityPlaylistPage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/pairs`)
         .then(res => (res.ok ? res.json() : []))
         .then((data: PromptPair[]) => data.length && setPairs(data))
@@ -44,7 +45,7 @@ export default function CommunityPlaylistPage() {
     const pair: PromptPair = { id: Date.now(), bad: bad.trim(), good: good.trim() }
     setPairs(prev => [...prev, pair])
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/pairs`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -5,6 +5,7 @@ import { UserContext } from '../context/UserContext'
 import ThemeToggle from '../components/layout/ThemeToggle'
 import type { PointsEntry } from './leaderboard'
 import { getTotalPoints } from '../utils/user'
+import { getApiBase } from '../utils/api'
 
 
 import '../styles/ProfilePage.css'
@@ -18,7 +19,7 @@ export default function ProfilePage() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const base = window.location.origin
+      const base = getApiBase()
       fetch(`${base}/api/scores`)
         .then(res => (res.ok ? res.json() : {}))
         .then(data => setScores(data))

--- a/nextjs-app/src/pages/stats.tsx
+++ b/nextjs-app/src/pages/stats.tsx
@@ -1,6 +1,7 @@
 import useSWR from 'swr'
 import Link from 'next/link'
 import Spinner from '../components/ui/Spinner'
+import { getApiBase } from '../utils/api'
 
 interface ViewData {
   id: number
@@ -16,7 +17,7 @@ interface ViewData {
 
 export default function StatsPage() {
 
-  const base = typeof window !== 'undefined' ? window.location.origin : ''
+  const base = getApiBase()
   const fetcher = (url: string) => fetch(url).then(res => res.json())
   const { data: views = [] } = useSWR<ViewData[]>(
     base ? `${base}/api/views` : null,

--- a/nextjs-app/src/utils/api.ts
+++ b/nextjs-app/src/utils/api.ts
@@ -1,0 +1,5 @@
+export function getApiBase() {
+  if (process.env.NEXT_PUBLIC_API_BASE) return process.env.NEXT_PUBLIC_API_BASE
+  if (typeof window !== 'undefined') return window.location.origin
+  return ''
+}


### PR DESCRIPTION
## Summary
- add `getApiBase` helpers for Next.js and Vite apps
- import the helpers into all API calls
- document `VITE_API_BASE` usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in nextjs-app *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847088882cc832fa836bf2ef8e18bc4