### PR TITLE
Improve introduction game email preview

### DIFF
--- a/nextjs-app/src/components/ui/EmailIntroModal.tsx
+++ b/nextjs-app/src/components/ui/EmailIntroModal.tsx
@@ -1,17 +1,36 @@
+import { useState } from 'react'
 import styles from './EmailIntroModal.module.css'
 
 export default function EmailIntroModal({ onClose }: { onClose: () => void }) {
+  const [step, setStep] = useState<'welcome' | 'howto'>('welcome')
+
   return (
     <div className={styles['intro-overlay']} role="dialog" aria-modal="true">
       <div className={styles['intro-modal']}>
-        <h2>Welcome to the AI-Powered Email Builder!</h2>
-        <p>AI predicts the most likely next words to help craft polished emails.</p>
-        <ul>
-          <li>Select the type of email you want to write.</li>
-          <li>Pick from polite openings and helpful body sentences.</li>
-          <li>Earn points for professional choices and unlock badges.</li>
-        </ul>
-        <button className="btn-primary" onClick={onClose}>Start Building</button>
+        {step === 'welcome' ? (
+          <>
+            <h2>Welcome to AI Basics!</h2>
+            <p>
+              AI is like a smart helper that guesses the next words in a
+              sentence.
+            </p>
+            <button className="btn-primary" onClick={() => setStep('howto')}>
+              Next
+            </button>
+          </>
+        ) : (
+          <>
+            <h2>How to Play</h2>
+            <ul>
+              <li>Pick the type of email you need.</li>
+              <li>Choose three lines suggested by AI.</li>
+              <li>Watch the preview grow after each choice.</li>
+            </ul>
+            <button className="btn-primary" onClick={onClose}>
+              Start Building
+            </button>
+          </>
+        )}
       </div>
     </div>
   )

--- a/nextjs-app/src/pages/games/intro.tsx
+++ b/nextjs-app/src/pages/games/intro.tsx
@@ -138,9 +138,11 @@ export default function IntroGame() {
 
   const [showIntro, setShowIntro] = useState(true)
   const [step, setStep] = useState<'context' | 'opener' | 'topic' | 'sentence' | 'review'>('context')
+  const TOTAL_SENTENCES = 3
   const [round, setRound] = useState(0)
   const [contextKey, setContextKey] = useState<string>('')
   const [topicIndex, setTopicIndex] = useState<number>(0)
+  const [usedTopics, setUsedTopics] = useState<number[]>([])
   const [email, setEmail] = useState<string[]>([])
   const [points, setPointsState] = useState(0)
 
@@ -164,13 +166,15 @@ export default function IntroGame() {
 
   function chooseSentence(sentence: SentenceOption) {
     setEmail(prev => [...prev, sentence.text])
-    setPointsState(p => p + 15 + (sentence.best ? 20 : 0))
-    if (round === 0) {
-      setRound(1)
+    setUsedTopics(prev => [...prev, topicIndex])
+    const gained = 15 + (sentence.best ? 20 : 0)
+    const total = points + gained
+    setPointsState(total)
+    if (round + 1 < TOTAL_SENTENCES) {
+      setRound(r => r + 1)
       setStep('topic')
     } else {
       setStep('review')
-      const total = points + 15 + (sentence.best ? 20 : 0)
       finalize(total)
     }
   }
@@ -245,11 +249,17 @@ export default function IntroGame() {
             <>
               <p className={styles.prompt}>What would you like to say next?</p>
               <div className={styles.options}>
-                {context.topics.map((t, i) => (
-                  <button key={t.name} className="btn-primary" onClick={() => chooseTopic(i)}>
-                    {t.name}
-                  </button>
-                ))}
+                {context.topics.map((t, i) =>
+                  usedTopics.includes(i) ? null : (
+                    <button
+                      key={t.name}
+                      className="btn-primary"
+                      onClick={() => chooseTopic(i)}
+                    >
+                      {t.name}
+                    </button>
+                  ),
+                )}
               </div>
             </>
           )}
@@ -265,6 +275,15 @@ export default function IntroGame() {
                 ))}
               </div>
             </>
+          )}
+
+          {email.length > 0 && step !== 'review' && (
+            <div className={styles.storyText} style={{ textAlign: 'left' }}>
+              <h3>Email So Far</h3>
+              {email.map((line, i) => (
+                <p key={i}>{line}</p>
+              ))}
+            </div>
           )}
 
           {step === 'review' && (
@@ -287,6 +306,14 @@ export default function IntroGame() {
         >
           <h3>Great job!</h3>
           <p>You built a professional email with AI assistance.</p>
+          <div className={styles['completion-tips']}>
+            <h4>Lesson Recap</h4>
+            <ul>
+              <li>AI suggests words by predicting what comes next.</li>
+              <li>Combining an opener and new topics creates a clear message.</li>
+              <li>Avoid repeating topics to keep the email focused.</li>
+            </ul>
+          </div>
         </CompletionModal>
       )}
     </>


### PR DESCRIPTION
## Summary
- enhance EmailIntroModal with two-step welcome message
- show email preview after each choice in IntroGame
- prevent duplicate topics and require three topic sentences
- add lesson recap to completion modal

## Testing
- `npm run lint` *(fails: next not found before install, then shows many lint errors)*
- `npm test` in nextjs-app *(fails: missing script)*
- `npm test` in learning-games *(errors during test run)*

------
https://chatgpt.com/codex/tasks/task_e_6851cadcc3ec832f86eaa95e646948f0