### PR TITLE
Expand AI Basics game

### DIFF
--- a/nextjs-app/src/components/ui/EmailIntroModal.tsx
+++ b/nextjs-app/src/components/ui/EmailIntroModal.tsx
@@ -2,23 +2,40 @@ import { useState } from 'react'
 import styles from './EmailIntroModal.module.css'
 
 export default function EmailIntroModal({ onClose }: { onClose: () => void }) {
-  const [step, setStep] = useState<'welcome' | 'howto'>('welcome')
+  const [step, setStep] = useState<'welcome' | 'details' | 'howto'>('welcome')
 
   return (
     <div className={styles['intro-overlay']} role="dialog" aria-modal="true">
       <div className={styles['intro-modal']}>
-        {step === 'welcome' ? (
+        {step === 'welcome' && (
           <>
             <h2>Welcome to AI Basics!</h2>
             <p>
               AI is like a smart helper that guesses the next words in a
               sentence.
             </p>
-            <button className="btn-primary" onClick={() => setStep('howto')}>
+            <button className="btn-primary" onClick={() => setStep('details')}>
               Next
             </button>
           </>
-        ) : (
+        )}
+        {step === 'details' && (
+          <>
+            <p>
+              Behind the scenes, large language models read millions of example
+              sentences. They learn patterns so they can predict the most likely
+              next word when given a prompt.
+            </p>
+            <p>
+              In this short game you'll build an email one line at a time to see
+              how those predictions add up.
+            </p>
+            <button className="btn-primary" onClick={() => setStep('howto')}>
+              How do I play?
+            </button>
+          </>
+        )}
+        {step === 'howto' && (
           <>
             <h2>How to Play</h2>
             <ul>

--- a/nextjs-app/src/pages/api/suggest.ts
+++ b/nextjs-app/src/pages/api/suggest.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const context = (req.query.context as string) || ''
+  if (!context) return res.status(400).json({ error: 'Missing context' })
+  const OPENAI_API_KEY = process.env.OPENAI_API_KEY
+
+  if (!OPENAI_API_KEY) {
+    const fallback: Record<string, string[]> = {
+      meeting: [
+        'Could we meet Wednesday at 2 PM?',
+        'Are you free Wednesday afternoon?',
+        'Let me know if Wednesday works.'
+      ],
+      followup: [
+        'Do you have any updates for me?',
+        'Have you had a chance to review?',
+        'Could you share your thoughts?'
+      ],
+      thankyou: [
+        'Your quick help made a difference.',
+        'Thanks again for your effort.',
+        'I appreciate your support.'
+      ],
+      jobapp: [
+        'I am excited to apply for this role.',
+        'My background matches the position well.',
+        'Attached is my resume for review.'
+      ],
+      support: [
+        'I am experiencing an issue with my order.',
+        'Could you assist with my problem?',
+        'Please let me know what details you need.'
+      ]
+    }
+    res.status(200).json({ suggestions: fallback[context] || [] })
+    return
+  }
+
+  try {
+    const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content: `Suggest three short, clear sentences for an email about ${context}. Separate each line with a newline.`
+          }
+        ],
+        max_tokens: 60,
+        temperature: 0.7
+      })
+    })
+    const data = await resp.json()
+    const text: string = data?.choices?.[0]?.message?.content || ''
+    const suggestions = text
+      .split(/\n+/)
+      .map(t => t.trim().replace(/^[-\d.\s]+/, ''))
+      .filter(Boolean)
+    res.status(200).json({ suggestions })
+  } catch (error) {
+    console.error('suggest endpoint failed', error)
+    res.status(500).json({ error: 'Failed to fetch suggestions' })
+  }
+}

--- a/nextjs-app/src/pages/games/intro.tsx
+++ b/nextjs-app/src/pages/games/intro.tsx
@@ -15,6 +15,7 @@ import styles from '../../styles/IntroGame.module.css'
 interface SentenceOption {
   text: string
   best?: boolean
+  hint?: string
 }
 
 interface Topic {
@@ -33,14 +34,14 @@ const EMAIL_DATA: Record<string, EmailContext> = {
     label: 'Scheduling Meeting',
     openers: [
       { text: 'I hope you\'re doing well.' },
-      { text: 'I\'m writing to schedule our meeting.', best: true },
+      { text: 'I\'m writing to schedule our meeting.', best: true, hint: 'States the purpose clearly' },
       { text: 'Just reaching out to find a good time to connect.' },
     ],
     topics: [
       {
         name: 'Propose Meeting Time',
         sentences: [
-          { text: 'Could we meet on Tuesday at 3 PM?', best: true },
+          { text: 'Could we meet on Tuesday at 3 PM?', best: true, hint: 'Specific time suggestion' },
           { text: 'Are you free Tuesday afternoon?' },
           { text: 'Let\'s plan to meet sometime Tuesday.' },
         ],
@@ -48,7 +49,7 @@ const EMAIL_DATA: Record<string, EmailContext> = {
       {
         name: 'Ask Availability',
         sentences: [
-          { text: 'What time works best for you?', best: true },
+          { text: 'What time works best for you?', best: true, hint: 'Asks directly for availability' },
           { text: 'When might you be available?' },
           { text: 'Let me know your preferred time.' },
         ],
@@ -56,7 +57,7 @@ const EMAIL_DATA: Record<string, EmailContext> = {
       {
         name: 'Mention Agenda',
         sentences: [
-          { text: 'I\'ll share a short agenda before we meet.', best: true },
+          { text: 'I\'ll share a short agenda before we meet.', best: true, hint: 'Prepares the recipient' },
           { text: 'I\'ll send over the discussion points soon.' },
           { text: 'I\'ll outline our topics beforehand.' },
         ],
@@ -67,14 +68,14 @@ const EMAIL_DATA: Record<string, EmailContext> = {
     label: 'Following Up',
     openers: [
       { text: 'I hope you\'re having a good week.' },
-      { text: 'I\'m following up on our last conversation.', best: true },
+      { text: 'I\'m following up on our last conversation.', best: true, hint: 'Reminds them of prior discussion' },
       { text: 'Just checking in regarding my previous email.' },
     ],
     topics: [
       {
         name: 'Request Update',
         sentences: [
-          { text: 'Do you have any updates for me?', best: true },
+          { text: 'Do you have any updates for me?', best: true, hint: 'Politely requests progress' },
           { text: 'Have you had a chance to review?' },
           { text: 'Could you share your thoughts?' },
         ],
@@ -82,7 +83,7 @@ const EMAIL_DATA: Record<string, EmailContext> = {
       {
         name: 'Offer Help',
         sentences: [
-          { text: 'I\'m happy to answer any questions.', best: true },
+          { text: 'I\'m happy to answer any questions.', best: true, hint: 'Offers assistance' },
           { text: 'Let me know if anything is unclear.' },
           { text: 'I\'d be glad to provide more details.' },
         ],
@@ -90,7 +91,7 @@ const EMAIL_DATA: Record<string, EmailContext> = {
       {
         name: 'Mention Deadline',
         sentences: [
-          { text: 'We\'re hoping to finalize this by Friday.', best: true },
+          { text: 'We\'re hoping to finalize this by Friday.', best: true, hint: 'Communicates a deadline' },
           { text: 'A quick response would be appreciated.' },
           { text: 'Please reply when you can.' },
         ],
@@ -100,7 +101,7 @@ const EMAIL_DATA: Record<string, EmailContext> = {
   thankyou: {
     label: 'Thank You',
     openers: [
-      { text: 'Thank you so much for your help.', best: true },
+      { text: 'Thank you so much for your help.', best: true, hint: 'Expresses gratitude plainly' },
       { text: 'I really appreciate your assistance.' },
       { text: 'I wanted to express my gratitude for your support.' },
     ],
@@ -108,7 +109,7 @@ const EMAIL_DATA: Record<string, EmailContext> = {
       {
         name: 'Acknowledge Effort',
         sentences: [
-          { text: 'Your quick response made all the difference.', best: true },
+          { text: 'Your quick response made all the difference.', best: true, hint: 'Praises the recipient directly' },
           { text: 'You really went above and beyond.' },
           { text: 'I recognize the time you put into this.' },
         ],
@@ -116,7 +117,7 @@ const EMAIL_DATA: Record<string, EmailContext> = {
       {
         name: 'Offer Future Help',
         sentences: [
-          { text: 'Please let me know if I can return the favor.', best: true },
+          { text: 'Please let me know if I can return the favor.', best: true, hint: 'Offers future assistance' },
           { text: 'Don\'t hesitate to reach out if you need anything.' },
           { text: 'Feel free to contact me whenever you need help.' },
         ],
@@ -124,9 +125,61 @@ const EMAIL_DATA: Record<string, EmailContext> = {
       {
         name: 'Close Warmly',
         sentences: [
-          { text: 'Looking forward to working with you again.', best: true },
+          { text: 'Looking forward to working with you again.', best: true, hint: 'Ends on a positive note' },
           { text: 'Hope we can collaborate again soon.' },
           { text: 'Can\'t wait to work together next time.' },
+        ],
+      },
+    ],
+  },
+  jobapp: {
+    label: 'Job Application',
+    openers: [
+      { text: 'I am excited to apply for the open position.', best: true, hint: 'Shows enthusiasm for the role' },
+      { text: 'Please consider my attached resume.' },
+      { text: 'I would love to join your team.' },
+    ],
+    topics: [
+      {
+        name: 'Highlight Skills',
+        sentences: [
+          { text: 'My experience aligns well with the job requirements.', best: true, hint: 'Connects skills to the role' },
+          { text: 'I have many of the skills you listed.' },
+          { text: 'My background matches what you need.' },
+        ],
+      },
+      {
+        name: 'Request Interview',
+        sentences: [
+          { text: 'Could we schedule a short interview?', best: true, hint: 'Politely asks for next step' },
+          { text: 'I would appreciate the chance to discuss the role.' },
+          { text: 'I hope to talk more about this opportunity.' },
+        ],
+      },
+    ],
+  },
+  support: {
+    label: 'Support Request',
+    openers: [
+      { text: 'I need help with a recent order.', best: true, hint: 'States the issue right away' },
+      { text: 'I am writing about a problem I encountered.' },
+      { text: 'I hope you can assist me with an issue.' },
+    ],
+    topics: [
+      {
+        name: 'Describe Issue',
+        sentences: [
+          { text: 'The product arrived damaged.', best: true, hint: 'Clear description of the problem' },
+          { text: 'Something is wrong with what I received.' },
+          { text: 'The item is not functioning as expected.' },
+        ],
+      },
+      {
+        name: 'Ask for Help',
+        sentences: [
+          { text: 'Can you send a replacement or refund?', best: true, hint: 'Clearly states the request' },
+          { text: 'What can be done to resolve this?' },
+          { text: 'Please advise on next steps.' },
         ],
       },
     ],
@@ -154,8 +207,27 @@ export default function IntroGame() {
   const [points, setPointsState] = useState(0)
   const [finalEmail, setFinalEmail] = useState('')
   const [generating, setGenerating] = useState(false)
+  const [options, setOptions] = useState<SentenceOption[]>([])
+  const [lastHint, setLastHint] = useState('')
+  const [debugInfo, setDebugInfo] = useState<string>('')
+  const [showDebug, setShowDebug] = useState(false)
+  const [quizAnswer, setQuizAnswer] = useState('')
+  const [quizResult, setQuizResult] = useState('')
 
   const context = EMAIL_DATA[contextKey]
+
+  useEffect(() => {
+    if (step === 'sentence' && contextKey) {
+      fetch(`/api/suggest?context=${contextKey}`)
+        .then(r => r.json())
+        .then(data =>
+          setOptions((data.suggestions || []).map((t: string) => ({ text: t })))
+        )
+        .catch(() => setOptions([]))
+    } else {
+      setOptions([])
+    }
+  }, [step, contextKey, round])
 
   function typeLine(text: string, after: () => void) {
     setIsTyping(true)
@@ -171,7 +243,7 @@ export default function IntroGame() {
         setIsTyping(false)
         after()
       }
-    }, 30)
+    }, 60)
   }
 
   function chooseOpener(opener: { context: string } & SentenceOption) {
@@ -184,6 +256,12 @@ export default function IntroGame() {
     const gained = 15 + (sentence.best ? 20 : 0)
     const total = points + gained
     setPointsState(total)
+    const hintText =
+      sentence.hint ||
+      (sentence.best
+        ? 'Great choice! It is clear and specific.'
+        : 'This works, but another option may be clearer.')
+    setLastHint(hintText)
     typeLine(sentence.text, () => {
       if (round + 1 < TOTAL_SENTENCES) {
         setRound(r => r + 1)
@@ -225,6 +303,7 @@ export default function IntroGame() {
       })
       const data = await resp.json()
       const text: string | undefined = data?.choices?.[0]?.message?.content
+      setDebugInfo(JSON.stringify({ request: { lines }, response: data }, null, 2))
       return text ? text.trim() : joined
     } catch (err) {
       console.error('Email generation failed', err)
@@ -243,6 +322,14 @@ export default function IntroGame() {
       addBadge('email-apprentice')
     } else if (overall >= 300 && !user.badges.includes('prompt-novice')) {
       addBadge('prompt-novice')
+    }
+  }
+
+  function checkQuiz() {
+    if (quizAnswer === 'predict') {
+      setQuizResult('Correct! AI predicts the next words.')
+    } else {
+      setQuizResult('Not quite. AI is guessing the next likely words.')
     }
   }
 
@@ -280,6 +367,12 @@ export default function IntroGame() {
     setShowEmailPreview(false)
     setPointsState(0)
     setFinalEmail('')
+    setOptions([])
+    setLastHint('')
+    setDebugInfo('')
+    setShowDebug(false)
+    setQuizAnswer('')
+    setQuizResult('')
   }
 
   const percent = Math.min(100, (points / GOAL_POINTS) * 100)
@@ -304,8 +397,17 @@ export default function IntroGame() {
         whyCard={
           <WhyCard
             title="What is AI?"
-            explanation="Think of AI as a prediction engine. It guesses the next words based on patterns, like finishing a puzzle."
-            lesson={<p>Pick the options you like best to assemble a polished email.</p>}
+            explanation="Think of AI as a prediction engine. It studies heaps of example text then guesses the most likely next word."
+            lesson={
+              <p>
+                Each selection helps the model refine its guess. Notice how
+                concise, specific lines often score higher.
+              </p>
+            }
+            examples={[
+              { good: 'Could we meet Tuesday at 2?', bad: 'Maybe we can meet.' },
+              { good: 'Please let me know your availability.', bad: 'Let me know.' }
+            ]}
           />
         }
       >
@@ -327,12 +429,19 @@ export default function IntroGame() {
             <>
               <p className={styles.prompt}>Choose a sentence</p>
               <div className={styles.options}>
-                {context.topics.flatMap(t => t.sentences).map((s, i) => (
-                  <button key={i} className="btn-primary" onClick={() => chooseSentence(s)} disabled={isTyping}>
+                {(options.length ? options : context.topics.flatMap(t => t.sentences)).map((s, i) => (
+                  <button
+                    key={i}
+                    className="btn-primary"
+                    onClick={() => chooseSentence(s)}
+                    disabled={isTyping}
+                    title={s.hint}
+                  >
                     {s.text}
                   </button>
                 ))}
               </div>
+              {lastHint && <p className={styles.hint}>{lastHint}</p>}
             </>
           )}
 
@@ -360,6 +469,14 @@ export default function IntroGame() {
                 email.map((line, i) => <p key={i}>{line}</p>)}
               <p className={styles.finalScore}>Total Points: {points}</p>
               <ProgressBar percent={percent} />
+              {debugInfo && showDebug && (
+                <pre className={styles.debug}>{debugInfo}</pre>
+              )}
+              {debugInfo && (
+                <button className="btn-secondary" onClick={() => setShowDebug(s => !s)}>
+                  {showDebug ? 'Hide Debug' : 'Show Debug'}
+                </button>
+              )}
               <button className="btn-secondary" onClick={restartGame}>
                 Restart
               </button>
@@ -385,6 +502,38 @@ export default function IntroGame() {
               <li>Combining an opener and new topics creates a clear message.</li>
               <li>Avoid repeating topics to keep the email focused.</li>
             </ul>
+          </div>
+          <div className={styles.quiz}>
+            <p>Quick Quiz: What is the AI doing in this game?</p>
+            <label>
+              <input
+                type="radio"
+                name="quiz"
+                value="predict"
+                onChange={e => setQuizAnswer(e.target.value)}
+              />
+              Predicting the next words
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="quiz"
+                value="mind"
+                onChange={e => setQuizAnswer(e.target.value)}
+              />
+              Reading your mind
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="quiz"
+                value="magic"
+                onChange={e => setQuizAnswer(e.target.value)}
+              />
+              Doing magic
+            </label>
+            <button className="btn-primary" onClick={checkQuiz}>Check</button>
+            {quizResult && <p>{quizResult}</p>}
           </div>
         </CompletionModal>
       )}

--- a/nextjs-app/src/styles/IntroGame.module.css
+++ b/nextjs-app/src/styles/IntroGame.module.css
@@ -54,6 +54,26 @@
   margin-top: 0.5rem;
 }
 
+.debug {
+  white-space: pre-wrap;
+  background: #f0f0f0;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow: auto;
+}
+
+.quiz {
+  margin-top: 1rem;
+  text-align: left;
+}
+
+.quiz label {
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
 .final-score {
   font-size: 1.3rem;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- broaden intro modal with extra details
- add fallback API route for sentence suggestions
- fetch dynamic sentences during play
- give hints and show debug info while reviewing
- show a quick quiz on completion
- add new email contexts
- style hints, debug view and quiz

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852b4a7c5b4832fbbba2302f142f173