### PR TITLE
Improve notifications and centralize API helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to StrawberryTech
+
+Thank you for considering contributing! To get started:
+
+1. **Install dependencies** for each package:
+   ```bash
+   cd learning-games && npm install
+   cd ../server && npm install
+   cd ../nextjs-app && npm install
+   ```
+
+2. **Run the dev servers**:
+   ```bash
+   # Terminal 1
+   cd learning-games && npm run dev
+   # Terminal 2
+   cd server && npm start
+   ```
+
+3. **Run tests and lint checks** before submitting a PR:
+   ```bash
+   npm run lint --workspace=learning-games
+   npm test --workspace=learning-games
+   npm test --workspace=server
+   npm test --workspace=nextjs-app
+   ```
+
+4. **Submit pull requests** to the `develop` branch with a clear description of your changes.
+
+Please follow the existing code style and ensure `npm test` passes.

--- a/learning-games/src/components/ui/NotificationModal.module.css
+++ b/learning-games/src/components/ui/NotificationModal.module.css
@@ -1,0 +1,166 @@
+/* NotificationModal.module.css */
+.notification-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.notification-modal {
+  background: var(--color-background);
+  color: var(--color-text-dark);
+  padding: 1.5rem;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 500px;
+  min-width: 280px;
+  position: relative;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  animation: slideIn 0.3s ease-out;
+  border: 2px solid var(--color-primary, #007bff);
+}
+
+.notification-message {
+  font-size: 1.1rem;
+  line-height: 1.4;
+  margin-bottom: 1rem;
+  text-align: center;
+  word-wrap: break-word;
+  padding-right: 2rem;
+}
+
+.notification-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--color-text-light, #666);
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.notification-close:hover {
+  background: rgba(0, 0, 0, 0.1);
+  color: var(--color-text-dark);
+}
+
+.notification-close:focus {
+  outline: 2px solid var(--color-primary, #007bff);
+  outline-offset: 2px;
+}
+
+.notification-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 0 0 12px 12px;
+  overflow: hidden;
+}
+
+.notification-progress-bar {
+  height: 100%;
+  background: var(--color-primary, #007bff);
+  animation: progressBar linear;
+  transform-origin: left;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes progressBar {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+}
+
+/* Mobile responsiveness */
+@media (max-width: 480px) {
+  .notification-modal {
+    width: 95%;
+    padding: 1rem;
+    margin: 1rem;
+  }
+  
+  .notification-message {
+    font-size: 1rem;
+    padding-right: 1.5rem;
+  }
+  
+  .notification-close {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 1.2rem;
+    top: 0.25rem;
+    right: 0.25rem;
+  }
+}
+
+/* Tablet responsiveness */
+@media (max-width: 768px) and (min-width: 481px) {
+  .notification-modal {
+    width: 85%;
+    max-width: 400px;
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .notification-modal {
+    border-width: 3px;
+  }
+  
+  .notification-close {
+    border: 1px solid currentColor;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .notification-overlay,
+  .notification-modal {
+    animation: none;
+  }
+  
+  .notification-progress-bar {
+    animation: none;
+    transform: scaleX(0);
+  }
+}

--- a/learning-games/src/components/ui/NotificationModal.tsx
+++ b/learning-games/src/components/ui/NotificationModal.tsx
@@ -1,0 +1,90 @@
+import { useEffect } from 'react'
+import styles from './NotificationModal.module.css'
+
+export interface NotificationModalProps {
+  message: string
+  isOpen: boolean
+  onClose: () => void
+  autoClose?: boolean
+  autoCloseDelay?: number
+}
+
+export default function NotificationModal({
+  message,
+  isOpen,
+  onClose,
+  autoClose = true,
+  autoCloseDelay = 3000,
+}: NotificationModalProps) {
+  useEffect(() => {
+    if (isOpen && autoClose) {
+      const timer = setTimeout(() => {
+        onClose()
+      }, autoCloseDelay)
+
+      return () => clearTimeout(timer)
+    }
+  }, [isOpen, autoClose, autoCloseDelay, onClose])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen) {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown)
+      // Prevent background scrolling
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.body.style.overflow = ''
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose()
+    }
+  }
+
+  return (
+    <div 
+      className={styles['notification-overlay']}
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="notification-message"
+    >
+      <div className={styles['notification-modal']}>
+        <div 
+          id="notification-message"
+          className={styles['notification-message']}
+        >
+          {message}
+        </div>
+        <button
+          className={styles['notification-close']}
+          onClick={onClose}
+          aria-label="Close notification"
+          type="button"
+        >
+          ✕
+        </button>
+        {autoClose && (
+          <div className={styles['notification-progress']}>
+            <div 
+              className={styles['notification-progress-bar']}
+              style={{ animationDuration: `${autoCloseDelay}ms` }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/learning-games/src/contexts/NotificationContext.tsx
+++ b/learning-games/src/contexts/NotificationContext.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react'
+import NotificationModal from '../components/ui/NotificationModal'
+import { setNotificationHandler } from '../shared/notify'
+
+interface NotificationContextType {
+  showNotification: (message: string, options?: NotificationOptions) => void
+}
+
+interface NotificationOptions {
+  autoClose?: boolean
+  autoCloseDelay?: number
+}
+
+interface NotificationState {
+  message: string
+  isOpen: boolean
+  autoClose: boolean
+  autoCloseDelay: number
+}
+
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined)
+
+export function useNotification() {
+  const context = useContext(NotificationContext)
+  if (!context) {
+    throw new Error('useNotification must be used within a NotificationProvider')
+  }
+  return context
+}
+
+interface NotificationProviderProps {
+  children: ReactNode
+}
+
+export function NotificationProvider({ children }: NotificationProviderProps) {
+  const [notification, setNotification] = useState<NotificationState>({
+    message: '',
+    isOpen: false,
+    autoClose: true,
+    autoCloseDelay: 3000,
+  })
+
+  const showNotification = useCallback((message: string, options: NotificationOptions = {}) => {
+    setNotification({
+      message,
+      isOpen: true,
+      autoClose: options.autoClose ?? true,
+      autoCloseDelay: options.autoCloseDelay ?? 3000,
+    })
+  }, [])
+  const closeNotification = useCallback(() => {
+    setNotification(prev => ({ ...prev, isOpen: false }))
+  }, [])
+
+  // Connect the global notify function to this context
+  useEffect(() => {
+    setNotificationHandler(showNotification)
+  }, [showNotification])
+
+  return (
+    <NotificationContext.Provider value={{ showNotification }}>
+      {children}
+      <NotificationModal
+        message={notification.message}
+        isOpen={notification.isOpen}
+        onClose={closeNotification}
+        autoClose={notification.autoClose}
+        autoCloseDelay={notification.autoCloseDelay}
+      />
+    </NotificationContext.Provider>
+  )
+}

--- a/learning-games/src/main.tsx
+++ b/learning-games/src/main.tsx
@@ -1,13 +1,19 @@
 import { StrictMode } from 'react'
+import { ErrorBoundary } from '../../shared/ErrorBoundary'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './index.css'
 import { UserProvider } from './shared/UserProvider'
+import { NotificationProvider } from './contexts/NotificationContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <UserProvider>
-      <App />
-    </UserProvider>
+    <NotificationProvider>
+      <UserProvider>
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
+      </UserProvider>
+    </NotificationProvider>
   </StrictMode>
 )

--- a/learning-games/src/shared/UserProvider.tsx
+++ b/learning-games/src/shared/UserProvider.tsx
@@ -3,19 +3,7 @@ import { notify } from './notify'
 import type { ReactNode } from 'react'
 import type { UserData } from '../../../shared/types/user'
 import { UserContext, defaultUser } from './UserContext'
-
-function getApiBase() {
-  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
-    return process.env.NEXT_PUBLIC_API_BASE
-  }
-  if (
-    typeof import.meta !== 'undefined' &&
-    (import.meta.env as { [key: string]: string }).VITE_API_BASE
-  ) {
-    return (import.meta.env as { VITE_API_BASE: string }).VITE_API_BASE
-  }
-  return ''
-}
+import { getApiBase } from '../../../shared/getApiBase'
 
 const STORAGE_KEY = 'strawberrytech_user'
 

--- a/learning-games/src/shared/notify.ts
+++ b/learning-games/src/shared/notify.ts
@@ -1,7 +1,18 @@
+// Global notification function that works with the NotificationProvider
+let globalNotificationHandler: ((message: string) => void) | null = null
+
+export function setNotificationHandler(handler: (message: string) => void) {
+  globalNotificationHandler = handler
+}
+
 export function notify(message: string) {
   if (typeof window !== 'undefined') {
-    alert(message);
+    if (globalNotificationHandler) {
+      globalNotificationHandler(message)
+    } else {
+      console.log('Notification:', message)
+    }
   } else {
-    console.log(message);
+    console.log(message)
   }
 }

--- a/learning-games/src/shared/useLeaderboards.ts
+++ b/learning-games/src/shared/useLeaderboards.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { getApiBase } from '../../../shared/getApiBase'
 
 export interface PointsEntry {
   id?: string
@@ -8,18 +9,6 @@ export interface PointsEntry {
 
 export type LeaderboardData = Record<string, PointsEntry[]>
 
-function getApiBase(): string {
-  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
-    return process.env.NEXT_PUBLIC_API_BASE
-  }
-  if (
-    typeof import.meta !== 'undefined' &&
-    (import.meta.env as { [key: string]: string }).VITE_API_BASE
-  ) {
-    return (import.meta.env as { VITE_API_BASE: string }).VITE_API_BASE
-  }
-  return ''
-}
 
 let cachedData: LeaderboardData | null = null
 let fetchPromise: Promise<LeaderboardData> | null = null

--- a/learning-games/src/utils/api.ts
+++ b/learning-games/src/utils/api.ts
@@ -1,4 +1,1 @@
-export function getApiBase() {
-  if (import.meta.env.VITE_API_BASE) return import.meta.env.VITE_API_BASE
-  return ''
-}
+export { getApiBase } from '../../../shared/getApiBase'

--- a/nextjs-app/src/pages/_app.tsx
+++ b/nextjs-app/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import { UserProvider } from '../shared/UserProvider'
 import { NotificationProvider } from '../contexts/NotificationContext'
+import { ErrorBoundary } from '../../shared/ErrorBoundary'
 import ModernNavBar from '../components/layout/ModernNavBar'
 import SkipLink from '../components/layout/SkipLink'
 import Footer from '../components/layout/Footer'
@@ -69,13 +70,15 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         <meta name="keywords" content="AI prompting, artificial intelligence, learning games, prompt engineering, AI skills, interactive learning" /></Head>
       <NotificationProvider>
         <UserProvider>
-          <ScrollToTop />
-          <SkipLink />
-          <ModernNavBar />
-          <AnalyticsTracker />
-          <Component {...pageProps} />
-          <Footer />
-          <Analytics />
+          <ErrorBoundary>
+            <ScrollToTop />
+            <SkipLink />
+            <ModernNavBar />
+            <AnalyticsTracker />
+            <Component {...pageProps} />
+            <Footer />
+            <Analytics />
+          </ErrorBoundary>
         </UserProvider>
       </NotificationProvider>
     </>

--- a/nextjs-app/src/shared/UserProvider.tsx
+++ b/nextjs-app/src/shared/UserProvider.tsx
@@ -3,16 +3,7 @@ import { notify } from './notify'
 import type { ReactNode } from 'react'
 import type { UserData } from './types/user'
 import { UserContext, defaultUser } from './UserContext'
-
-function getApiBase() {
-  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
-    return process.env.NEXT_PUBLIC_API_BASE
-  }
-  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
-    return (import.meta as any).env.VITE_API_BASE as string
-  }
-  return ''
-}
+import { getApiBase } from '../../shared/getApiBase'
 
 const STORAGE_KEY = 'strawberrytech_user'
 

--- a/nextjs-app/src/shared/useLeaderboards.ts
+++ b/nextjs-app/src/shared/useLeaderboards.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { getApiBase } from '../../shared/getApiBase'
 
 export interface PointsEntry {
   name: string
@@ -8,15 +9,6 @@ export interface PointsEntry {
 
 export type LeaderboardData = Record<string, PointsEntry[]>
 
-function getApiBase(): string {
-  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
-    return process.env.NEXT_PUBLIC_API_BASE
-  }
-  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
-    return (import.meta as any).env.VITE_API_BASE as string
-  }
-  return ''
-}
 
 let cachedData: LeaderboardData | null = null
 let fetchPromise: Promise<LeaderboardData> | null = null

--- a/nextjs-app/src/utils/api.ts
+++ b/nextjs-app/src/utils/api.ts
@@ -1,15 +1,1 @@
-export function getApiBase() {
-  // In production, always use empty string for relative URLs to use Next.js API routes
-  if (process.env.NODE_ENV === 'production') {
-    return ''
-  }
-  
-  // In development, use the full URL if provided for external server
-  if (typeof window !== 'undefined') {
-    // Client-side: use relative URLs for same-origin requests in production
-    return process.env.NODE_ENV === 'development' ? (process.env.NEXT_PUBLIC_API_BASE || '') : ''
-  }
-  
-  // Server-side: use environment variable only in development
-  return process.env.NODE_ENV === 'development' ? (process.env.NEXT_PUBLIC_API_BASE || '') : ''
-}
+export { getApiBase } from '../../shared/getApiBase'

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,13 @@ const fs = require('fs');
 const path = require('path');
 const firestore = require('./firebase');
 
+// Validate essential environment variables
+['OPENAI_API_KEY'].forEach(key => {
+  if (!process.env[key]) {
+    console.warn(`Warning: ${key} is not set`);
+  }
+});
+
 const useLocalStore = process.env.USE_LOCAL_STORE === 'true';
 
 function ensureFirestore(res) {
@@ -452,5 +459,11 @@ if (require.main === module) {
     res.status(404).sendFile(path.join(__dirname, '404.html'));
   });
 }
+
+// Centralized error handler
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+});
 
 module.exports = app;

--- a/shared/ErrorBoundary.tsx
+++ b/shared/ErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div role="alert">Something went wrong. Please reload the page.</div>
+    }
+    return this.props.children
+  }
+}

--- a/shared/UserProvider.tsx
+++ b/shared/UserProvider.tsx
@@ -3,16 +3,7 @@ import { notify } from './notify'
 import type { ReactNode } from 'react'
 import type { UserData } from './types/user'
 import { UserContext, defaultUser } from './UserContext'
-
-function getApiBase() {
-  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
-    return process.env.NEXT_PUBLIC_API_BASE
-  }
-  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
-    return (import.meta as any).env.VITE_API_BASE as string
-  }
-  return ''
-}
+import { getApiBase } from './getApiBase'
 
 const STORAGE_KEY = 'strawberrytech_user'
 

--- a/shared/getApiBase.ts
+++ b/shared/getApiBase.ts
@@ -1,0 +1,18 @@
+export function getApiBase(): string {
+  // Use browser env variables when available
+  if (typeof window !== 'undefined') {
+    if (process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_API_BASE) {
+      return process.env.NEXT_PUBLIC_API_BASE
+    }
+    if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
+      return (import.meta as any).env.VITE_API_BASE as string
+    }
+    return ''
+  }
+
+  // Server-side: prefer development env var
+  if (process.env.NODE_ENV === 'development' && process.env.NEXT_PUBLIC_API_BASE) {
+    return process.env.NEXT_PUBLIC_API_BASE
+  }
+  return ''
+}

--- a/shared/notify.ts
+++ b/shared/notify.ts
@@ -1,7 +1,18 @@
+// Global notification function that works with the NotificationProvider
+let globalNotificationHandler: ((message: string) => void) | null = null
+
+export function setNotificationHandler(handler: (message: string) => void) {
+  globalNotificationHandler = handler
+}
+
 export function notify(message: string) {
   if (typeof window !== 'undefined') {
-    alert(message);
+    if (globalNotificationHandler) {
+      globalNotificationHandler(message)
+    } else {
+      console.log('Notification:', message)
+    }
   } else {
-    console.log(message);
+    console.log(message)
   }
 }

--- a/shared/useLeaderboards.ts
+++ b/shared/useLeaderboards.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { getApiBase } from './getApiBase'
 
 export interface PointsEntry {
   name: string
@@ -8,15 +9,6 @@ export interface PointsEntry {
 
 export type LeaderboardData = Record<string, PointsEntry[]>
 
-function getApiBase(): string {
-  if (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_BASE) {
-    return process.env.NEXT_PUBLIC_API_BASE
-  }
-  if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) {
-    return (import.meta as any).env.VITE_API_BASE as string
-  }
-  return ''
-}
 
 let cachedData: LeaderboardData | null = null
 let fetchPromise: Promise<LeaderboardData> | null = null


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guidelines
- provide a reusable ErrorBoundary component
- create `getApiBase` helper shared by all packages
- replace alert-based notifications with modal notifications
- wrap apps with ErrorBoundary and NotificationProvider
- warn when important env vars are missing and add a global error handler

## Testing
- `npm test` in `learning-games`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_6852a3443d6c832fb78908fa681f5b54