### PR TITLE
Fix UserContext age group

### DIFF
--- a/nextjs-app/src/shared/UserContext.ts
+++ b/nextjs-app/src/shared/UserContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
-import type { UserData, UserContextType } from './types/user'
+import type { UserData, UserContextType, AgeGroup } from './types/user'
+import { getAgeGroup } from '../../../shared/getAgeGroup'
 
 export const defaultUser: UserData = {
   id: '',
@@ -10,6 +11,8 @@ export const defaultUser: UserData = {
   badges: [],
 }
 
+const defaultAgeGroup: AgeGroup = getAgeGroup(null)
+
 export const UserContext = createContext<UserContextType>({
   user: defaultUser,
   setUser: () => {},
@@ -18,4 +21,5 @@ export const UserContext = createContext<UserContextType>({
   setPoints: () => {},
   addBadge: () => {},
   setDifficulty: () => {},
+  ageGroup: defaultAgeGroup,
 })

--- a/nextjs-app/src/shared/UserProvider.tsx
+++ b/nextjs-app/src/shared/UserProvider.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react'
 import type { UserData } from './types/user'
 import { UserContext, defaultUser } from './UserContext'
 import { getApiBase } from '../../../shared/getApiBase'
+import { getAgeGroup } from '../../../shared/getAgeGroup'
 
 const STORAGE_KEY = 'strawberrytech_user'
 
@@ -133,6 +134,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         setPoints,
         addBadge,
         setDifficulty,
+        ageGroup: getAgeGroup(user.age),
       }}
     >
       {children}

--- a/nextjs-app/src/shared/types/user.ts
+++ b/nextjs-app/src/shared/types/user.ts
@@ -10,6 +10,8 @@ export interface UserData {
   badges: string[]
 }
 
+export type AgeGroup = 'child' | 'teen' | 'adult' | 'senior'
+
 export interface UserContextType {
   user: UserData
   setUser: (user: UserData) => void
@@ -35,4 +37,8 @@ export interface UserContextType {
    * Update the difficulty setting for all games.
    */
   setDifficulty: (level: 'easy' | 'medium' | 'hard') => void
+  /**
+   * Age group derived from the user's age. Used to tailor AI responses.
+   */
+  ageGroup: AgeGroup
 }


### PR DESCRIPTION
## Summary
- add missing `ageGroup` definition for Next.js app
- expose default age group in context and provider

## Testing
- `npm install` and `npm test` in `learning-games`

------
https://chatgpt.com/codex/tasks/task_e_6852b0b7723c832f9883a255b63f366b