### PR TITLE
Fix firebase dynamic require warning

### DIFF
--- a/nextjs-app/src/utils/firebase.ts
+++ b/nextjs-app/src/utils/firebase.ts
@@ -1,5 +1,6 @@
 import admin from 'firebase-admin'
 import path from 'path'
+import fs from 'fs'
 
 let serviceAccount: any
 const envCred = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.GOOGLE_APPLICATION_CREDENTIALS
@@ -8,8 +9,11 @@ if (envCred) {
     if (envCred.trim().startsWith('{')) {
       serviceAccount = JSON.parse(envCred)
     } else {
-      const filePath = path.isAbsolute(envCred) ? envCred : path.join(process.cwd(), envCred)
-      serviceAccount = require(filePath)
+      const filePath = path.isAbsolute(envCred)
+        ? envCred
+        : path.join(process.cwd(), envCred)
+      const fileContent = fs.readFileSync(filePath, 'utf8')
+      serviceAccount = JSON.parse(fileContent)
     }
   } catch (err) {
     console.error('Failed to load Firebase credentials', err)


### PR DESCRIPTION
## Summary
- avoid dynamic `require` in `firebase.ts`

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684828afb1dc832fad50cd28939f0dc2