### PR TITLE
Show email preview in Intro Game

### DIFF
--- a/nextjs-app/src/components/ui/EmailPreviewModal.module.css
+++ b/nextjs-app/src/components/ui/EmailPreviewModal.module.css
@@ -1,0 +1,28 @@
+.preview-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.preview-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  text-align: left;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.email-text p {
+  margin: 0 0 0.5rem 0;
+}

--- a/nextjs-app/src/components/ui/EmailPreviewModal.tsx
+++ b/nextjs-app/src/components/ui/EmailPreviewModal.tsx
@@ -1,0 +1,24 @@
+import styles from './EmailPreviewModal.module.css'
+
+export interface EmailPreviewModalProps {
+  emailText: string
+  onClose: () => void
+}
+
+export default function EmailPreviewModal({ emailText, onClose }: EmailPreviewModalProps) {
+  const lines = emailText.split('\n')
+  return (
+    <div className={styles['preview-overlay']} role="dialog" aria-modal="true">
+      <div className={styles['preview-modal']}>
+        <div className={styles['email-text']}>
+          {lines.map((line, idx) => (
+            <p key={idx}>{line}</p>
+          ))}
+        </div>
+        <button className="btn-primary" onClick={onClose} style={{ marginTop: '0.5rem' }}>
+          OK
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/nextjs-app/src/pages/games/intro.tsx
+++ b/nextjs-app/src/pages/games/intro.tsx
@@ -5,6 +5,7 @@ import ModernGameLayout from '../../components/layout/ModernGameLayout'
 import WhyCard from '../../components/layout/WhyCard'
 import EmailIntroModal from '../../components/ui/EmailIntroModal'
 import CompletionModal from '../../components/ui/CompletionModal'
+import EmailPreviewModal from '../../components/ui/EmailPreviewModal'
 import ProgressBar from '../../components/ui/ProgressBar'
 import { UserContext } from '../../shared/UserContext'
 import type { UserContextType } from '../../shared/types/user'
@@ -147,6 +148,7 @@ export default function IntroGame() {
   const [typingLine, setTypingLine] = useState('')
   const [isTyping, setIsTyping] = useState(false)
   const [showCompletion, setShowCompletion] = useState(false)
+  const [showEmailPreview, setShowEmailPreview] = useState(false)
   const [points, setPointsState] = useState(0)
   const [finalEmail, setFinalEmail] = useState('')
   const [generating, setGenerating] = useState(false)
@@ -257,11 +259,23 @@ export default function IntroGame() {
       if (!finalEmail && !generating) {
         generateFullEmail(email).then(text => setFinalEmail(text))
       }
-      const timer = setTimeout(() => setShowCompletion(true), 5000)
-      return () => clearTimeout(timer)
+    } else {
+      setShowCompletion(false)
+      setShowEmailPreview(false)
+      setFinalEmail('')
     }
-    setShowCompletion(false)
   }, [step, finalEmail, generating, email])
+
+  useEffect(() => {
+    if (step === 'review' && finalEmail && !showEmailPreview) {
+      setShowEmailPreview(true)
+    }
+  }, [finalEmail, step, showEmailPreview])
+
+  function handlePreviewClose() {
+    setShowEmailPreview(false)
+    setShowCompletion(true)
+  }
 
   const percent = Math.min(100, (points / GOAL_POINTS) * 100)
 
@@ -375,6 +389,9 @@ export default function IntroGame() {
           )}
         </div>
       </ModernGameLayout>
+      {showEmailPreview && finalEmail && (
+        <EmailPreviewModal emailText={finalEmail} onClose={handlePreviewClose} />
+      )}
       {showCompletion && (
         <CompletionModal
           imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png"


### PR DESCRIPTION
## Summary
- add `EmailPreviewModal` component for showing the generated email
- display the preview modal when finishing the Intro Game

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npx tsc --noEmit`
- `npm run test` in `learning-games`

------
https://chatgpt.com/codex/tasks/task_e_6851d3b4e104832fb7109b4d4b2aa603