### PR TITLE
Fix leaderboard entry typing

### DIFF
--- a/nextjs-app/src/pages/api/scores/[game].ts
+++ b/nextjs-app/src/pages/api/scores/[game].ts
@@ -1,6 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { scores } from '../helpers'
 
+interface ScoreEntry {
+  name: string
+  score: number
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST')
@@ -10,10 +15,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { game } = req.query
   const docRef = scores.doc(String(game))
   const snap = await docRef.get()
-  let entries: any[] = snap.exists ? (snap.data()?.entries || []) : []
-  const entry = { name: req.body?.name || 'Anonymous', score: Number(req.body?.score) || 0 }
+  let entries: ScoreEntry[] = snap.exists ? (snap.data()?.entries || []) : []
+  const entry: ScoreEntry = {
+    name: req.body?.name || 'Anonymous',
+    score: Number(req.body?.score) || 0,
+  }
   entries.push(entry)
-  entries.sort((a, b) => b.score - a.score)
+  entries.sort((a: ScoreEntry, b: ScoreEntry) => b.score - a.score)
   entries = entries.slice(0, 10)
   await docRef.set({ entries })
   res.status(200).json(entries)


### PR DESCRIPTION
## Summary
- define `ScoreEntry` interface
- use it to type leaderboard API route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684838ddd1fc832fa31abef0c7f42fc8