### PR TITLE
Fix lints in Prompt pages

### DIFF
--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -92,12 +92,21 @@ export default function PromptDartsGame() {
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
         if (Array.isArray(data) && data.length) {
-          const fetched = data.map((r: DartRound) => ({
-            options: r.options ?? [(r as any).bad, (r as any).good].filter(Boolean),
-            correct: typeof (r as any).correct === 'number' ? (r as any).correct : 1,
-            why: (r as any).why ?? '',
-            response: (r as any).response ?? ''
-          })) as DartRound[]
+          interface RemoteRound {
+            options?: string[]
+            bad?: string
+            good?: string
+            correct?: number
+            why?: string
+            response?: string
+          }
+
+          const fetched: DartRound[] = (data as RemoteRound[]).map(r => ({
+            options: r.options ?? [r.bad, r.good].filter(Boolean) as string[],
+            correct: typeof r.correct === 'number' ? r.correct : 1,
+            why: r.why ?? '',
+            response: r.response ?? ''
+          }))
           setRounds(shuffle(fetched))
         } else {
           setRounds(shuffle(ROUNDS))

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from 'react'
+import { useState, useEffect, useContext, useCallback } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import { motion } from 'framer-motion'
@@ -59,7 +59,7 @@ export default function PromptRecipeGame() {
   })
   const [example, setExample] = useState<string | null>(null)
 
-  async function startRound() {
+  const startRound = useCallback(async () => {
     const newCards = await generateCards()
     setRoundCards(newCards)
     setCards(shuffle([...newCards]))
@@ -76,7 +76,7 @@ export default function PromptRecipeGame() {
       Format: null,
       Constraints: null,
     })
-  }
+  }, [TOTAL_TIME])
 
   useEffect(() => {
     startRound()


### PR DESCRIPTION
## Summary
- eliminate `any` usage in Prompt Darts game by defining typed interface
- wrap `startRound` in `useCallback` in Prompt Recipe game

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473090b7bc832f91e517b7c014e627