### PR TITLE
Add server tests and Next.js build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,15 @@ jobs:
       - name: Build project
         run: npm run build
         working-directory: learning-games
+
+      - name: Run server tests
+        run: |
+          npm ci
+          npm test
+        working-directory: server
+
+      - name: Build nextjs app
+        run: |
+          npm ci
+          npm run build
+        working-directory: nextjs-app


### PR DESCRIPTION
## Summary
- run server tests in CI
- install and build Next.js app in CI

## Testing
- `npm test` in `server`
- `npm run build` in `nextjs-app` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484e8f7350832fbe60ed12ed58747a