### PR TITLE
Update Next.js README

### DIFF
--- a/nextjs-app/README.md
+++ b/nextjs-app/README.md
@@ -16,7 +16,7 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `pages/index.tsx`. If you're using the new app router, edit `app/page.tsx` instead. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 


### PR DESCRIPTION
## Summary
- correct path to Next.js main page in the README

## Testing
- `npm test --prefix server` *(fails: ERR_TEST_FAILURE)*
- `npm test --prefix learning-games` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684862dd8a7c832f8ce3c968851ac573