### PR TITLE
Fix environment typing and configure Vitest setup

### DIFF
--- a/learning-games/src/types/env.d.ts
+++ b/learning-games/src/types/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMetaEnv {
+  readonly VITE_API_BASE: string;
+}

--- a/learning-games/vitest.config.ts
+++ b/learning-games/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     },
   },
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts'
   }
 })

--- a/learning-games/vitest.setup.ts
+++ b/learning-games/vitest.setup.ts
@@ -1,0 +1,7 @@
+import { vi, beforeAll } from 'vitest'
+
+globalThis.alert = vi.fn()
+
+beforeAll(() => {
+  ;(import.meta.env as any).VITE_API_BASE = 'http://mock-api.local'
+})

--- a/shared/types/env.d.ts
+++ b/shared/types/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMetaEnv {
+  readonly VITE_API_BASE: string;
+}


### PR DESCRIPTION
## Summary
- declare `VITE_API_BASE` in env types
- mock `window.alert` and configure API base for tests
- run setup file automatically with Vitest

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in `server` *(fails: Cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68486d2b4608832fb4837851575097ed