### PR TITLE
Redesigned community page

### DIFF
--- a/nextjs-app/src/styles/CommunityPage.module.css
+++ b/nextjs-app/src/styles/CommunityPage.module.css
@@ -1,9 +1,9 @@
 /* Modern Combined Community & Leaderboard Styles */
 .communityWrapper {
-  display: flex;
   min-height: 100vh;
   font-family: 'Poppins', system-ui, -apple-system, sans-serif;
   background: #f8fafc;
+  padding: 1rem;
 }
 
 .mainContent {
@@ -209,6 +209,24 @@
 
 .shareBtn:hover {
   background: #dc2626;
+}
+
+/* Stats bar at the top */
+.statsBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: white;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  margin-bottom: 1.5rem;
+  gap: 1rem;
+}
+
+.statsBar .badges {
+  display: flex;
+  gap: 0.25rem;
 }
 
 /* Community Section */


### PR DESCRIPTION
## Summary
- simplify Community page layout
- add a single stats bar for points, badges and sharing
- remove leaderboard and sidebar
- tweak CSS for new design

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4aca88c0832f903725f9314f248e