### PR TITLE
Fix React module not found

### DIFF
--- a/nextjs-app/next.config.ts
+++ b/nextjs-app/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
   },
   webpack(config) {
     config.resolve.modules.push(path.resolve(__dirname, "../node_modules"));
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      react: path.resolve(__dirname, 'node_modules/react'),
+      'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),
+    };
     return config;
   },
   async rewrites() {

--- a/nextjs-app/tsconfig.json
+++ b/nextjs-app/tsconfig.json
@@ -8,18 +8,22 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
+    "types": ["react", "react-dom"],
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "react": ["./node_modules/react"],
+      "react-dom": ["./node_modules/react-dom"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- add webpack aliases for React modules
- configure tsconfig to resolve React types
- revert symlink tweak for `node_modules`

## Testing
- `npm test` in `learning-games`
- `npm test` in `server`
- `npm run build` in `nextjs-app` *(fails: Property 'user' does not exist on type 'unknown')*

------
https://chatgpt.com/codex/tasks/task_e_684820a23f9c832fbb1bc3f0345d9209