### PR TITLE
Add typed reducer to stats pages

### DIFF
--- a/learning-games/src/pages/StatsPage.tsx
+++ b/learning-games/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { getApiBase } from '../utils/api'
 
-interface ViewData {
+interface View {
   id: number
   visitorId: string | null
   user: string | null
@@ -15,7 +15,7 @@ interface ViewData {
 }
 
 export default function StatsPage() {
-  const [views, setViews] = useState<ViewData[]>([])
+  const [views, setViews] = useState<View[]>([])
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -53,7 +53,7 @@ export default function StatsPage() {
   const sessionViews = views.filter(v => typeof v.duration === 'number')
   const avgDuration = sessionViews.length
     ? Math.round(
-        sessionViews.reduce((sum, v) => sum + (v.duration || 0), 0) /
+        sessionViews.reduce((sum: number, v: View) => sum + (v.duration || 0), 0) /
           sessionViews.length /
           1000
       )

--- a/nextjs-app/src/pages/stats.tsx
+++ b/nextjs-app/src/pages/stats.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import Spinner from '../components/ui/Spinner'
 import { getApiBase } from '../utils/api'
 
-interface ViewData {
+interface View {
   id: number
   visitorId: string | null
   user: string | null
@@ -19,7 +19,7 @@ export default function StatsPage() {
 
   const base = getApiBase()
   const fetcher = (url: string) => fetch(url).then(res => res.json())
-  const { data: views = [] } = useSWR<ViewData[]>(
+  const { data: views = [] } = useSWR<View[]>(
     base ? `${base}/api/views` : null,
     fetcher,
     { refreshInterval: 60000 }
@@ -54,7 +54,7 @@ export default function StatsPage() {
   const sessionViews = views.filter(v => typeof v.duration === 'number')
   const avgDuration = sessionViews.length
     ? Math.round(
-        sessionViews.reduce((sum, v) => sum + (v.duration || 0), 0) /
+        sessionViews.reduce((sum: number, v: View) => sum + (v.duration || 0), 0) /
           sessionViews.length /
           1000
       )


### PR DESCRIPTION
## Summary
- use a `View` interface in stats page components
- type the reducer in each `StatsPage` for average session duration

## Testing
- `npm test` in `server`
- `npm test` in `learning-games`


------
https://chatgpt.com/codex/tasks/task_e_68483a2e5c34832fb81dd8b255660598