### PR TITLE
Update badge lookup types

### DIFF
--- a/learning-games/src/pages/BadgesPage.tsx
+++ b/learning-games/src/pages/BadgesPage.tsx
@@ -48,8 +48,8 @@ export default function BadgesPage() {
         <button
           type="button"
           onClick={() => {            const earnedList = user.badges
-              .map((id: any) => {
-                const badge = badges.find((b: any) => b.id === id)
+              .map((id: string) => {
+                const badge = badges.find((b: BadgeDefinition) => b.id === id)
                 return badge ? `${badge.emoji} ${badge.name}` : id
               })
               .join(', ')


### PR DESCRIPTION
## Summary
- update `earnedList` mapping types to use strict `string` and `BadgeDefinition`

## Testing
- `npx eslint src/pages/BadgesPage.tsx`
- `npm run build` in `learning-games`


------
https://chatgpt.com/codex/tasks/task_e_68486b1815fc832fb8af489f55b97c2d