### PR TITLE
Add Vercel analytics

### DIFF
--- a/learning-games/package-lock.json
+++ b/learning-games/package-lock.json
@@ -8,6 +8,7 @@
       "name": "learning-games",
       "version": "0.0.0",
       "dependencies": {
+        "@vercel/analytics": "^1.5.0",
         "canvas-confetti": "^1.9.3",
         "framer-motion": "^12.16.0",
         "next": "15.2.4",
@@ -2032,6 +2033,44 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/learning-games/package.json
+++ b/learning-games/package.json
@@ -15,6 +15,7 @@
     "nextstart": "next start"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.5.0",
     "canvas-confetti": "^1.9.3",
     "framer-motion": "^12.16.0",
     "next": "15.2.4",

--- a/learning-games/pages/_app.tsx
+++ b/learning-games/pages/_app.tsx
@@ -5,12 +5,15 @@ import '../src/index.css'
 import '../src/App.css'
 import '../src/pages/Home.css'
 
-const Analytics = dynamic(() => import('../src/components/AnalyticsTrackerNext'), { ssr: false })
+import { Analytics as VercelAnalytics } from '@vercel/analytics/next'
+
+const AnalyticsTrackerDynamic = dynamic(() => import('../src/components/AnalyticsTrackerNext'), { ssr: false })
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <UserProvider>
-      <Analytics />
+      <AnalyticsTrackerDynamic />
+      <VercelAnalytics />
       <Component {...pageProps} />
     </UserProvider>
   )

--- a/nextjs-app/package-lock.json
+++ b/nextjs-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs-app",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^1.5.0",
         "canvas-confetti": "^1.9.3",
         "firebase-admin": "^12.0.0",
         "framer-motion": "^12.16.0",
@@ -2017,6 +2018,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.5.0",
     "canvas-confetti": "^1.9.3",
     "firebase-admin": "^12.0.0",
     "framer-motion": "^12.16.0",

--- a/nextjs-app/src/pages/_app.tsx
+++ b/nextjs-app/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { UserProvider } from '../../../shared/UserProvider'
 import NavBar from '../components/layout/NavBar'
 import Footer from '../components/layout/Footer'
 import AnalyticsTracker from '../components/AnalyticsTracker'
+import { Analytics } from '@vercel/analytics/next'
 import ScrollToTop from '../components/ScrollToTop'
 import '../styles/index.css'
 import '../styles/App.css'
@@ -23,6 +24,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         <AnalyticsTracker />
         <Component {...pageProps} />
         <Footer />
+        <Analytics />
       </UserProvider>
     </>
   )


### PR DESCRIPTION
## Summary
- install `@vercel/analytics`
- add `<Analytics />` component for visitor tracking

## Testing
- `npm run lint` (nextjs-app)
- `npm test` (learning-games)


------
https://chatgpt.com/codex/tasks/task_e_68486b79fc6c832fb7c5d624268d01bb