### PR TITLE
Handle missing Firebase credentials

### DIFF
--- a/server/firebase.js
+++ b/server/firebase.js
@@ -1,6 +1,7 @@
 const admin = require('firebase-admin');
 const path = require('path');
 
+let firestore = null;
 let serviceAccount;
 const envCred = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.GOOGLE_APPLICATION_CREDENTIALS;
 if (envCred) {
@@ -16,8 +17,20 @@ if (envCred) {
   }
 }
 
-if (!admin.apps.length) {
-  admin.initializeApp(serviceAccount ? { credential: admin.credential.cert(serviceAccount) } : {});
+try {
+  if (!admin.apps.length) {
+    if (serviceAccount) {
+      admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+    } else {
+      console.warn('Firebase credentials not supplied; Firestore disabled.');
+      module.exports = null;
+      return;
+    }
+  }
+  firestore = admin.firestore();
+} catch (err) {
+  console.error('Failed to initialize Firebase', err);
+  firestore = null;
 }
 
-module.exports = admin.firestore();
+module.exports = firestore;


### PR DESCRIPTION
## Summary
- add warning for missing credentials in `server/firebase.js`
- return `null` when initialization fails
- gate Firestore routes behind a check in `server/index.js`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472bfb9cd0832fadb033d2e1a6b2f2