### PR TITLE
Update Next.js env instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
   keys. `VITE_API_BASE` defaults to `http://localhost:3001` and the Vite dev
   server proxies `/api` requests there automatically. Provide
   `VITE_OPENAI_API_KEY=<your key>` for the Robot chat and recipe features.
-4. Open the printed URL in your browser.
+4. Copy `.env.example` to `.env` in `nextjs-app` and set `NEXT_PUBLIC_API_BASE`,
+  `NEXT_PUBLIC_OPENAI_API_KEY`, `OPENAI_API_KEY` and the Firebase credentials.
+  Leaving these blank causes 500 errors from the API routes. See
+  [`server/.env.example`](server/.env.example) for reference.
+5. Open the printed URL in your browser.
 
 Node **18+** is recommended. Major dependencies include React 19, React Router 7, Vite 6 and TypeScript. Toast notifications are provided by `react-hot-toast` and unit tests use `vitest`.
 


### PR DESCRIPTION
## Summary
- mention copying `.env.example` for Next.js in Getting Started
- highlight the required variables and link to server example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68472dde9f7c832fabbd7a0333231d42