### PR TITLE
Implement email builder intro game

### DIFF
--- a/nextjs-app/src/components/ui/EmailIntroModal.module.css
+++ b/nextjs-app/src/components/ui/EmailIntroModal.module.css
@@ -1,0 +1,33 @@
+.intro-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.intro-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  text-align: left;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.intro-modal ul {
+  padding-left: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.intro-modal li {
+  margin-bottom: 0.5rem;
+}

--- a/nextjs-app/src/components/ui/EmailIntroModal.tsx
+++ b/nextjs-app/src/components/ui/EmailIntroModal.tsx
@@ -1,0 +1,18 @@
+import styles from './EmailIntroModal.module.css'
+
+export default function EmailIntroModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div className={styles['intro-overlay']} role="dialog" aria-modal="true">
+      <div className={styles['intro-modal']}>
+        <h2>Welcome to the AI-Powered Email Builder!</h2>
+        <p>AI predicts the most likely next words to help craft polished emails.</p>
+        <ul>
+          <li>Select the type of email you want to write.</li>
+          <li>Pick from polite openings and helpful body sentences.</li>
+          <li>Earn points for professional choices and unlock badges.</li>
+        </ul>
+        <button className="btn-primary" onClick={onClose}>Start Building</button>
+      </div>
+    </div>
+  )
+}

--- a/server/badges.json
+++ b/server/badges.json
@@ -52,5 +52,23 @@
     "name": "First Chain",
     "description": "Complete your first prompt chain without hints",
     "emoji": "\u26d3"
+  },
+  {
+    "id": "prompt-novice",
+    "name": "Prompt Novice",
+    "description": "Reach 300 total points across games",
+    "emoji": "\ud83d\udc7e"
+  },
+  {
+    "id": "email-apprentice",
+    "name": "Email Apprentice",
+    "description": "Earn 600 total points across games",
+    "emoji": "\ud83d\udc69\u200d\ud83d\udcbb"
+  },
+  {
+    "id": "prompt-master",
+    "name": "Prompt Master",
+    "description": "Accumulate 1000 total points",
+    "emoji": "\ud83e\udd47"
   }
 ]


### PR DESCRIPTION
## Summary
- redesign intro game as an AI‑powered email builder
- add game intro modal component
- register new progress badges

## Testing
- `npm install`
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851c4730810832f826e285cce2a52e5