### PR TITLE
Add skip link accessibility

### DIFF
--- a/learning-games/src/App.tsx
+++ b/learning-games/src/App.tsx
@@ -25,12 +25,14 @@ import NavBar from './components/layout/NavBar'
 import Footer from './components/layout/Footer'
 import AnalyticsTracker from './components/AnalyticsTracker'
 import ScrollToTop from './components/ScrollToTop'
+import SkipLink from './components/SkipLink'
 import './App.css'
 
 function App() {
   return (
     <Router>
       <ScrollToTop />
+      <SkipLink />
       <NavBar />
       <AnalyticsTracker />
       <Routes>

--- a/learning-games/src/components/SkipLink.tsx
+++ b/learning-games/src/components/SkipLink.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function SkipLink() {
+  return (
+    <a href="#main-content" className="skip-link">
+      Skip to content
+    </a>
+  )
+}

--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -176,6 +176,24 @@ body.high-contrast button {
   border: 0;
 }
 
+/* Skip link for keyboard users */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 1rem;
+  background: #ffffff;
+  color: #000000;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  z-index: 10000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 .game-card-image {
   float: left;
   width: 120px;

--- a/learning-games/src/pages/AgeInputForm.tsx
+++ b/learning-games/src/pages/AgeInputForm.tsx
@@ -45,7 +45,7 @@ export default function AgeInputForm({
   }
 
   return (
-    <div className="age-form">
+    <div id="main-content" className="age-form">
       <form onSubmit={handleSubmit}>
         <label htmlFor="name">Enter your name:</label>
         <input

--- a/learning-games/src/pages/CommunityPage.tsx
+++ b/learning-games/src/pages/CommunityPage.tsx
@@ -102,7 +102,7 @@ export default function CommunityPage() {
   }
 
   return (
-    <div className="community-page">
+    <div id="main-content" className="community-page">
       <h2>Community</h2>
       <form onSubmit={addPost} style={{ marginBottom: '1rem' }}>
         <label htmlFor="message">Share your thoughts:</label>

--- a/learning-games/src/pages/CommunityPlaylistPage.tsx
+++ b/learning-games/src/pages/CommunityPlaylistPage.tsx
@@ -57,7 +57,7 @@ export default function CommunityPlaylistPage() {
   }
 
   return (
-    <div className="playlist-page">
+    <div id="main-content" className="playlist-page">
       <h2>Community Playlist</h2>
       <form onSubmit={addPair} style={{ marginBottom: '1rem' }}>
         <label htmlFor="bad">Bad prompt:</label>

--- a/learning-games/src/pages/ContactPage.tsx
+++ b/learning-games/src/pages/ContactPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 export default function ContactPage() {
   return (
-    <div className="legal-page">
+    <div id="main-content" className="legal-page">
       <h2>Contact Us</h2>
       <p>Email questions to example@strawberry-tech.test.</p>
       <p style={{ marginTop: '2rem' }}>

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -44,7 +44,7 @@ export default function Home() {
   const totalPoints = getTotalPoints(user.points)
 
   return (
-    <div className="home">
+    <div id="main-content" className="home">
       {/* hero section */}
       <section className="hero reveal" aria-label="Homepage hero">
         <h1 className="hero-title">Embark on a Fruity Learning Adventure!</h1>

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -196,7 +196,7 @@ export default function Match3Game() {
 
   if (showComplete) {
     return (
-      <div className="match3-page">
+      <div id="main-content" className="match3-page">
         <div className="congrats-overlay">
           <div className="congrats-modal" role="dialog" aria-modal="true">
             <img
@@ -228,7 +228,7 @@ export default function Match3Game() {
   }
 
   return (
-    <div className="match3-page">
+    <div id="main-content" className="match3-page">
       <InstructionBanner>
         Match adjectives to explore how tone changes the meaning of a message.
       </InstructionBanner>

--- a/learning-games/src/pages/PrivacyPage.tsx
+++ b/learning-games/src/pages/PrivacyPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 export default function PrivacyPage() {
   return (
-    <div className="legal-page">
+    <div id="main-content" className="legal-page">
       <h2>Privacy Policy</h2>
       <img
         src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"

--- a/learning-games/src/pages/PromptChainGame.tsx
+++ b/learning-games/src/pages/PromptChainGame.tsx
@@ -256,7 +256,7 @@ export default function PromptChainGame() {
 
   return (
     <>
-      <div className="chain-page">
+      <div id="main-content" className="chain-page">
         <InstructionBanner>
           Break complex tasks into a chain of simple prompts
         </InstructionBanner>

--- a/learning-games/src/pages/PromptDartsGame.tsx
+++ b/learning-games/src/pages/PromptDartsGame.tsx
@@ -184,7 +184,7 @@ export default function PromptDartsGame() {
 
   if (!rounds.length) {
     return (
-      <div className="darts-page">
+      <div id="main-content" className="darts-page">
         <InstructionBanner>Loading rounds...</InstructionBanner>
       </div>
     )
@@ -192,7 +192,7 @@ export default function PromptDartsGame() {
 
   if (round >= rounds.length) {
     return (
-      <div className="darts-page">
+      <div id="main-content" className="darts-page">
         <CompletionModal
           imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png"
           buttonHref="/games/chain"
@@ -206,7 +206,7 @@ export default function PromptDartsGame() {
   }
 
   return (
-    <div className="darts-page">
+    <div id="main-content" className="darts-page">
       <InstructionBanner>
         Choose the clearer prompt that best targets the requested format.
       </InstructionBanner>

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -235,7 +235,7 @@ export default function PromptGuessEscape() {
   }
 
   return (
-    <div className="guess-page">
+    <div id="main-content" className="guess-page">
       <InstructionBanner>Escape Room: Guess the Prompt</InstructionBanner>
       <div className="guess-wrapper">
         <WhyCard

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -294,7 +294,7 @@ export default function PromptRecipeGame() {
   const allFilled = Object.values(dropped).every(Boolean)
 
   return (
-    <div className="recipe-page">
+    <div id="main-content" className="recipe-page">
       <InstructionBanner>
         Drag each card to the category it best fits to build a clear AI prompt.
       </InstructionBanner>

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -196,7 +196,7 @@ export default function QuizGame() {
 
   return (
     <>
-    <div className="quiz-page">
+    <div id="main-content" className="quiz-page">
       <ChallengeBanner />
       <InstructionBanner>
         Find the one false statement—the AI hallucination. Tap the refresh icon

--- a/learning-games/src/pages/StatsPage.tsx
+++ b/learning-games/src/pages/StatsPage.tsx
@@ -71,7 +71,7 @@ export default function StatsPage() {
     .join(' ')
 
   return (
-    <div className="stats-page">
+    <div id="main-content" className="stats-page">
       <h2>Site Statistics</h2>
       <img
         src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"

--- a/learning-games/src/pages/TermsPage.tsx
+++ b/learning-games/src/pages/TermsPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 
 export default function TermsPage() {
   return (
-    <div className="legal-page">
+    <div id="main-content" className="legal-page">
       <h2>Terms of Service</h2>
       <img
         src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"

--- a/nextjs-app/src/components/layout/GamePageLayout.tsx
+++ b/nextjs-app/src/components/layout/GamePageLayout.tsx
@@ -21,7 +21,7 @@ const GamePageLayout: React.FC<GamePageLayoutProps> = ({
   ctaText,
 }) => {
   return (
-    <div className={styles['game-page-container']}>
+    <div id="main-content" className={styles['game-page-container']}>
       <aside className={styles['left-column']}>
         <div className={styles['info-card']}>
           <img src={imageSrc} alt={imageAlt} className={styles['game-image']} />

--- a/nextjs-app/src/components/layout/ModernGameLayout.tsx
+++ b/nextjs-app/src/components/layout/ModernGameLayout.tsx
@@ -26,7 +26,7 @@ export default function ModernGameLayout({
   nextGameButton
 }: ModernGameLayoutProps) {
   return (
-    <div className={`${styles.modernGameLayout} ${className}`}>
+    <div id="main-content" className={`${styles.modernGameLayout} ${className}`}>
       {/* Game Header */}
       <header className={styles.gameHeader}>
         <div className={styles.gameTitleSection}>

--- a/nextjs-app/src/components/layout/SkipLink.tsx
+++ b/nextjs-app/src/components/layout/SkipLink.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function SkipLink() {
+  return (
+    <a href="#main-content" className="skip-link">
+      Skip to content
+    </a>
+  )
+}

--- a/nextjs-app/src/pages/404.tsx
+++ b/nextjs-app/src/pages/404.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export default function NotFoundPage() {
   return (
-    <div className="not-found-page">
+    <div id="main-content" className="not-found-page">
       <h2>Page Not Found</h2>
       <img
         src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"

--- a/nextjs-app/src/pages/_app.tsx
+++ b/nextjs-app/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import { UserProvider } from '../shared/UserProvider'
 import { NotificationProvider } from '../contexts/NotificationContext'
 import ModernNavBar from '../components/layout/ModernNavBar'
+import SkipLink from '../components/layout/SkipLink'
 import Footer from '../components/layout/Footer'
 import AnalyticsTracker from '../components/AnalyticsTracker'
 import { Analytics } from '@vercel/analytics/next'
@@ -69,6 +70,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <NotificationProvider>
         <UserProvider>
           <ScrollToTop />
+          <SkipLink />
           <ModernNavBar />
           <AnalyticsTracker />
           <Component {...pageProps} />

--- a/nextjs-app/src/pages/age.tsx
+++ b/nextjs-app/src/pages/age.tsx
@@ -43,7 +43,7 @@ export default function AgeInputForm({
   }
 
   return (
-    <div className={styles['age-form']}>
+    <div id="main-content" className={styles['age-form']}>
       <form onSubmit={handleSubmit}>
         <label htmlFor="name">Enter your name:</label>
         <input

--- a/nextjs-app/src/pages/badges.tsx
+++ b/nextjs-app/src/pages/badges.tsx
@@ -28,7 +28,7 @@ export default function BadgesPage() {
 
   const loading = badges.length === 0
   return (
-    <div className={styles['badges-page']}>
+    <div id="main-content" className={styles['badges-page']}>
       <h2>Badges</h2>
       {loading ? (
         <Spinner />

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -103,7 +103,7 @@ export default function CommunityPage() {
     }
   }
   return (
-    <div className={styles.communityWrapper}>
+    <div id="main-content" className={styles.communityWrapper}>
       <div className={styles.mainContent}>
         <h1 className={styles.pageTitle}>Community</h1>
         

--- a/nextjs-app/src/pages/contact.tsx
+++ b/nextjs-app/src/pages/contact.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export default function ContactPage() {
   return (
-    <div className="legal-page">
+    <div id="main-content" className="legal-page">
       <h2>Contact Us</h2>
       <p>Email questions to example@strawberry-tech.test.</p>
       <p style={{ marginTop: '2rem' }}>

--- a/nextjs-app/src/pages/games/compose.tsx
+++ b/nextjs-app/src/pages/games/compose.tsx
@@ -4,7 +4,7 @@ export default function ComposeTweetGame() {
   const router = useRouter()
 
   return (
-    <div style={{ 
+    <div id="main-content" style={{
       padding: '2rem', 
       textAlign: 'center',
       minHeight: '60vh',

--- a/nextjs-app/src/pages/help.tsx
+++ b/nextjs-app/src/pages/help.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export default function HelpPage() {
   return (
-    <div className="help-page">
+    <div id="main-content" className="help-page">
       <h2>How to Play</h2>
       <img
         src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"

--- a/nextjs-app/src/pages/index.tsx
+++ b/nextjs-app/src/pages/index.tsx
@@ -73,7 +73,7 @@ export default function Home() {
         />
       </HeadTag>
       
-      <div className={styles.home}>        {/* Modern Hero Section */}
+      <div id="main-content" className={styles.home}>        {/* Modern Hero Section */}
         <header className={styles.hero}>
           <div className={styles.heroContent}>
             <div className={styles.heroText}>

--- a/nextjs-app/src/pages/privacy.tsx
+++ b/nextjs-app/src/pages/privacy.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export default function PrivacyPage() {
   return (
-    <div className="legal-page">
+    <div id="main-content" className="legal-page">
       <h2>Privacy Policy</h2>
       <img
         src="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"

--- a/nextjs-app/src/styles/index.css
+++ b/nextjs-app/src/styles/index.css
@@ -178,6 +178,24 @@ body.high-contrast button {
   border: 0;
 }
 
+/* Skip link for keyboard users */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 1rem;
+  background: #ffffff;
+  color: #000000;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  z-index: 10000;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 .game-card-image {
   float: left;
   width: 120px;


### PR DESCRIPTION
## Summary
- add SkipLink component for accessibility in both apps
- include skip link in global layouts
- style `.skip-link` in shared CSS
- mark main content areas with `id="main-content"`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm test` in `nextjs-app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5162cd0832fbf81de4cfd9d35a8