### PR TITLE
Add tutorial overlay and hints to intro game

### DIFF
--- a/nextjs-app/src/pages/games/intro.tsx
+++ b/nextjs-app/src/pages/games/intro.tsx
@@ -1,8 +1,10 @@
-import { useState, useContext } from 'react'
+import { useState, useContext, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/router'
 import JsonLd from '../../components/seo/JsonLd'
 import ModernGameLayout from '../../components/layout/ModernGameLayout'
 import WhyCard from '../../components/layout/WhyCard'
+import IntroOverlay from '../../components/ui/IntroOverlay'
+import CompletionModal from '../../components/ui/CompletionModal'
 import { UserContext } from '../../shared/UserContext'
 import type { UserContextType } from '../../shared/types/user'
 import styles from '../../styles/IntroGame.module.css'
@@ -10,23 +12,27 @@ import styles from '../../styles/IntroGame.module.css'
 interface StoryPart {
   line: string
   explanation: string
+  hint: string
 }
 
 const STORY_PARTS: StoryPart[] = [
   {
     line: 'I hope this email finds you well.',
     explanation:
-      'AI predicts a polite opener because most professional emails start with a friendly greeting.'
+      'AI predicts a polite opener because most professional emails start with a friendly greeting.',
+    hint: 'Try beginning with a warm greeting.'
   },
   {
     line: 'I wanted to follow up about our upcoming meeting.',
     explanation:
-      'Given the greeting, the model assumes a common next step is stating the reason for writing.'
+      'Given the greeting, the model assumes a common next step is stating the reason for writing.',
+    hint: 'Mention why you are writing.'
   },
   {
     line: 'Please let me know if you have any questions.',
     explanation:
-      'Many emails end with an invitation to respond, so the model predicts a courteous closing line.'
+      'Many emails end with an invitation to respond, so the model predicts a courteous closing line.',
+    hint: 'End with a polite invitation to reply.'
   }
 ]
 
@@ -37,12 +43,15 @@ export default function IntroGame() {
   const [story, setStory] = useState<string[]>([])
   const [input, setInput] = useState('')
   const [explanation, setExplanation] = useState('')
+  const [hint, setHint] = useState('')
+  const [showIntro, setShowIntro] = useState(true)
 
   function start(reason: string) {
     setStory([`You chose: ${reason}`])
     setExplanation('Great choice! Let\'s see what might happen next.')
     setStep(0)
     setInput('')
+    setHint('')
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -51,9 +60,16 @@ export default function IntroGame() {
     const userAction = input.trim() || '...'
     setStory(prev => [...prev, `You: ${userAction}`, `AI: ${STORY_PARTS[step].line}`])
     setExplanation(STORY_PARTS[step].explanation)
+    setHint('')
     setInput('')
     setStep(s => s + 1)
   }
+
+  const revealHint = useCallback(() => {
+    if (step >= 0 && step < STORY_PARTS.length) {
+      setHint(STORY_PARTS[step].hint)
+    }
+  }, [step])
 
   function finish() {
     setPoints('intro', STORY_PARTS.length * 5)
@@ -62,8 +78,36 @@ export default function IntroGame() {
 
   const finished = step >= STORY_PARTS.length
 
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (
+        e.key.toLowerCase() === 'h' &&
+        (e.target as HTMLElement).tagName !== 'INPUT' &&
+        (e.target as HTMLElement).tagName !== 'TEXTAREA'
+      ) {
+        e.preventDefault()
+        revealHint()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [revealHint])
+
+  useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setShowIntro(false)
+      }
+    }
+    if (showIntro) {
+      window.addEventListener('keydown', handleEsc)
+      return () => window.removeEventListener('keydown', handleEsc)
+    }
+  }, [showIntro])
+
   return (
     <>
+      {showIntro && <IntroOverlay onClose={() => setShowIntro(false)} />}
       <JsonLd
         data={{
           '@context': 'https://schema.org',
@@ -81,7 +125,9 @@ export default function IntroGame() {
         whyCard={
           <WhyCard
             title="What is AI?"
-            explanation="Think of AI as a prediction engine. It guesses the next words based on patterns, like finishing a puzzle." />
+            explanation="Think of AI as a prediction engine. It guesses the next words based on patterns, like finishing a puzzle."
+            lesson={<p>Type the next line you expect. The AI will reveal a common follow-up so you can compare.</p>}
+          />
         }
         nextGameButton={
           finished && (
@@ -126,13 +172,35 @@ export default function IntroGame() {
                   placeholder="Type your next sentence"
                   />
                   <button type="submit" className="btn-primary">Continue</button>
+                  <button type="button" className="btn-primary" onClick={revealHint}>
+                    Hint (H)
+                  </button>
                 </form>
               )}
+              {hint && <p className={styles.hint}>Hint: {hint}</p>}
               {explanation && <p className={styles.explanation}>{explanation}</p>}
             </>
           )}
         </div>
       </ModernGameLayout>
+      {finished && (
+        <CompletionModal
+          imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"
+          buttonHref="/games/tone"
+          buttonLabel="Play Tone Game"
+        >
+          <h3>Great job!</h3>
+          <p>You learned how AI predicts the next line in an email.</p>
+          <div className={styles['completion-tips']}>
+            <h4>Key Learning:</h4>
+            <ul>
+              <li>AI guesses text based on common patterns</li>
+              <li>Clear context helps it continue your writing</li>
+              <li>Use hints if you're not sure what comes next</li>
+            </ul>
+          </div>
+        </CompletionModal>
+      )}
     </>
   )
 }

--- a/nextjs-app/src/styles/IntroGame.module.css
+++ b/nextjs-app/src/styles/IntroGame.module.css
@@ -47,3 +47,37 @@
   font-size: 0.9rem;
   color: var(--color-text-dark);
 }
+
+.hint {
+  font-size: 0.9rem;
+  color: var(--color-brand);
+  margin-top: 0.5rem;
+}
+
+.final-score {
+  font-size: 1.3rem;
+  font-weight: bold;
+  color: var(--color-brand);
+  margin: 1rem 0;
+}
+
+.completion-tips {
+  text-align: left;
+  margin-top: 1rem;
+}
+
+.completion-tips h4 {
+  margin: 0 0 0.5rem 0;
+  color: var(--color-brand);
+}
+
+.completion-tips ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.completion-tips li {
+  margin-bottom: 0.3rem;
+  color: var(--color-text);
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Summary
- enhance intro game with `IntroOverlay` and `CompletionModal`
- add hints for each step and keyboard shortcuts
- show short lesson on the "What is AI?" card
- style hints and completion tips

## Testing
- `npm run lint` *(fails: setProgress unused etc.)*
- `npm run build` in `nextjs-app`
- `npm run build` in `learning-games` *(fails: TS2307 cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6851b8f563a0832f9efa1c82c9146b0d