### PR TITLE
Fix app router home route

### DIFF
--- a/nextjs-app/src/app/page.tsx
+++ b/nextjs-app/src/app/page.tsx
@@ -1,0 +1,3 @@
+import Home from '../pages/index'
+
+export default Home


### PR DESCRIPTION
## Summary
- wire up `src/app/page.tsx` to use the existing Pages router home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485e125010832fac4966ff9f4c1296