### PR TITLE
Fix API base helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ publishing.
 To point either frontend at a custom server URL set `NEXT_PUBLIC_API_BASE`
 in `nextjs-app/.env` or `VITE_API_BASE` in `learning-games/.env`. These must
 be the backend URL when the frontend and API run on different hosts. If these
-variables are omitted each app falls back to `window.location.origin`, which only
-works when the API is served from the same host.
+variables are omitted each app makes relative requests to `/api/...`, which only
+works when the API is served from the same host or proxied.
 Sample `.env.example` files in each app illustrate this configuration.
 
 

--- a/learning-games/src/shared/UserProvider.tsx
+++ b/learning-games/src/shared/UserProvider.tsx
@@ -11,9 +11,6 @@ function getApiBase() {
   if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
     return (import.meta as any).env.VITE_API_BASE as string
   }
-  if (typeof window !== 'undefined') {
-    return window.location.origin
-  }
   return ''
 }
 

--- a/learning-games/src/shared/useLeaderboards.ts
+++ b/learning-games/src/shared/useLeaderboards.ts
@@ -15,9 +15,6 @@ function getApiBase(): string {
   if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
     return (import.meta as any).env.VITE_API_BASE as string
   }
-  if (typeof window !== 'undefined') {
-    return window.location.origin
-  }
   return ''
 }
 

--- a/learning-games/src/utils/api.ts
+++ b/learning-games/src/utils/api.ts
@@ -1,5 +1,4 @@
 export function getApiBase() {
   if (import.meta.env.VITE_API_BASE) return import.meta.env.VITE_API_BASE
-  if (typeof window !== 'undefined') return window.location.origin
   return ''
 }

--- a/nextjs-app/src/utils/api.ts
+++ b/nextjs-app/src/utils/api.ts
@@ -1,5 +1,4 @@
 export function getApiBase() {
   if (process.env.NEXT_PUBLIC_API_BASE) return process.env.NEXT_PUBLIC_API_BASE
-  if (typeof window !== 'undefined') return window.location.origin
   return ''
 }

--- a/shared/UserProvider.tsx
+++ b/shared/UserProvider.tsx
@@ -11,9 +11,6 @@ function getApiBase() {
   if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
     return (import.meta as any).env.VITE_API_BASE as string
   }
-  if (typeof window !== 'undefined') {
-    return window.location.origin
-  }
   return ''
 }
 

--- a/shared/useLeaderboards.ts
+++ b/shared/useLeaderboards.ts
@@ -14,9 +14,6 @@ function getApiBase(): string {
   if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
     return (import.meta as any).env.VITE_API_BASE as string
   }
-  if (typeof window !== 'undefined') {
-    return window.location.origin
-  }
   return ''
 }
 


### PR DESCRIPTION
## Summary
- return an empty string when no API base is configured
- document relative `/api` requests when no base is provided

## Testing
- `npm test` in `server`
- `npm test` in `learning-games`
- `npm run lint` in `nextjs-app` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476c064750832fadc883bc5be05adc