### PR TITLE
Implement prompt library API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
 - A unified leaderboard with tabs displays top points for every game.
 - A dedicated Badges page lets you track all achievements.
 - A hidden `/stats` page displays live visitor analytics collected on the server.
-- A prompt library lets everyone browse shared prompts by category.
+- A prompt library lets everyone browse shared prompts by category and submit their own ideas.
 - A community feedback page highlights positive comments from players.
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- allow browsing and submitting prompts
- implement Express endpoints for prompts
- add form on Prompt Library page
- document contributions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472848366c832f8aacf4676d35af76