### PR TITLE
Add shared leaderboard hook

### DIFF
--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -1,12 +1,11 @@
-import { useContext, useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import confetti from 'canvas-confetti'
 import { Link, useLocation } from 'react-router-dom'
 import { UserContext } from '../../../../shared/UserContext'
 import Tooltip from '../ui/Tooltip'
 import { getTotalPoints } from '../../utils/user'
 import { GOAL_POINTS } from '../../constants/progress'
-import type { PointsEntry } from '../../pages/LeaderboardPage'
-import { getApiBase } from '../../utils/api'
+import { useLeaderboards, type PointsEntry } from '../../../../shared/useLeaderboards'
 
 export interface ProgressSidebarProps {
   points?: Record<string, number>
@@ -25,7 +24,7 @@ export default function ProgressSidebar({ badges }: ProgressSidebarProps = {}) {
   const totalPoints = getTotalPoints(userScores)
 
   const celebrated = useRef(false)
-  const [leaderboards, setLeaderboards] = useState<Record<string, PointsEntry[]>>({})
+  const { data: leaderboards = {} } = useLeaderboards()
 
   useEffect(() => {
     if (totalPoints >= GOAL_POINTS && !celebrated.current) {
@@ -34,19 +33,6 @@ export default function ProgressSidebar({ badges }: ProgressSidebarProps = {}) {
     }
   }, [totalPoints])
 
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const base = getApiBase()
-      fetch(`${base}/api/scores`)
-        .then((res) => (res.ok ? res.json() : {}))
-
-        .then((data: Record<string, PointsEntry[]>) => {
-          setLeaderboards(data)
-
-        })
-        .catch(() => {})
-    }
-  }, [])
 
 
   const location = useLocation()

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -1,15 +1,10 @@
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { toast } from 'react-hot-toast'
 import { UserContext } from '../../../shared/UserContext'
+import { useLeaderboards, type PointsEntry } from '../../../shared/useLeaderboards'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import './LeaderboardPage.css'
-import { getApiBase } from '../utils/api'
-
-export interface PointsEntry {
-  name: string
-  points: number
-}
 
 
 export default function LeaderboardPage() {
@@ -19,7 +14,7 @@ export default function LeaderboardPage() {
   const [sortField, setSortField] = useState<'name' | 'points'>('points')
   const [ascending, setAscending] = useState(false)
 
-  const [pointsData, setPointsData] = useState<Record<string, PointsEntry[]>>({})
+  const { data: pointsData = {} } = useLeaderboards()
   const [game, setGame] = useState('tone')
   const tabs = useMemo(() => {
     const base = ['tone', 'quiz', 'darts', 'recipe', 'escape', 'compose']
@@ -27,15 +22,6 @@ export default function LeaderboardPage() {
     return Array.from(new Set([...base, ...dynamic]))
   }, [pointsData])
 
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const base = getApiBase()
-      fetch(`${base}/api/scores`)
-        .then(res => (res.ok ? res.json() : {}))
-        .then(data => setPointsData(data))
-        .catch(() => {})
-    }
-  }, [])
 
   const entries = useMemo(() => {
     const list = (pointsData[game] ?? []).slice()

--- a/nextjs-app/src/components/layout/ProgressSidebar.tsx
+++ b/nextjs-app/src/components/layout/ProgressSidebar.tsx
@@ -1,11 +1,10 @@
-import { useContext, useEffect, useRef, useState } from 'react'
-import { getApiBase } from '../../utils/api'
+import { useContext, useEffect, useRef } from 'react'
+import { useLeaderboards, type PointsEntry } from '../../../../shared/useLeaderboards'
 import confetti from 'canvas-confetti'
 import Link from 'next/link'
 import { UserContext } from '../../../../shared/UserContext'
 import { getTotalPoints } from '../../utils/user'
 import Tooltip from '../ui/Tooltip'
-import type { PointsEntry } from '../../pages/leaderboard'
 import { GOAL_POINTS } from '../../constants/progress'
 
 export interface ProgressSidebarProps {
@@ -22,7 +21,7 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
   const totalPoints = getTotalPoints(userPoints)
   const celebrated = useRef(false)
 
-  const [leaderboards, setLeaderboards] = useState<Record<string, PointsEntry[]>>({})
+  const { data: leaderboards = {} } = useLeaderboards()
 
   useEffect(() => {
     if (totalPoints >= GOAL_POINTS && !celebrated.current) {
@@ -30,20 +29,6 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
       celebrated.current = true
     }
   }, [totalPoints])
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const base = getApiBase()
-      fetch(`${base}/api/scores`)
-        .then((res) => (res.ok ? res.json() : {}))
-
-        .then((data: Record<string, PointsEntry[]>) => {
-          setLeaderboards(data)
-
-        })
-        .catch(() => {})
-    }
-  }, [])
 
 
   const path = typeof window !== 'undefined' ? window.location.pathname : ''

--- a/nextjs-app/src/pages/leaderboard.tsx
+++ b/nextjs-app/src/pages/leaderboard.tsx
@@ -1,15 +1,11 @@
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { toast } from 'react-hot-toast'
 import { UserContext } from '../../../shared/UserContext'
+import { useLeaderboards, type PointsEntry } from '../../../shared/useLeaderboards'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import '../styles/LeaderboardPage.css'
-import { getApiBase } from '../utils/api'
 
-export interface PointsEntry {
-  name: string
-  points: number
-}
 
 
 export default function LeaderboardPage() {
@@ -19,23 +15,13 @@ export default function LeaderboardPage() {
   const [sortField, setSortField] = useState<'name' | 'points'>('points')
   const [ascending, setAscending] = useState(false)
 
-  const [pointsData, setPointsData] = useState<Record<string, PointsEntry[]>>({})
+  const { data: pointsData = {}, loading, error } = useLeaderboards()
   const [game, setGame] = useState('tone')
   const tabs = useMemo(() => {
     const base = ['tone', 'quiz', 'darts', 'recipe', 'escape', 'compose']
     const dynamic = Object.keys(pointsData)
     return Array.from(new Set([...base, ...dynamic]))
   }, [pointsData])
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const base = getApiBase()
-      fetch(`${base}/api/scores`)
-        .then(res => (res.ok ? res.json() : {}))
-        .then(data => setPointsData(data))
-        .catch(() => {})
-    }
-  }, [])
 
   const entries = useMemo(() => {
     const list = (pointsData[game] ?? []).slice()

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -1,11 +1,10 @@
-import { useContext, useState, useEffect, useMemo } from 'react'
+import { useContext, useState, useMemo } from 'react'
 import Link from 'next/link'
 import { toast } from 'react-hot-toast'
 import { UserContext } from '../../../shared/UserContext'
 import ThemeToggle from '../components/layout/ThemeToggle'
-import type { PointsEntry } from './leaderboard'
+import { useLeaderboards, type PointsEntry } from '../../../shared/useLeaderboards'
 import { getTotalPoints } from '../utils/user'
-import { getApiBase } from '../utils/api'
 
 
 import '../styles/ProfilePage.css'
@@ -15,17 +14,7 @@ export default function ProfilePage() {
   const [name, setNameState] = useState(user.name ?? '')
   const [age, setAgeState] = useState<string>(user.age ? String(user.age) : '')
   const [difficulty, setDifficultyState] = useState(user.difficulty)
-  const [scores, setScores] = useState<Record<string, PointsEntry[]>>({})
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const base = getApiBase()
-      fetch(`${base}/api/scores`)
-        .then(res => (res.ok ? res.json() : {}))
-        .then(data => setScores(data))
-        .catch(() => {})
-    }
-  }, [])
+  const { data: scores = {} } = useLeaderboards()
 
   const totalPoints = useMemo(() => getTotalPoints(user.points), [user.points])
 

--- a/shared/useLeaderboards.ts
+++ b/shared/useLeaderboards.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+
+export interface PointsEntry {
+  name: string
+  points: number
+}
+
+export type LeaderboardData = Record<string, PointsEntry[]>
+
+function getApiBase(): string {
+  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
+    return process.env.NEXT_PUBLIC_API_BASE
+  }
+  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
+    return (import.meta as any).env.VITE_API_BASE as string
+  }
+  if (typeof window !== 'undefined') {
+    return window.location.origin
+  }
+  return ''
+}
+
+let cachedData: LeaderboardData | null = null
+let fetchPromise: Promise<LeaderboardData> | null = null
+
+export function useLeaderboards() {
+  const [data, setData] = useState<LeaderboardData | null>(cachedData)
+  const [loading, setLoading] = useState(!cachedData)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (cachedData) return
+
+    if (!fetchPromise) {
+      const base = getApiBase()
+      fetchPromise = fetch(`${base}/api/scores`)
+        .then(res => {
+          if (!res.ok) throw new Error('Failed to fetch scores')
+          return res.json()
+        })
+        .then(json => {
+          cachedData = json
+          return json
+        })
+    }
+
+    fetchPromise
+      .then(json => setData(json))
+      .catch(err => setError(err))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return { data, loading, error }
+}


### PR DESCRIPTION
## Summary
- create `useLeaderboards` hook in shared folder
- use hook in leaderboard page and sidebar
- update profile page to consume cached scores
- apply same changes for learning-games

## Testing
- `npm test` within `server` *(fails: Cannot find module 'supertest')*
- `npm test` within `learning-games` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684738885824832fb77a4640aea42025