### PR TITLE
Fix AnalyticsTracker context type

### DIFF
--- a/nextjs-app/src/components/AnalyticsTracker.tsx
+++ b/nextjs-app/src/components/AnalyticsTracker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useContext } from 'react'
 import { usePathname } from 'next/navigation'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import { getApiBase } from '../utils/api'
 
 function getCookie(name: string) {
@@ -18,7 +19,7 @@ function setCookie(name: string, value: string, days: number) {
 
 export default function AnalyticsTracker() {
   const pathname = usePathname()
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
 
   useEffect(() => {
     if (typeof window === 'undefined') return


### PR DESCRIPTION
## Summary
- fix Typescript error in AnalyticsTracker by casting `useContext` result

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*
- `npm test` in `learning-games`
- `npm run build` in `learning-games`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68482d255554832f9f3568720d14c914