### PR TITLE
Fix user context typings

### DIFF
--- a/nextjs-app/src/components/AnalyticsTracker.tsx
+++ b/nextjs-app/src/components/AnalyticsTracker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useContext } from 'react'
 import { usePathname } from 'next/navigation'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import { getApiBase } from '../utils/api'
 
 function getCookie(name: string) {
@@ -18,7 +19,7 @@ function setCookie(name: string, value: string, days: number) {
 
 export default function AnalyticsTracker() {
   const pathname = usePathname()
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/nextjs-app/src/components/CourseOverview.tsx
+++ b/nextjs-app/src/components/CourseOverview.tsx
@@ -1,11 +1,12 @@
 import { useContext } from 'react'
 import Link from 'next/link'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import COURSES from '../data/courses'
 import Card from './ui/card'
 
 export default function CourseOverview() {
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
   return (
     <div className="course-grid">
       {COURSES.map((course) => {

--- a/nextjs-app/src/components/layout/ProgressSidebar.tsx
+++ b/nextjs-app/src/components/layout/ProgressSidebar.tsx
@@ -3,6 +3,7 @@ import { useLeaderboards, type PointsEntry } from '../../../../shared/useLeaderb
 import confetti from 'canvas-confetti'
 import Link from 'next/link'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import { getTotalPoints } from '../../utils/user'
 import Tooltip from '../ui/Tooltip'
 import { GOAL_POINTS } from '../../constants/progress'
@@ -13,7 +14,7 @@ export interface ProgressSidebarProps {
 }
 
 export default function ProgressSidebar({ points, badges }: ProgressSidebarProps = {}) {
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
 
   const userPoints = points ?? user.points
   const [progress, setProgress] = useState({

--- a/nextjs-app/src/pages/age.tsx
+++ b/nextjs-app/src/pages/age.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import Link from 'next/link'; import { useRouter } from 'next/router'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import '../styles/AgeInputForm.css'
 
 /**
@@ -15,7 +16,7 @@ export default function AgeInputForm({
   onSaved?: () => void
   allowEdit?: boolean
 }) {
-  const { user, setAge, setName, setDifficulty } = useContext(UserContext)
+  const { user, setAge, setName, setDifficulty } = useContext(UserContext) as UserContextType
   const [age, setAgeState] = useState<number | ''>(user.age ?? '')
   const [name, setNameState] = useState(user.name ?? '')
   const [difficulty, setDifficultyState] = useState(user.difficulty)

--- a/nextjs-app/src/pages/badges.tsx
+++ b/nextjs-app/src/pages/badges.tsx
@@ -1,12 +1,13 @@
 import { useContext, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import Spinner from '../components/ui/Spinner'
 import { getApiBase } from '../utils/api'
 import '../styles/BadgesPage.css'
 
 export default function BadgesPage() {
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
   interface BadgeDefinition {
     id: string
     name: string

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Post from '../components/Post'
 import type { PostData } from '../components/Post'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import styles from '../styles/CommunityPage.module.css'
 import { getApiBase } from '../utils/api'
 
@@ -21,7 +22,7 @@ const initialPosts: PostData[] = [
 ]
 
 export default function CommunityPage() {
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
   const [posts, setPosts] = useState<PostData[]>(() => {
     const saved = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
     if (saved) {

--- a/nextjs-app/src/pages/games/compose.tsx
+++ b/nextjs-app/src/pages/games/compose.tsx
@@ -8,6 +8,7 @@ import { scorePrompt } from '../../utils/scorePrompt'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import JsonLd from '../../components/seo/JsonLd'
 import '../../styles/ComposeTweetGame.css'
 import CompletionModal from '../../components/ui/CompletionModal'
@@ -36,7 +37,7 @@ const pairs: PromptPair[] = [
 ]
 
 export default function ComposeTweetGame() {
-  const { setPoints, addBadge, user } = useContext(UserContext)
+  const { setPoints, addBadge, user } = useContext(UserContext) as UserContextType
   const router = useRouter()
   const [guess, setGuess] = useState('')
   const [feedback, setFeedback] = useState('')

--- a/nextjs-app/src/pages/games/darts.tsx
+++ b/nextjs-app/src/pages/games/darts.tsx
@@ -6,6 +6,7 @@ import WhyCard from '../../components/layout/WhyCard'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import TimerBar from '../../components/ui/TimerBar'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import shuffle from '../../utils/shuffle'
 import { getTimeLimit } from '../../utils/time'
 import '../../styles/PromptDartsGame.css'
@@ -272,7 +273,7 @@ export function streakBonus(streak: number) {
 
 export default function PromptDartsGame() {
 
-  const { setPoints, user } = useContext(UserContext)
+  const { setPoints, user } = useContext(UserContext) as UserContextType
   const router = useRouter()
   const [rounds, setRounds] = useState<DartRound[]>([])
   const [round, setRound] = useState(0)

--- a/nextjs-app/src/pages/games/dragdrop.tsx
+++ b/nextjs-app/src/pages/games/dragdrop.tsx
@@ -4,6 +4,7 @@ import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import GamePageLayout from '../../components/layout/GamePageLayout'
 import WhyCard from '../../components/layout/WhyCard'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import '../../styles/DragDropGame.css'
 import JsonLd from '../../components/seo/JsonLd'
 
@@ -39,7 +40,7 @@ export default function DragDropGame() {
   const [quizAnswer, setQuizAnswer] = useState<Tone | null>(null)
   const [userMessage, setUserMessage] = useState('')
   const [submitted, setSubmitted] = useState(false)
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
 
   function handleDragStart(e: React.DragEvent<HTMLDivElement>, tone: Tone) {
     e.dataTransfer.setData('text/plain', tone)

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -11,6 +11,7 @@ import WhyCard from '../../components/layout/WhyCard'
 import Tooltip from '../../components/ui/Tooltip'
 import IntroOverlay from '../../components/ui/IntroOverlay'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import shuffle from '../../utils/shuffle'
 import '../../styles/ClarityEscapeRoom.css'
 import CompletionModal from '../../components/ui/CompletionModal'
@@ -114,7 +115,7 @@ const TOTAL_STEPS = 4
 
 export default function ClarityEscapeRoom() {
   const navigate = useRouter()
-  const { setPoints: recordScore } = useContext(UserContext)
+  const { setPoints: recordScore } = useContext(UserContext) as UserContextType
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -9,6 +9,7 @@ import DoorUnlockedModal from '../../components/ui/DoorUnlockedModal'
 import ProgressSidebar from '../../components/layout/ProgressSidebar'
 import WhyCard from '../../components/layout/WhyCard'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import shuffle from '../../utils/shuffle'
 import '../../styles/PromptGuessEscape.css'
 import { scorePrompt } from '../../utils/scorePrompt'
@@ -115,7 +116,7 @@ const EXTRA_TIME = 10
 
 export default function PromptGuessEscape() {
   const navigate = useRouter()
-  const { setPoints: recordScore } = useContext(UserContext)
+  const { setPoints: recordScore } = useContext(UserContext) as UserContextType
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'; import { useRouter } from 'next/router'
 import CompletionModal from '../../components/ui/CompletionModal'
 import HeadTag from 'next/head'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import '../../styles/QuizGame.css'
 import InstructionBanner from '../../components/ui/InstructionBanner'
 import { HALLUCINATION_EXAMPLES } from '../../data/hallucinationExamples'
@@ -128,7 +129,7 @@ function ChatBox() {
 }
 
 export default function QuizGame() {
-  const { user, setPoints, addBadge } = useContext(UserContext)
+  const { user, setPoints, addBadge } = useContext(UserContext) as UserContextType
   const navigate = useRouter()
   const [round, setRound] = useState(0)
   const [choice, setChoice] = useState<number | null>(null)

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -14,6 +14,7 @@ import Tooltip from '../../components/ui/Tooltip'
 import TimerBar from '../../components/ui/TimerBar'
 import CompletionModal from '../../components/ui/CompletionModal'
 import { UserContext } from '../../../../shared/UserContext'
+import type { UserContextType } from '../../../../shared/types/user'
 import { getTimeLimit } from '../../utils/time'
 import '../../styles/PromptRecipeGame.css'
 
@@ -176,7 +177,7 @@ async function generateCards(): Promise<Card[]> {
 }
 
 export default function PromptRecipeGame() {
-  const { setPoints, addBadge, user } = useContext(UserContext)
+  const { setPoints, addBadge, user } = useContext(UserContext) as UserContextType
   const router = useRouter()
   const TOTAL_ROUNDS = 5
   const TOTAL_TIME = getTimeLimit(user, {

--- a/nextjs-app/src/pages/games/tone.tsx
+++ b/nextjs-app/src/pages/games/tone.tsx
@@ -7,6 +7,7 @@ import HeadTag from "next/head";
 import JsonLd from "../../components/seo/JsonLd";
 
 import { UserContext } from "../../../../shared/UserContext";
+import type { UserContextType } from "../../../../shared/types/user";
 import RobotChat from "../../components/RobotChat";
 import InstructionBanner from "../../components/ui/InstructionBanner";
 import WhyCard from "../../components/layout/WhyCard";
@@ -170,7 +171,7 @@ export function checkMatches(
 }
 
 function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) {
-  const { setPoints: recordScore } = useContext(UserContext)
+  const { setPoints: recordScore } = useContext(UserContext) as UserContextType
   const [selected, setSelected] = useState<Tone | null>(null)
   const [used, setUsed] = useState<Set<Tone>>(new Set())
   const [quizAnswer, setQuizAnswer] = useState<Tone | null>(null)
@@ -282,7 +283,7 @@ function ToneMatchGame({ onComplete }: { onComplete: (score: number) => void }) 
  * show an age-based leadership tip.
  */
 export default function Match3Game() {
-  const { user, addBadge } = useContext(UserContext)
+  const { user, addBadge } = useContext(UserContext) as UserContextType
   const router = useRouter()
   const [sidebarQuote] = useState(
     () => quotes[Math.floor(Math.random() * quotes.length)],

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect } from 'react'
 import HeadTag from 'next/head'
 import Link from 'next/link'; import { useRouter } from 'next/router'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import { getTotalPoints } from '../utils/user'
 import '../styles/Home.css'
 import { GOAL_POINTS } from '../constants/progress'
@@ -12,7 +13,7 @@ import ProgressSummary from '../components/ProgressSummary'
  * If the user's age isn't known we send them to the age input form first.
  */
 export default function Home() {
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
   const router = useRouter()
 
   // Redirect to the age form if age hasn't been provided yet

--- a/nextjs-app/src/pages/leaderboard.tsx
+++ b/nextjs-app/src/pages/leaderboard.tsx
@@ -2,6 +2,7 @@ import { useContext, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { notify } from '../../../shared/notify'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import { useLeaderboards, type PointsEntry } from '../../../shared/useLeaderboards'
 import ProgressSidebar from '../components/layout/ProgressSidebar'
 import '../styles/LeaderboardPage.css'
@@ -10,7 +11,7 @@ import '../styles/LeaderboardPage.css'
 
 
 export default function LeaderboardPage() {
-  const { user } = useContext(UserContext)
+  const { user } = useContext(UserContext) as UserContextType
 
   const [filter, setFilter] = useState('')
   const [sortField, setSortField] = useState<'name' | 'points'>('points')

--- a/nextjs-app/src/pages/profile.tsx
+++ b/nextjs-app/src/pages/profile.tsx
@@ -2,6 +2,7 @@ import { useContext, useState, useMemo } from 'react'
 import Link from 'next/link'
 import { notify } from '../../../shared/notify'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import ThemeToggle from '../components/layout/ThemeToggle'
 import { useLeaderboards, type PointsEntry } from '../../../shared/useLeaderboards'
 import { getTotalPoints } from '../utils/user'
@@ -10,7 +11,7 @@ import { getTotalPoints } from '../utils/user'
 import '../styles/ProfilePage.css'
 
 export default function ProfilePage() {
-  const { user, setName, setAge, setDifficulty } = useContext(UserContext)
+  const { user, setName, setAge, setDifficulty } = useContext(UserContext) as UserContextType
   const [name, setNameState] = useState(user.name ?? '')
   const [age, setAgeState] = useState<string>(user.age ? String(user.age) : '')
   const [difficulty, setDifficultyState] = useState(user.difficulty)

--- a/nextjs-app/src/pages/welcome.tsx
+++ b/nextjs-app/src/pages/welcome.tsx
@@ -2,10 +2,11 @@ import { useContext, useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import { useRouter } from 'next/router'
 import { UserContext } from '../../../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 import '../styles/SplashPage.css'
 
 export default function SplashPage() {
-  const { user, setUser } = useContext(UserContext)
+  const { user, setUser } = useContext(UserContext) as UserContextType
   const [name, setName] = useState(user.name ?? '')
   const [age, setAge] = useState<number | ''>(user.age ?? '')
   const navigate = useRouter()


### PR DESCRIPTION
## Summary
- fix `useContext(UserContext)` usages
- cast context to `UserContextType` everywhere

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848301e2d74832fb8f10794c4c1a8c1