### PR TITLE
Log env vars on server start

### DIFF
--- a/nextjs-app/src/utils/firebase.ts
+++ b/nextjs-app/src/utils/firebase.ts
@@ -4,6 +4,14 @@ import fs from 'fs'
 
 let serviceAccount: any
 const envCred = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.GOOGLE_APPLICATION_CREDENTIALS
+if (typeof console !== 'undefined') {
+  if (envCred) {
+    const display = envCred.length > 100 ? envCred.slice(0, 100) + '...' : envCred
+    console.log('FIREBASE_SERVICE_ACCOUNT loaded:', display)
+  } else {
+    console.log('FIREBASE_SERVICE_ACCOUNT not set')
+  }
+}
 if (envCred) {
   try {
     if (envCred.trim().startsWith('{')) {

--- a/server/firebase.js
+++ b/server/firebase.js
@@ -5,6 +5,12 @@ let firestore = null;
 let serviceAccount;
 const envCred = process.env.FIREBASE_SERVICE_ACCOUNT || process.env.GOOGLE_APPLICATION_CREDENTIALS;
 if (envCred) {
+  const display = envCred.length > 100 ? envCred.slice(0, 100) + '...' : envCred;
+  console.log('FIREBASE_SERVICE_ACCOUNT loaded:', display);
+} else {
+  console.log('FIREBASE_SERVICE_ACCOUNT not set');
+}
+if (envCred) {
   try {
     if (envCred.trim().startsWith('{')) {
       serviceAccount = JSON.parse(envCred);

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,25 @@ const firestore = require('./firebase');
 
 const useLocalStore = process.env.USE_LOCAL_STORE === 'true';
 
+function logEnvVars() {
+  const keys = [
+    'FIREBASE_SERVICE_ACCOUNT',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'USE_LOCAL_STORE',
+    'NODE_ENV',
+  ];
+  console.log('Loaded environment variables:');
+  keys.forEach(key => {
+    const val = process.env[key];
+    if (val) {
+      const display = val.length > 100 ? val.slice(0, 100) + '...' : val;
+      console.log(`  ${key}=${display}`);
+    } else {
+      console.log(`  ${key} is not set`);
+    }
+  });
+}
+
 function ensureFirestore(res) {
   if (!firestore) {
     if (!useLocalStore) {
@@ -418,6 +437,7 @@ app.post('/api/scores/:game', async (req, res) => {
 });
 
 if (require.main === module) {
+  logEnvVars();
   const next = require('next');
   const dev = process.env.NODE_ENV !== 'production';
   const nextApp = next({ dev, dir: path.join(__dirname, '../nextjs-app') });


### PR DESCRIPTION
## Summary
- log important environment variables when server starts
- show firebase env presence when Firebase utils initialize

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68489b6632c0832fbc8a25cb326bdf96