### PR TITLE
Remove local env config

### DIFF
--- a/learning-games/.gitignore
+++ b/learning-games/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .next
+# env files
+.env*
+!.env.example


### PR DESCRIPTION
## Summary
- stop tracking `learning-games/.env`
- ignore `.env` in the Vite app so Vercel uses the default API base

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684715d58fb0832f80bb8dcd3d399d4d