### PR TITLE
Fix env access typing

### DIFF
--- a/learning-games/src/shared/UserProvider.tsx
+++ b/learning-games/src/shared/UserProvider.tsx
@@ -8,8 +8,11 @@ function getApiBase() {
   if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
     return process.env.NEXT_PUBLIC_API_BASE
   }
-  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
-    return (import.meta as any).env.VITE_API_BASE as string
+  if (
+    typeof import.meta !== 'undefined' &&
+    (import.meta.env as { [key: string]: string }).VITE_API_BASE
+  ) {
+    return (import.meta.env as { VITE_API_BASE: string }).VITE_API_BASE
   }
   return ''
 }

--- a/learning-games/src/shared/useLeaderboards.ts
+++ b/learning-games/src/shared/useLeaderboards.ts
@@ -12,8 +12,11 @@ function getApiBase(): string {
   if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
     return process.env.NEXT_PUBLIC_API_BASE
   }
-  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
-    return (import.meta as any).env.VITE_API_BASE as string
+  if (
+    typeof import.meta !== 'undefined' &&
+    (import.meta.env as { [key: string]: string }).VITE_API_BASE
+  ) {
+    return (import.meta.env as { VITE_API_BASE: string }).VITE_API_BASE
   }
   return ''
 }


### PR DESCRIPTION
## Summary
- type check `import.meta.env.VITE_API_BASE` in `UserProvider` and `useLeaderboards`
- return typed value when provided

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68486b223298832f9679d7a40db4e04b