### PR TITLE
Add progress endpoint and integrate client

### DIFF
--- a/learning-games/src/components/ProgressSummary.tsx
+++ b/learning-games/src/components/ProgressSummary.tsx
@@ -1,17 +1,36 @@
+import { useEffect, useState } from 'react'
+import { getApiBase } from '../utils/api'
+
 interface ProgressSummaryProps {
-  totalPoints: number
-  badges: string[]
+  totalPoints?: number
+  badges?: string[]
   goalPoints: number
 }
 
 export default function ProgressSummary({ totalPoints, badges, goalPoints }: ProgressSummaryProps) {
+  const [progress, setProgress] = useState({ totalPoints: totalPoints ?? 0, badges: badges ?? [] as string[] })
+
+  useEffect(() => {
+    if (totalPoints !== undefined && badges !== undefined) return
+    if (typeof window !== 'undefined') {
+      const base = getApiBase()
+      fetch(`${base}/api/progress`)
+        .then(res => (res.ok ? res.json() : null))
+        .then(data => { if (data) setProgress(data) })
+        .catch(() => {})
+    }
+  }, [totalPoints, badges])
+
+  const pts = totalPoints ?? progress.totalPoints
+  const earned = badges ?? progress.badges
+
   return (
     <div className="progress-summary">
-      <p>Total Points: {totalPoints}</p>
-      <progress value={totalPoints} max={goalPoints} />
-      <p>Badges Earned: {badges.length}</p>
+      <p>Total Points: {pts}</p>
+      <progress value={pts} max={goalPoints} />
+      <p>Badges Earned: {earned.length}</p>
       <div className="badge-icons">
-        {badges.map((b) => (
+        {earned.map((b) => (
           <span key={b}>🏅</span>
         ))}
       </div>

--- a/learning-games/src/components/layout/ProgressSidebar.tsx
+++ b/learning-games/src/components/layout/ProgressSidebar.tsx
@@ -17,12 +17,12 @@ export default function ProgressSidebar({ badges }: ProgressSidebarProps = {}) {
   const { user } = useContext(UserContext)
 
   const userScores = user.points
-  const userBadges = badges ?? user.badges
-
-
-
-
-  const totalPoints = getTotalPoints(userScores)
+  const [progress, setProgress] = useState({
+    totalPoints: getTotalPoints(userScores),
+    badges: badges ?? user.badges,
+  })
+  const userBadges = progress.badges
+  const totalPoints = progress.totalPoints
 
   const celebrated = useRef(false)
   const [leaderboards, setLeaderboards] = useState<Record<string, PointsEntry[]>>({})
@@ -33,6 +33,18 @@ export default function ProgressSidebar({ badges }: ProgressSidebarProps = {}) {
       celebrated.current = true
     }
   }, [totalPoints])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const base = getApiBase()
+      fetch(`${base}/api/progress`)
+        .then(res => (res.ok ? res.json() : null))
+        .then(data => {
+          if (data) setProgress(data)
+        })
+        .catch(() => {})
+    }
+  }, [])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {

--- a/nextjs-app/src/components/ProgressSummary.tsx
+++ b/nextjs-app/src/components/ProgressSummary.tsx
@@ -1,19 +1,38 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { getApiBase } from '../utils/api'
 
 interface ProgressSummaryProps {
-  totalPoints: number
-  badges: string[]
+  totalPoints?: number
+  badges?: string[]
   goalPoints: number
 }
 
 export default function ProgressSummary({ totalPoints, badges, goalPoints }: ProgressSummaryProps) {
+  const [progress, setProgress] = useState({ totalPoints: totalPoints ?? 0, badges: badges ?? [] as string[] })
+
+  useEffect(() => {
+    if (totalPoints !== undefined && badges !== undefined) return
+    if (typeof window !== 'undefined') {
+      const base = getApiBase()
+      fetch(`${base}/api/progress`)
+        .then(res => (res.ok ? res.json() : null))
+        .then(data => {
+          if (data) setProgress(data)
+        })
+        .catch(() => {})
+    }
+  }, [totalPoints, badges])
+
+  const pts = totalPoints ?? progress.totalPoints
+  const earned = badges ?? progress.badges
+
   return (
     <div className="progress-summary">
-      <p>Total Points: {totalPoints}</p>
-      <progress value={totalPoints} max={goalPoints} />
-      <p>Badges Earned: {badges.length}</p>
+      <p>Total Points: {pts}</p>
+      <progress value={pts} max={goalPoints} />
+      <p>Badges Earned: {earned.length}</p>
       <div className="badge-icons">
-        {badges.map((b) => (
+        {earned.map((b) => (
           <span key={b}>🏅</span>
         ))}
       </div>

--- a/nextjs-app/src/components/layout/ProgressSidebar.tsx
+++ b/nextjs-app/src/components/layout/ProgressSidebar.tsx
@@ -17,9 +17,12 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
   const { user } = useContext(UserContext)
 
   const userPoints = points ?? user.points
-  const userBadges = badges ?? user.badges
-
-  const totalPoints = getTotalPoints(userPoints)
+  const [progress, setProgress] = useState({
+    totalPoints: getTotalPoints(userPoints),
+    badges: badges ?? user.badges,
+  })
+  const userBadges = progress.badges
+  const totalPoints = progress.totalPoints
   const celebrated = useRef(false)
 
   const [leaderboards, setLeaderboards] = useState<Record<string, PointsEntry[]>>({})
@@ -30,6 +33,18 @@ export default function ProgressSidebar({ points, badges }: ProgressSidebarProps
       celebrated.current = true
     }
   }, [totalPoints])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const base = getApiBase()
+      fetch(`${base}/api/progress`)
+        .then(res => (res.ok ? res.json() : null))
+        .then(data => {
+          if (data) setProgress(data)
+        })
+        .catch(() => {})
+    }
+  }, [])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {

--- a/server/index.js
+++ b/server/index.js
@@ -226,6 +226,17 @@ app.post('/api/user', async (req, res) => {
   res.json(user);
 });
 
+app.get('/api/progress', async (req, res) => {
+  if (!ensureFirestore(res)) return;
+  const snap = await userDoc.get();
+  const data = snap.exists ? snap.data() : { points: {}, badges: [] };
+  const totalPoints = Object.values(data.points || {}).reduce(
+    (a, b) => a + b,
+    0,
+  );
+  res.json({ totalPoints, badges: data.badges || [] });
+});
+
 app.get('/api/posts', async (req, res) => {
   if (!ensureFirestore(res)) return;
   const snap = await posts.where('status', '==', 'approved').get();


### PR DESCRIPTION
## Summary
- create `/api/progress` route on the server that returns total points and badges
- load progress from the new route in `ProgressSidebar` and `ProgressSummary`

## Testing
- `npm test` in `server`
- `npm test` in `learning-games` *(fails: Failed to resolve import "react-hot-toast" from `UserProvider.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_6847388c35d8832fafc0ee05c88ea404