### PR TITLE
Add hint for first CLUES entry

### DIFF
--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -28,6 +28,7 @@ const CLUES: Clue[] = [
     hints: [
       'The subject is humor suitable for children.',
       "The verb asks to 'tell' something funny.",
+      'The correct prompt is "Tell me a kid-friendly joke".',
     ],
   },
   {

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -26,6 +26,7 @@ const CLUES: Clue[] = [
     hints: [
       'The subject is humor suitable for children.',
       "The verb asks to 'tell' something funny.",
+      'The correct prompt is "Tell me a kid-friendly joke".',
     ],
   },
   {

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -32,6 +32,7 @@ const CLUES: Clue[] = [
     hints: [
       'The subject is humor suitable for children.',
       "The verb asks to 'tell' something funny.",
+      'The correct prompt is "Tell me a kid-friendly joke".',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- provide a direct hint for the first clue in all Escape Room pages

## Testing
- `npm test --silent` in `learning-games`

------
https://chatgpt.com/codex/tasks/task_e_684733d7c200832fbeb0c815994033f7