### PR TITLE
Fix internal links in footer

### DIFF
--- a/nextjs-app/src/components/layout/Footer.tsx
+++ b/nextjs-app/src/components/layout/Footer.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 export default function Footer() {
   const year = new Date().getFullYear()
   return (
@@ -12,9 +14,9 @@ export default function Footer() {
           <span>&copy; {year} StrawberryTech</span>
         </div>
         <nav className="footer-links">
-          <a href="/privacy">Privacy Policy</a>
-          <a href="/terms">Terms of Service</a>
-          <a href="/contact">Contact</a>
+          <Link href="/privacy">Privacy Policy</Link>
+          <Link href="/terms">Terms of Service</Link>
+          <Link href="/contact">Contact</Link>
         </nav>
         <a
           className="coffee-link"


### PR DESCRIPTION
## Summary
- use `next/link` for internal navigation links in the footer

## Testing
- `npx next lint` *(fails: Needs to install next@15.3.3)*
- `npm test` in `server` *(fails: Cannot find module 'supertest')*
- `npm test` in `learning-games` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684837034790832f80e927c1df1f7e44