### PR TITLE
Skip age prompt on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A short quiz where you spot the single AI hallucination hidden among two truthfu
 Drag cards to assemble a prompt. Each round now fetches fresh card text from the OpenAI API and shows a short sample response after you build the recipe.
 
 ## Age‑Adaptive Features
-- Players enter their age and name on first visit.
+- Players can optionally enter their age and name to personalize the games.
 - Games read the stored age to tweak difficulty and show tailored tips.
 - On easy difficulty, older players automatically receive extra time for tasks
   (5s at 40+, 10s at 50+, 15s at 60+).

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -16,11 +16,14 @@ export default function Home() {
   const navigate = useNavigate()
 
   // Redirect to the age form if age hasn't been provided yet
+  // Temporarily disabled so the home page loads without requiring age
+  /*
   useEffect(() => {
     if (user.age === null) {
       navigate('/age')
     }
   }, [user.age, navigate])
+  */
 
   // Apply reveal animation when elements scroll into view
   useEffect(() => {

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -17,11 +17,14 @@ export default function Home() {
   const router = useRouter()
 
   // Redirect to the age form if age hasn't been provided yet
+  // Temporarily disabled so the home page loads without requiring age
+  /*
   useEffect(() => {
     if (user.age === null) {
       router.push('/age')
     }
   }, [user.age, router])
+  */
 
   // Apply reveal animation when elements scroll into view
   useEffect(() => {


### PR DESCRIPTION
## Summary
- show home page on first load without forcing age entry
- update documentation about optional age

## Testing
- `npm install` in `learning-games`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684899069be4832f9685483a228ab386