### PR TITLE
Fix recipe round logic

### DIFF
--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -80,7 +80,11 @@ export default function PromptRecipeGame() {
 
   useEffect(() => {
     startRound()
-  }, [startRound])
+  }, [round])
+
+  useEffect(() => {
+    setRound(0)
+  }, [])
 
   useEffect(() => {
     if (showPrompt) return
@@ -176,7 +180,6 @@ export default function PromptRecipeGame() {
   function nextRound() {
     if (round + 1 < TOTAL_ROUNDS) {
       setRound(r => r + 1)
-      startRound()
     } else {
       setFinished(true)
       setPoints('recipe', points)

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -233,6 +233,10 @@ export default function PromptRecipeGame() {
 
   useEffect(() => {
     startRound()
+  }, [round])
+
+  useEffect(() => {
+    setRound(0)
   }, [])
 
   useEffect(() => {
@@ -323,7 +327,6 @@ export default function PromptRecipeGame() {
   function nextRound() {
     if (round + 1 < TOTAL_ROUNDS) {
       setRound(r => r + 1)
-      startRound()
     } else {
       setFinished(true)
       setPoints('recipe', points)


### PR DESCRIPTION
## Summary
- regenerate cards only when advancing rounds
- start at round 0 automatically

## Testing
- `npm test` within `learning-games`
- `npm run lint` within `learning-games`
- `npm run lint` within `nextjs-app` *(fails: next not found until after installing deps; many lint warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_684733d87f84832f82bc39630b1ee5a6