### PR TITLE
Add age group context and AI prompt updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Drag cards to assemble a prompt. Each round now fetches fresh card text from the
 ## Age‑Adaptive Features
 - Players can optionally enter their age and name to personalize the games.
 - Games read the stored age to tweak difficulty and show tailored tips.
+- AI-generated hints and chat responses adapt tone for each age group.
 - On easy difficulty, older players automatically receive extra time for tasks
   (5s at 40+, 10s at 50+, 15s at 60+).
 - Points and badges now sync to a small server so progress follows you across devices.

--- a/learning-games/src/components/RobotChat.tsx
+++ b/learning-games/src/components/RobotChat.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import { motion } from 'framer-motion'
 import { notify } from '../shared/notify'
+import { UserContext } from '../shared/UserContext'
+import type { UserContextType } from '../../../shared/types/user'
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -8,15 +10,15 @@ interface ChatMessage {
 }
 
 export default function RobotChat() {
+  const { ageGroup } = useContext(UserContext) as UserContextType
   const [open, setOpen] = useState(false)
   const [input, setInput] = useState('')
   const [messages, setMessages] = useState<ChatMessage[]>([])
 
   // Instruction sent with every request so the bot behaves like a teacher
   const systemMsg = {
-    role: 'system',
-    content:
-      'You are a friendly instructor for this lesson. Reply in one short sentence at a 4th grade reading level.',
+    role: 'system' as const,
+    content: `You are a friendly instructor for this lesson. Reply in one short sentence for a ${ageGroup} player.`,
   }
 
   async function sendMessage(e: React.FormEvent) {

--- a/learning-games/src/pages/ClarityEscapeRoom.tsx
+++ b/learning-games/src/pages/ClarityEscapeRoom.tsx
@@ -118,7 +118,7 @@ const EXTRA_TIME = 10
 
 export default function ClarityEscapeRoom() {
   const navigate = useNavigate()
-  const { setPoints: recordScore } = useContext(UserContext) as UserContextType
+  const { setPoints: recordScore, ageGroup } = useContext(UserContext) as UserContextType
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')
@@ -142,8 +142,8 @@ export default function ClarityEscapeRoom() {
   const [showSummary, setShowSummary] = useState(false)
 
   useEffect(() => {
-    generateRoomDescription().then(text => setRoomDescription(text))
-  }, [index])
+    generateRoomDescription(ageGroup).then(text => setRoomDescription(text))
+  }, [index, ageGroup])
 
   const clue = doors[index]
 
@@ -222,7 +222,7 @@ export default function ClarityEscapeRoom() {
             {
               role: 'system',
               content:
-                'Provide a single short hint referencing the user\'s guess without revealing the answer.',
+                `Provide a single short hint for a ${ageGroup} player referencing the user's guess without revealing the answer.`,
             },
             {
               role: 'user',

--- a/learning-games/src/pages/PromptGuessEscape.tsx
+++ b/learning-games/src/pages/PromptGuessEscape.tsx
@@ -114,7 +114,7 @@ const EXTRA_TIME = 10
 
 export default function PromptGuessEscape() {
   const navigate = useNavigate()
-  const { setPoints: recordScore } = useContext(UserContext)
+  const { setPoints: recordScore, ageGroup } = useContext(UserContext)
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')
@@ -134,8 +134,8 @@ export default function PromptGuessEscape() {
   const [showSummary, setShowSummary] = useState(false)
 
   useEffect(() => {
-    generateRoomDescription().then(text => setRoomDescription(text))
-  }, [index])
+    generateRoomDescription(ageGroup).then(text => setRoomDescription(text))
+  }, [index, ageGroup])
 
   const clue = doors[index]
 

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -23,7 +23,7 @@ import {
 
 
 export default function PromptRecipeGame() {
-  const { setPoints, addBadge, user } = useContext(UserContext)
+  const { setPoints, addBadge, user, ageGroup } = useContext(UserContext)
   const navigate = useNavigate()
   const TOTAL_ROUNDS = 5
   const TOTAL_TIME = getTimeLimit(user, {
@@ -60,7 +60,7 @@ export default function PromptRecipeGame() {
   const [example, setExample] = useState<string | null>(null)
 
   const startRound = useCallback(async () => {
-    const newCards = await generateCards()
+    const newCards = await generateCards(ageGroup)
     setRoundCards(newCards)
     setCards(shuffle([...newCards]))
     setDropped({ Action: null, Context: null, Format: null, Constraints: null })
@@ -76,7 +76,7 @@ export default function PromptRecipeGame() {
       Format: null,
       Constraints: null,
     })
-  }, [TOTAL_TIME])
+  }, [TOTAL_TIME, ageGroup])
 
   useEffect(() => {
     startRound()
@@ -258,7 +258,10 @@ export default function PromptRecipeGame() {
         },
         body: JSON.stringify({
           model: 'gpt-3.5-turbo',
-          messages: [{ role: 'user', content: prompt }],
+          messages: [
+            { role: 'system', content: `Reply in one short sentence for a ${ageGroup} player.` },
+            { role: 'user', content: prompt },
+          ],
           max_tokens: 60,
         }),
       })

--- a/learning-games/src/pages/QuizGame.tsx
+++ b/learning-games/src/pages/QuizGame.tsx
@@ -68,8 +68,14 @@ function WhyItMatters() {
 }
 
 function ChatBox() {
+  const { ageGroup } = useContext(UserContext)
   const [input, setInput] = useState('')
   const [messages, setMessages] = useState<ChatMessage[]>([])
+
+  const systemMsg = {
+    role: 'system' as const,
+    content: `Reply in one short sentence for a ${ageGroup} player.`,
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -88,7 +94,7 @@ function ChatBox() {
         },
         body: JSON.stringify({
           model: 'gpt-3.5-turbo',
-          messages: [...messages, userMsg],
+          messages: [systemMsg, ...messages, userMsg],
         }),
       })
       const data = await resp.json()

--- a/learning-games/src/pages/promptRecipeHelpers.ts
+++ b/learning-games/src/pages/promptRecipeHelpers.ts
@@ -121,7 +121,9 @@ function randomItem<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)]
 }
 
-export async function generateCards(): Promise<Card[]> {
+import type { AgeGroup } from '../../../shared/getAgeGroup'
+
+export async function generateCards(ageGroup: AgeGroup): Promise<Card[]> {
   try {
     const resp = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -135,7 +137,7 @@ export async function generateCards(): Promise<Card[]> {
           {
             role: 'system',
             content:
-              'Provide four short phrases that clearly fit the labels Action, Context, Format and Constraints. Output exactly four lines in that order and prefix each line with the matching label followed by a colon. Example:\nAction: Write a thank you note\nContext: to a colleague\nFormat: as a short poem\nConstraints: under 50 words.',
+              `Provide four short phrases for a ${ageGroup} player that clearly fit the labels Action, Context, Format and Constraints. Output exactly four lines in that order and prefix each line with the matching label followed by a colon. Example:\nAction: Write a thank you note\nContext: to a colleague\nFormat: as a short poem\nConstraints: under 50 words.`,
           },
           { role: 'user', content: 'Provide the labeled phrases.' },
         ],

--- a/learning-games/src/shared/UserContext.ts
+++ b/learning-games/src/shared/UserContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
-import type { UserData, UserContextType } from '../../../shared/types/user'
+import type { UserData, UserContextType, AgeGroup } from '../../../shared/types/user'
+import { getAgeGroup } from '../../../shared/getAgeGroup'
 
 export const defaultUser: UserData = {
   id: '',
@@ -10,6 +11,8 @@ export const defaultUser: UserData = {
   badges: [],
 }
 
+const defaultAgeGroup: AgeGroup = getAgeGroup(null)
+
 export const UserContext = createContext<UserContextType>({
   user: defaultUser,
   setUser: () => {},
@@ -18,4 +21,5 @@ export const UserContext = createContext<UserContextType>({
   setPoints: () => {},
   addBadge: () => {},
   setDifficulty: () => {},
+  ageGroup: defaultAgeGroup,
 })

--- a/learning-games/src/shared/UserProvider.tsx
+++ b/learning-games/src/shared/UserProvider.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 import type { UserData } from '../../../shared/types/user'
 import { UserContext, defaultUser } from './UserContext'
 import { getApiBase } from '../../../shared/getApiBase'
+import { getAgeGroup } from '../../../shared/getAgeGroup'
 
 const STORAGE_KEY = 'strawberrytech_user'
 
@@ -128,6 +129,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         setPoints,
         addBadge,
         setDifficulty,
+        ageGroup: getAgeGroup(user.age),
       }}
     >
       {children}

--- a/learning-games/src/shared/__tests__/getAgeGroup.test.ts
+++ b/learning-games/src/shared/__tests__/getAgeGroup.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { getAgeGroup } from '../../../../shared/getAgeGroup'
+
+describe('getAgeGroup', () => {
+  it('maps numbers to groups', () => {
+    expect(getAgeGroup(5)).toBe('child')
+    expect(getAgeGroup(15)).toBe('teen')
+    expect(getAgeGroup(30)).toBe('adult')
+    expect(getAgeGroup(70)).toBe('senior')
+  })
+})

--- a/learning-games/src/utils/__tests__/generateRoomDescription.test.ts
+++ b/learning-games/src/utils/__tests__/generateRoomDescription.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { generateRoomDescription } from '../generateRoomDescription'
+
+const originalFetch = global.fetch
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+describe('generateRoomDescription', () => {
+  it('includes age group in system prompt', async () => {
+    const mock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ choices: [{ message: { content: 'room' } }] }),
+    })
+    global.fetch = mock as any
+    await generateRoomDescription('teen')
+    const body = JSON.parse(mock.mock.calls[0][1].body)
+    expect(body.messages[0].content).toContain('teen')
+  })
+})

--- a/learning-games/src/utils/generateRoomDescription.ts
+++ b/learning-games/src/utils/generateRoomDescription.ts
@@ -1,4 +1,6 @@
-export async function generateRoomDescription(): Promise<string> {
+import type { AgeGroup } from '../../../shared/getAgeGroup'
+
+export async function generateRoomDescription(ageGroup: AgeGroup): Promise<string> {
   try {
     const resp = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -12,7 +14,7 @@ export async function generateRoomDescription(): Promise<string> {
           {
             role: 'system',
             content:
-              'You create short, vivid scene descriptions for an escape room game. Keep it under 20 words.',
+              `You create short, vivid scene descriptions for an escape room game that a ${ageGroup} player would understand. Keep it under 20 words.`,
           },
           { role: 'user', content: 'Describe the next room the player enters.' },
         ],

--- a/nextjs-app/src/components/RobotChat.tsx
+++ b/nextjs-app/src/components/RobotChat.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import { motion } from 'framer-motion'
 import { notify } from '../shared/notify'
+import { UserContext } from '../shared/UserContext'
+import type { UserContextType } from '../shared/types/user'
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -8,15 +10,15 @@ interface ChatMessage {
 }
 
 export default function RobotChat() {
+  const { ageGroup } = useContext(UserContext) as UserContextType
   const [open, setOpen] = useState(false)
   const [input, setInput] = useState('')
   const [messages, setMessages] = useState<ChatMessage[]>([])
 
   // Instruction sent with every request so the bot behaves like a teacher
   const systemMsg = {
-    role: 'system',
-    content:
-      'You are a friendly instructor for this lesson. Reply in one short sentence at a 4th grade reading level.',
+    role: 'system' as const,
+    content: `You are a friendly instructor for this lesson. Reply in one short sentence for a ${ageGroup} player.`,
   }
 
   async function sendMessage(e: React.FormEvent) {

--- a/nextjs-app/src/pages/games/escape.tsx
+++ b/nextjs-app/src/pages/games/escape.tsx
@@ -114,7 +114,7 @@ const TOTAL_STEPS = 4
 
 export default function ClarityEscapeRoom() {
   const router = useRouter()
-  const { setPoints: recordScore } = useContext(UserContext) as UserContextType
+  const { setPoints: recordScore, ageGroup } = useContext(UserContext) as UserContextType
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')
@@ -137,8 +137,8 @@ export default function ClarityEscapeRoom() {
   const [showSummary, setShowSummary] = useState(false)
 
   useEffect(() => {
-    generateRoomDescription().then(text => setRoomDescription(text))
-  }, [index])
+    generateRoomDescription(ageGroup).then(text => setRoomDescription(text))
+  }, [index, ageGroup])
 
   const clue = doors[index]
 
@@ -213,7 +213,7 @@ export default function ClarityEscapeRoom() {
             {
               role: 'system',
               content:
-                'Provide a single short hint referencing the user\'s guess without revealing the answer.',
+                `Provide a single short hint for a ${ageGroup} player referencing the user's guess without revealing the answer.`,
             },
             {
               role: 'user',

--- a/nextjs-app/src/pages/games/guess.tsx
+++ b/nextjs-app/src/pages/games/guess.tsx
@@ -115,7 +115,7 @@ const EXTRA_TIME = 10
 
 export default function PromptGuessEscape() {
   const router = useRouter()
-  const { setPoints: recordScore } = useContext(UserContext) as UserContextType
+  const { setPoints: recordScore, ageGroup } = useContext(UserContext) as UserContextType
   const [doors] = useState(() => shuffle(CLUES).slice(0, TOTAL_STEPS))
   const [index, setIndex] = useState(0)
   const [input, setInput] = useState('')
@@ -139,8 +139,8 @@ export default function PromptGuessEscape() {
   const [earned, setEarned] = useState(0)
 
   useEffect(() => {
-    generateRoomDescription().then(text => setRoomDescription(text))
-  }, [index])
+    generateRoomDescription(ageGroup).then(text => setRoomDescription(text))
+  }, [index, ageGroup])
 
   const clue = doors[index]
 

--- a/nextjs-app/src/pages/games/intro.tsx
+++ b/nextjs-app/src/pages/games/intro.tsx
@@ -139,7 +139,7 @@ const ALL_OPENERS = Object.entries(EMAIL_DATA).flatMap(([context, ctx]) =>
 
 export default function IntroGame() {
   const router = useRouter()
-  const { setPoints, addBadge, user } = useContext(UserContext) as UserContextType
+  const { setPoints, addBadge, user, ageGroup } = useContext(UserContext) as UserContextType
 
   const [showIntro, setShowIntro] = useState(true)
   const [step, setStep] = useState<'opener' | 'sentence' | 'review'>('opener')
@@ -215,7 +215,7 @@ export default function IntroGame() {
             {
               role: 'system',
               content:
-                'Write a concise, professional email incorporating the provided lines. Include a greeting and closing. Keep it under 120 words.',
+                `Write a concise, professional email for a ${ageGroup} user incorporating the provided lines. Include a greeting and closing. Keep it under 120 words.`,
             },
             { role: 'user', content: joined },
           ],

--- a/nextjs-app/src/pages/games/quiz.tsx
+++ b/nextjs-app/src/pages/games/quiz.tsx
@@ -33,8 +33,14 @@ interface ChatMessage {
 }
 
 function ChatBox() {
+  const { ageGroup } = useContext(UserContext) as UserContextType
   const [input, setInput] = useState('')
   const [messages, setMessages] = useState<ChatMessage[]>([])
+
+  const systemMsg = {
+    role: 'system' as const,
+    content: `Reply in one short sentence for a ${ageGroup} player.`,
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -53,7 +59,7 @@ function ChatBox() {
         },
         body: JSON.stringify({
           model: 'gpt-3.5-turbo',
-          messages: [...messages, userMsg],
+          messages: [systemMsg, ...messages, userMsg],
         }),
       })
       const data = await resp.json()

--- a/nextjs-app/src/pages/games/recipe.tsx
+++ b/nextjs-app/src/pages/games/recipe.tsx
@@ -138,7 +138,9 @@ function randomItem<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)]
 }
 
-async function generateCards(): Promise<Card[]> {
+import type { AgeGroup } from '../../../shared/getAgeGroup'
+
+async function generateCards(ageGroup: AgeGroup): Promise<Card[]> {
   try {
     const resp = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -152,7 +154,7 @@ async function generateCards(): Promise<Card[]> {
           {
             role: 'system',
             content:
-              'Provide four short phrases that clearly fit the labels Action, Context, Format and Constraints. Output exactly four lines in that order and prefix each line with the matching label followed by a colon. Example:\nAction: Write a thank you note\nContext: to a colleague\nFormat: as a short poem\nConstraints: under 50 words.',
+              `Provide four short phrases for a ${ageGroup} player that clearly fit the labels Action, Context, Format and Constraints. Output exactly four lines in that order and prefix each line with the matching label followed by a colon. Example:\nAction: Write a thank you note\nContext: to a colleague\nFormat: as a short poem\nConstraints: under 50 words.`,
           },
           { role: 'user', content: 'Provide the labeled phrases.' },
         ],
@@ -176,7 +178,7 @@ async function generateCards(): Promise<Card[]> {
 }
 
 export default function PromptRecipeGame() {
-  const { setPoints, addBadge, user } = useContext(UserContext) as UserContextType
+  const { setPoints, addBadge, user, ageGroup } = useContext(UserContext) as UserContextType
   const router = useRouter()
   const TOTAL_ROUNDS = 5
   const TOTAL_TIME = getTimeLimit(user, {
@@ -213,7 +215,7 @@ export default function PromptRecipeGame() {
   const [example, setExample] = useState<string | null>(null)
 
   async function startRound() {
-    const newCards = await generateCards()
+    const newCards = await generateCards(ageGroup)
     setRoundCards(newCards)
     setCards(shuffle([...newCards]))
     setDropped({ Action: null, Context: null, Format: null, Constraints: null })
@@ -405,7 +407,10 @@ export default function PromptRecipeGame() {
         },
         body: JSON.stringify({
           model: 'gpt-3.5-turbo',
-          messages: [{ role: 'user', content: prompt }],
+          messages: [
+            { role: 'system', content: `Reply in one short sentence for a ${ageGroup} player.` },
+            { role: 'user', content: prompt },
+          ],
           max_tokens: 60,
         }),
       })

--- a/nextjs-app/src/utils/generateRoomDescription.ts
+++ b/nextjs-app/src/utils/generateRoomDescription.ts
@@ -1,4 +1,6 @@
-export async function generateRoomDescription(): Promise<string> {
+import type { AgeGroup } from '../../../shared/getAgeGroup'
+
+export async function generateRoomDescription(ageGroup: AgeGroup): Promise<string> {
   try {
     const resp = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -12,7 +14,7 @@ export async function generateRoomDescription(): Promise<string> {
           {
             role: 'system',
             content:
-              'You create short, vivid scene descriptions for an escape room game. Keep it under 20 words.',
+              `You create short, vivid scene descriptions for an escape room game that a ${ageGroup} player would understand. Keep it under 20 words.`,
           },
           { role: 'user', content: 'Describe the next room the player enters.' },
         ],

--- a/shared/UserContext.ts
+++ b/shared/UserContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
-import type { UserData, UserContextType } from './types/user'
+import type { UserData, UserContextType, AgeGroup } from './types/user'
+import { getAgeGroup } from './getAgeGroup'
 
 export const defaultUser: UserData = {
   id: '',
@@ -10,6 +11,8 @@ export const defaultUser: UserData = {
   badges: [],
 }
 
+const defaultAgeGroup: AgeGroup = getAgeGroup(null)
+
 export const UserContext = createContext<UserContextType>({
   user: defaultUser,
   setUser: () => {},
@@ -18,4 +21,5 @@ export const UserContext = createContext<UserContextType>({
   setPoints: () => {},
   addBadge: () => {},
   setDifficulty: () => {},
+  ageGroup: defaultAgeGroup,
 })

--- a/shared/UserProvider.tsx
+++ b/shared/UserProvider.tsx
@@ -3,6 +3,7 @@ import { notify } from './notify'
 import type { ReactNode } from 'react'
 import type { UserData } from './types/user'
 import { UserContext, defaultUser } from './UserContext'
+import { getAgeGroup } from './getAgeGroup'
 import { getApiBase } from './getApiBase'
 
 const STORAGE_KEY = 'strawberrytech_user'
@@ -133,6 +134,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         setPoints,
         addBadge,
         setDifficulty,
+        ageGroup: getAgeGroup(user.age),
       }}
     >
       {children}

--- a/shared/getAgeGroup.ts
+++ b/shared/getAgeGroup.ts
@@ -1,0 +1,12 @@
+export type AgeGroup = 'child' | 'teen' | 'adult' | 'senior'
+
+/**
+ * Map a numeric age to a broad age group used to tailor AI prompts.
+ */
+export function getAgeGroup(age?: number | null): AgeGroup {
+  if (age == null) return 'adult'
+  if (age < 13) return 'child'
+  if (age < 18) return 'teen'
+  if (age < 65) return 'adult'
+  return 'senior'
+}

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -10,6 +10,8 @@ export interface UserData {
   badges: string[]
 }
 
+export type AgeGroup = 'child' | 'teen' | 'adult' | 'senior'
+
 export interface UserContextType {
   user: UserData
   setUser: (user: UserData) => void
@@ -35,4 +37,8 @@ export interface UserContextType {
    * Update the difficulty setting for all games.
    */
   setDifficulty: (level: 'easy' | 'medium' | 'hard') => void
+  /**
+   * Age group derived from the user's age. Used to tailor AI responses.
+   */
+  ageGroup: AgeGroup
 }


### PR DESCRIPTION
## Summary
- map ages to age groups via `getAgeGroup`
- expose `ageGroup` through `UserContext`
- update RobotChat, games and utils to include age group in system prompts
- adjust OpenAI calls across apps
- add unit tests for age group helper and room description prompts
- document adaptive AI responses in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a8110ccc832fb649ad54f8b94485