### PR TITLE
Fix mobile prompt builder layout

### DIFF
--- a/nextjs-app/src/components/layout/ModernNavBar.module.css
+++ b/nextjs-app/src/components/layout/ModernNavBar.module.css
@@ -5,7 +5,7 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1000;
+  z-index: 1100;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
@@ -44,7 +44,7 @@
   font-size: 1.25rem;
   letter-spacing: -0.025em;
   transition: all 0.2s ease;
-  z-index: 1001;
+  z-index: 1101;
 }
 
 .brand:hover {
@@ -170,7 +170,7 @@
   visibility: hidden;
   transform: translateX(-50%) translateY(-10px);
   transition: all 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-  z-index: 1000;
+  z-index: 1100;
   animation: dropdownFadeIn 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
 }
 
@@ -254,7 +254,7 @@
   cursor: pointer;
   padding: 8px;
   position: relative;
-  z-index: 1001;
+  z-index: 1101;
   border-radius: 8px;
   transition: background-color 0.2s ease, transform 0.1s ease;
   /* Ensure adequate touch target size */
@@ -313,7 +313,7 @@
   transition: transform 0.3s cubic-bezier(0.4, 0.0, 0.2, 1), 
               opacity 0.3s cubic-bezier(0.4, 0.0, 0.2, 1),
               visibility 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
-  z-index: 1002;
+  z-index: 1102;
   display: block;
   visibility: hidden;
   opacity: 0;

--- a/nextjs-app/src/styles/PromptRecipeGame.module.css
+++ b/nextjs-app/src/styles/PromptRecipeGame.module.css
@@ -21,6 +21,8 @@
 
 .recipe-wrapper {
   width: 100%;
+  max-width: 550px;
+  margin: 0 auto;
   display: grid;
   grid-template-columns: 250px 1fr 250px;
   grid-template-areas:
@@ -236,6 +238,7 @@
 
 @media (max-width: 600px) {
   .recipe-wrapper {
+    max-width: 100%;
     grid-template-columns: 1fr;
     grid-template-areas:
       'sidebar'


### PR DESCRIPTION
## Summary
- center prompt builder game content on mobile screens
- raise navbar z-index so it appears above game content

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac41f23c832fb05a42bfd3a93174