### PR TITLE
Configure USE_LOCAL_STORE env var

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -5,5 +5,8 @@ OPENAI_API_KEY=
 FIREBASE_SERVICE_ACCOUNT=
 GOOGLE_APPLICATION_CREDENTIALS=
 
+# When true, use in-memory storage if Firestore credentials are missing
+USE_LOCAL_STORE=false
+
 # Port the server runs on
 PORT=3001

--- a/server/test/badges.test.js
+++ b/server/test/badges.test.js
@@ -1,3 +1,4 @@
+process.env.USE_LOCAL_STORE = 'true';
 const request = require('supertest');
 const app = require('../index');
 const { test } = require('node:test');

--- a/server/test/firestoreUnavailable.test.js
+++ b/server/test/firestoreUnavailable.test.js
@@ -1,0 +1,10 @@
+process.env.USE_LOCAL_STORE = 'false';
+const request = require('supertest');
+const app = require('../index');
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('returns 503 when firestore missing and local store disabled', async () => {
+  const res = await request(app).get('/api/user');
+  assert.equal(res.statusCode, 503);
+});

--- a/server/test/scores.test.js
+++ b/server/test/scores.test.js
@@ -1,3 +1,4 @@
+process.env.USE_LOCAL_STORE = 'true';
 const request = require('supertest');
 const app = require('../index');
 const { test, beforeEach } = require('node:test');


### PR DESCRIPTION
## Summary
- make `USE_LOCAL_STORE` control whether the server uses an in-memory store
- gate API calls if Firestore is missing and `USE_LOCAL_STORE` is false
- document `USE_LOCAL_STORE` in `.env.example`
- adjust tests to set the variable and add a check for the 503 case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68484be6e9e8832f9b2b9af06d7fbec5