### PR TITLE
Remove react-hot-toast

### DIFF
--- a/learning-games/package-lock.json
+++ b/learning-games/package-lock.json
@@ -13,7 +13,6 @@
         "next": "15.2.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-hot-toast": "^2.5.2",
         "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
@@ -2532,6 +2531,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3429,15 +3429,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/goober": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -4134,23 +4125,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-hot-toast": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
-      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/learning-games/package.json
+++ b/learning-games/package.json
@@ -20,7 +20,6 @@
     "next": "15.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-hot-toast": "^2.5.2",
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {

--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -21,7 +21,6 @@ import TermsPage from './pages/TermsPage'
 import ContactPage from './pages/ContactPage'
 import StatsPage from './pages/StatsPage'
 import BadgesPage from './pages/BadgesPage'
-import { Toaster } from 'react-hot-toast'
 import NavBar from './components/layout/NavBar'
 import Footer from './components/layout/Footer'
 import AnalyticsTracker from './components/AnalyticsTracker'
@@ -60,11 +59,6 @@ function App() {
         <Route path="/stats" element={<StatsPage />} />
       </Routes>
       {/* Verification comment: routes render correctly with context */}
-      <Toaster
-        toastOptions={{
-          ariaProps: { role: 'status', 'aria-live': 'polite' },
-        }}
-      />
       <Footer />
     </Router>
   )

--- a/learning-games/src/components/RobotChat.tsx
+++ b/learning-games/src/components/RobotChat.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -46,7 +46,7 @@ export default function RobotChat() {
       }
     } catch (err) {
       console.error(err)
-      toast.error('Unable to reach the API. Check your network or .env key.')
+      notify('Unable to reach the API. Check your network or .env key.')
       setMessages(prev => [
         ...prev,
         { role: 'assistant', content: 'Failed to get response.' },

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useContext } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import InstructionBanner from '../components/ui/InstructionBanner'
@@ -177,7 +177,7 @@ export default function ClarityEscapeRoom() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
-        toast('Hint revealed \u2013 \u22122 points')
+        notify('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }

--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 import { Link } from 'react-router-dom'
 import Post from '../components/Post'
 import type { PostData } from '../components/Post'
@@ -49,7 +49,7 @@ export default function CommunityPage() {
         )
         .catch(() => {
           setError('Failed to load posts')
-          toast.error('Failed to load posts')
+          notify('Failed to load posts')
         })
     }
   }, [])
@@ -66,7 +66,7 @@ export default function CommunityPage() {
       fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' })
         .catch(() => {
           setError('Failed to flag post')
-          toast.error('Failed to flag post')
+          notify('Failed to flag post')
         })
     }
   }
@@ -93,7 +93,7 @@ export default function CommunityPage() {
           body: JSON.stringify(newPost),
         }).catch(() => {
           setError('Failed to post')
-          toast.error('Failed to post')
+          notify('Failed to post')
         })
       }
       setError('')

--- a/learning-games/src/pages/LeaderboardPage.tsx
+++ b/learning-games/src/pages/LeaderboardPage.tsx
@@ -1,6 +1,6 @@
 import { useContext, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 import { UserContext } from '../shared/UserContext'
 import type { UserContextType } from '../shared/types/user'
 import { useLeaderboards } from '../shared/useLeaderboards'
@@ -114,7 +114,7 @@ export default function LeaderboardPage() {
                   navigator.share({ text }).catch(() => {})
                 } else {
                   navigator.clipboard.writeText(text).catch(() => {})
-                  toast.success('Points copied to clipboard')
+                  notify('Points copied to clipboard')
                 }
               }}
             >

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState, useEffect } from "react";
-import { toast } from "react-hot-toast";
+import { notify } from "../shared/notify";
 import confetti from "canvas-confetti";
 
 import { useNavigate, Link } from "react-router-dom";
@@ -190,7 +190,7 @@ export default function Match3Game() {
     if (earned.length > 0) {
       confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
     }
-    toast.success(msg);
+    notify(msg);
     setShowComplete(true);
   }
 

--- a/learning-games/src/pages/ProfilePage.tsx
+++ b/learning-games/src/pages/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 import { UserContext } from '../shared/UserContext'
 import ThemeToggle from '../components/layout/ThemeToggle'
 import './ProfilePage.css'
@@ -15,17 +15,17 @@ export default function ProfilePage() {
     e.preventDefault()
     const ageNum = Number(age)
     if (!name.trim()) {
-      toast.error('Please enter your name')
+      notify('Please enter your name')
       return
     }
     if (!age || Number.isNaN(ageNum) || ageNum <= 0) {
-      toast.error('Age must be a valid number')
+      notify('Age must be a valid number')
       return
     }
     setName(name.trim())
     setAge(ageNum)
     setDifficulty(difficulty)
-    toast.success('Profile saved successfully!')
+    notify('Profile saved successfully!')
   }
 
   return (

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 import { useNavigate } from 'react-router-dom'
 import InstructionBanner from '../components/ui/InstructionBanner'
 import Tooltip from '../components/ui/Tooltip'
@@ -168,7 +168,7 @@ export default function PromptGuessEscape() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
-        toast('Hint revealed \u2013 \u22122 points')
+        notify('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import { motion } from 'framer-motion'
 import confetti from 'canvas-confetti'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import WhyCard from '../components/layout/WhyCard'
@@ -118,7 +118,7 @@ export default function PromptRecipeGame() {
   function dropSelected(slot: Slot) {
     if (!selectedCard) return
     if (selectedCard.type !== slot) {
-      toast.error('Try a different category.')
+      notify('Try a different category.')
       setSelectedCard(null)
       return
     }
@@ -243,7 +243,7 @@ export default function PromptRecipeGame() {
         addBadge('prompt-chef')
       }
     }
-    toast.success(`+${finalScore} points`)
+    notify(`+${finalScore} points`)
     setSubmitted(true)
     setShowPrompt(true)
   }
@@ -267,13 +267,13 @@ export default function PromptRecipeGame() {
       if (text) setExample(text.trim())
     } catch (err) {
       console.error(err)
-      toast.error('Unable to fetch example output.')
+      notify('Unable to fetch example output.')
     }
   }
 
   function copyPrompt() {
     navigator.clipboard.writeText(promptText).then(() => {
-      toast.success('Prompt copied!')
+      notify('Prompt copied!')
     })
   }
 

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useContext, useMemo } from 'react'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import WhyCard from '../components/layout/WhyCard'
 import { motion } from 'framer-motion'
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 import { Link, useNavigate } from 'react-router-dom'
 import CompletionModal from '../components/ui/CompletionModal'
 import { UserContext } from '../shared/UserContext'
@@ -98,7 +98,7 @@ function ChatBox() {
       }
     } catch (err) {
       console.error(err)
-      toast.error('Unable to reach the API. Check your network or .env key.')
+      notify('Unable to reach the API. Check your network or .env key.')
       setMessages(prev => [
         ...prev,
         { role: 'assistant', content: 'Failed to get response.' },
@@ -168,7 +168,7 @@ export default function QuizGame() {
       if (newScore === ROUNDS.length && !user.badges.includes('quiz-whiz')) {
         addBadge('quiz-whiz')
       }
-      toast.success(`You scored ${newScore} out of ${ROUNDS.length}`)
+      notify(`You scored ${newScore} out of ${ROUNDS.length}`)
       setFinished(true)
       return
     }

--- a/learning-games/src/pages/promptRecipeHelpers.ts
+++ b/learning-games/src/pages/promptRecipeHelpers.ts
@@ -1,4 +1,4 @@
-import { toast } from 'react-hot-toast'
+import { notify } from '../shared/notify'
 
 export type Slot = 'Action' | 'Context' | 'Format' | 'Constraints'
 
@@ -153,7 +153,7 @@ export async function generateCards(): Promise<Card[]> {
     }
   } catch (err) {
     console.error(err)
-    toast.error('Unable to fetch new cards. Using defaults.')
+    notify('Unable to fetch new cards. Using defaults.')
   }
   return ensureCardSet([])
 }

--- a/learning-games/src/shared/UserProvider.tsx
+++ b/learning-games/src/shared/UserProvider.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from './notify'
 import type { ReactNode } from 'react'
 import type { UserData } from './types/user'
 import { UserContext, defaultUser } from './UserContext'
@@ -69,7 +69,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         const prevBest = prev.points[game] ?? 0
         const nextBest = Math.max(points, prevBest)
         if (nextBest > prevBest) {
-          toast.success(`New high points in ${game}: ${nextBest}`)
+          notify(`New high points in ${game}: ${nextBest}`)
         }
         return {
           ...prev,
@@ -98,7 +98,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const addBadge = useCallback((badge: string) => {
     setUser(prev => {
       if (!prev.badges.includes(badge)) {
-        toast.success(`Badge unlocked: ${badge}`)
+        notify(`Badge unlocked: ${badge}`)
         return { ...prev, badges: [...prev.badges, badge] }
       }
       return prev

--- a/learning-games/src/shared/notify.ts
+++ b/learning-games/src/shared/notify.ts
@@ -1,0 +1,7 @@
+export function notify(message: string) {
+  if (typeof window !== 'undefined') {
+    alert(message);
+  } else {
+    console.log(message);
+  }
+}

--- a/nextjs-app/package-lock.json
+++ b/nextjs-app/package-lock.json
@@ -14,7 +14,6 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-hot-toast": "^2.5.2",
         "swr": "^2.3.3"
       },
       "devDependencies": {
@@ -2683,6 +2682,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4028,15 +4028,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/goober": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
       }
     },
     "node_modules/google-auth-library": {
@@ -5825,23 +5816,6 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
-      }
-    },
-    "node_modules/react-hot-toast": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
-      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -15,7 +15,6 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hot-toast": "^2.5.2",
     "swr": "^2.3.3"
   },
   "devDependencies": {

--- a/nextjs-app/src/components/RobotChat.tsx
+++ b/nextjs-app/src/components/RobotChat.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../shared/notify'
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -46,7 +46,7 @@ export default function RobotChat() {
       }
     } catch (err) {
       console.error(err)
-      toast.error('Unable to reach the API. Check your network or .env key.')
+      notify('Unable to reach the API. Check your network or .env key.')
       setMessages(prev => [
         ...prev,
         { role: 'assistant', content: 'Failed to get response.' },

--- a/nextjs-app/src/pages/_app.tsx
+++ b/nextjs-app/src/pages/_app.tsx
@@ -5,7 +5,6 @@ import NavBar from '../components/layout/NavBar'
 import Footer from '../components/layout/Footer'
 import AnalyticsTracker from '../components/AnalyticsTracker'
 import ScrollToTop from '../components/ScrollToTop'
-import { Toaster } from 'react-hot-toast'
 import '../styles/index.css'
 import '../styles/App.css'
 import '../app/globals.css'
@@ -23,7 +22,6 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         <NavBar />
         <AnalyticsTracker />
         <Component {...pageProps} />
-        <Toaster toastOptions={{ ariaProps: { role: 'status', 'aria-live': 'polite' } }} />
         <Footer />
       </UserProvider>
     </>

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../shared/notify'
 import Link from 'next/link'
 import Post from '../components/Post'
 import type { PostData } from '../components/Post'
@@ -46,7 +46,7 @@ export default function CommunityPage() {
         .then((data: PostData[]) => setPosts(data.length ? data : initialPosts))
         .catch(() => {
           setError('Failed to load posts')
-          toast.error('Failed to load posts')
+          notify('Failed to load posts')
         })
     }
   }, [])
@@ -62,7 +62,7 @@ export default function CommunityPage() {
       fetch(`${base}/api/posts/${id}/flag`, { method: 'POST' })
         .catch(() => {
           setError('Failed to flag post')
-          toast.error('Failed to flag post')
+          notify('Failed to flag post')
         })
     }
   }

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../../shared/notify'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import InstructionBanner from '../../components/ui/InstructionBanner'
@@ -165,7 +165,7 @@ export default function ClarityEscapeRoom() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
-        toast('Hint revealed \u2013 \u22122 points')
+        notify('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useContext, useCallback } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../../shared/notify'
 import { useRouter } from 'next/router'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import Tooltip from '../../components/ui/Tooltip'
@@ -174,7 +174,7 @@ export default function PromptGuessEscape() {
   const revealHint = useCallback(() => {
     setHintIndex(i => {
       if (i < clue.hints.length) {
-        toast('Hint revealed \u2013 \u22122 points')
+        notify('Hint revealed \u2013 \u22122 points')
         setHintCount(c => c + 1)
         return i + 1
       }

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useContext, useMemo } from 'react'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import WhyCard from '../../components/layout/WhyCard'
 import { motion } from 'framer-motion'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../../shared/notify'
 import Link from 'next/link'; import { useRouter } from 'next/router'
 import CompletionModal from '../../components/ui/CompletionModal'
 import HeadTag from 'next/head'
@@ -99,7 +99,7 @@ function ChatBox() {
       }
     } catch (err) {
       console.error(err)
-      toast.error('Unable to reach the API. Check your network or .env key.')
+      notify('Unable to reach the API. Check your network or .env key.')
       setMessages(prev => [
         ...prev,
         { role: 'assistant', content: 'Failed to get response.' },
@@ -169,7 +169,7 @@ export default function QuizGame() {
       if (newScore === ROUNDS.length && !user.badges.includes('quiz-whiz')) {
         addBadge('quiz-whiz')
       }
-      toast.success(`You scored ${newScore} out of ${ROUNDS.length}`)
+      notify(`You scored ${newScore} out of ${ROUNDS.length}`)
       setFinished(true)
       return
     }

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -4,7 +4,7 @@ import HeadTag from 'next/head'
 import { useRouter } from 'next/router'
 import { motion } from 'framer-motion'
 import confetti from 'canvas-confetti'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../../shared/notify'
 import JsonLd from '../../components/seo/JsonLd'
 
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
@@ -170,7 +170,7 @@ async function generateCards(): Promise<Card[]> {
     }
   } catch (err) {
     console.error(err)
-    toast.error('Unable to fetch new cards. Using defaults.')
+    notify('Unable to fetch new cards. Using defaults.')
   }
   return ensureCardSet([])
 }
@@ -265,7 +265,7 @@ export default function PromptRecipeGame() {
   function dropSelected(slot: Slot) {
     if (!selectedCard) return
     if (selectedCard.type !== slot) {
-      toast.error('Try a different category.')
+      notify('Try a different category.')
       setSelectedCard(null)
       return
     }
@@ -390,7 +390,7 @@ export default function PromptRecipeGame() {
         addBadge('prompt-chef')
       }
     }
-    toast.success(`+${finalScore} points`)
+    notify(`+${finalScore} points`)
     setSubmitted(true)
     setShowPrompt(true)
   }
@@ -414,13 +414,13 @@ export default function PromptRecipeGame() {
       if (text) setExample(text.trim())
     } catch (err) {
       console.error(err)
-      toast.error('Unable to fetch example output.')
+      notify('Unable to fetch example output.')
     }
   }
 
   function copyPrompt() {
     navigator.clipboard.writeText(promptText).then(() => {
-      toast.success('Prompt copied!')
+      notify('Prompt copied!')
     })
   }
 

--- a/nextjs-app/src/pages/games/tone.tsx
+++ b/nextjs-app/src/pages/games/tone.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState, useEffect } from "react";
-import { toast } from "react-hot-toast";
+import { notify } from "../../../../shared/notify";
 import confetti from "canvas-confetti";
 
 import Link from "next/link"; import { useRouter } from "next/router";
@@ -313,7 +313,7 @@ export default function Match3Game() {
     if (earned.length > 0) {
       confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
     }
-    toast.success(msg);
+    notify(msg);
     setShowComplete(true);
   }
 

--- a/nextjs-app/src/pages/leaderboard.tsx
+++ b/nextjs-app/src/pages/leaderboard.tsx
@@ -1,6 +1,6 @@
 import { useContext, useMemo, useState } from 'react'
 import Link from 'next/link'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../shared/notify'
 import { UserContext } from '../../../shared/UserContext'
 import { useLeaderboards, type PointsEntry } from '../../../shared/useLeaderboards'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
@@ -117,7 +117,7 @@ export default function LeaderboardPage() {
                   navigator.share({ text }).catch(() => {})
                 } else {
                   navigator.clipboard.writeText(text).catch(() => {})
-                  toast.success('Points copied to clipboard')
+                  notify('Points copied to clipboard')
                 }
               }}
             >

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState, useMemo } from 'react'
 import Link from 'next/link'
-import { toast } from 'react-hot-toast'
+import { notify } from '../../../shared/notify'
 import { UserContext } from '../../../shared/UserContext'
 import ThemeToggle from '../components/layout/ThemeToggle'
 import { useLeaderboards, type PointsEntry } from '../../../shared/useLeaderboards'
@@ -39,17 +39,17 @@ export default function ProfilePage() {
     e.preventDefault()
     const ageNum = Number(age)
     if (!name.trim()) {
-      toast.error('Please enter your name')
+      notify('Please enter your name')
       return
     }
     if (!age || Number.isNaN(ageNum) || ageNum <= 0) {
-      toast.error('Age must be a valid number')
+      notify('Age must be a valid number')
       return
     }
     setName(name.trim())
     setAge(ageNum)
     setDifficulty(difficulty)
-    toast.success('Profile saved successfully!')
+    notify('Profile saved successfully!')
   }
 
   return (

--- a/shared/UserProvider.tsx
+++ b/shared/UserProvider.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { toast } from 'react-hot-toast'
+import { notify } from './notify'
 import type { ReactNode } from 'react'
 import type { UserData } from './types/user'
 import { UserContext, defaultUser } from './UserContext'
@@ -69,7 +69,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         const prevBest = prev.points[game] ?? 0
         const nextBest = Math.max(points, prevBest)
         if (nextBest > prevBest) {
-          toast.success(`New high points in ${game}: ${nextBest}`)
+          notify(`New high points in ${game}: ${nextBest}`)
         }
         return {
           ...prev,
@@ -98,7 +98,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const addBadge = useCallback((badge: string) => {
     setUser(prev => {
       if (!prev.badges.includes(badge)) {
-        toast.success(`Badge unlocked: ${badge}`)
+        notify(`Badge unlocked: ${badge}`)
         return { ...prev, badges: [...prev.badges, badge] }
       }
       return prev

--- a/shared/notify.ts
+++ b/shared/notify.ts
@@ -1,0 +1,7 @@
+export function notify(message: string) {
+  if (typeof window !== 'undefined') {
+    alert(message);
+  } else {
+    console.log(message);
+  }
+}


### PR DESCRIPTION
## Summary
- drop `react-hot-toast` from dependencies
- replace toast notifications with simple alert wrapper
- update all pages and components to use `notify`
- keep build scripts working without toast

## Testing
- `npm run build` in `nextjs-app`
- `npm run build` in `learning-games`


------
https://chatgpt.com/codex/tasks/task_e_684817ca9978832f801b8181022d527f