### PR TITLE
Update setPoints dependencies

### DIFF
--- a/learning-games/src/shared/UserProvider.tsx
+++ b/learning-games/src/shared/UserProvider.tsx
@@ -95,7 +95,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         }).catch(err => console.error('Failed to save score', err))
       }
     },
-    [user.name],
+    [user.name, user.id],
   )
 
   const addBadge = useCallback((badge: string) => {

--- a/learning-games/vitest.setup.ts
+++ b/learning-games/vitest.setup.ts
@@ -3,5 +3,6 @@ import { vi, beforeAll } from 'vitest'
 globalThis.alert = vi.fn()
 
 beforeAll(() => {
-  ;(import.meta.env as any).VITE_API_BASE = 'http://mock-api.local'
+  ;(import.meta.env as { [key: string]: string }).VITE_API_BASE =
+    'http://mock-api.local'
 })


### PR DESCRIPTION
## Summary
- watch `user.id` in the `setPoints` callback so points update correctly
- fix lint error in vitest setup

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module framer-motion/dist/es/render/components/m/proxy.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_684870d58a70832f83c5210d128c7caa