### PR TITLE
Implement sequential adventure flow

### DIFF
--- a/learning-games/src/components/ui/AdventureProgress.css
+++ b/learning-games/src/components/ui/AdventureProgress.css
@@ -1,0 +1,33 @@
+.adventure-progress {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin: 1rem 0;
+  padding: 0;
+}
+
+.adventure-progress li {
+  text-align: center;
+  color: var(--color-text-dark);
+  font-size: 0.85rem;
+}
+
+.adventure-progress .step-num {
+  width: 2rem;
+  height: 2rem;
+  line-height: 2rem;
+  border-radius: 50%;
+  background: var(--color-secondary);
+  color: #fff;
+  display: inline-block;
+  margin-bottom: 0.25rem;
+}
+
+.adventure-progress li.done .step-num {
+  background: var(--color-accent);
+}
+
+.adventure-progress li.current .step-num {
+  background: var(--color-brand);
+}

--- a/learning-games/src/components/ui/AdventureProgress.tsx
+++ b/learning-games/src/components/ui/AdventureProgress.tsx
@@ -1,0 +1,18 @@
+import { ADVENTURE_GAMES } from '../../utils/adventure'
+import './AdventureProgress.css'
+
+export default function AdventureProgress({ step }: { step: number }) {
+  return (
+    <ol className="adventure-progress">
+      {ADVENTURE_GAMES.map((g, idx) => (
+        <li
+          key={g.key}
+          className={`${idx < step ? 'done' : ''} ${idx === step ? 'current' : ''}`}
+        >
+          <span className="step-num">{idx + 1}</span>
+          <span className="step-label">{g.title}</span>
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/learning-games/src/pages/Home.css
+++ b/learning-games/src/pages/Home.css
@@ -170,3 +170,20 @@
   object-fit: cover;
   border-radius: 4px;
 }
+.game-card.locked {
+  filter: grayscale(1);
+  opacity: 0.5;
+  pointer-events: none;
+  position: relative;
+}
+.game-card.locked::after {
+  content: 'Locked';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}

--- a/learning-games/src/pages/Home.tsx
+++ b/learning-games/src/pages/Home.tsx
@@ -6,6 +6,8 @@ import { getTotalPoints } from '../utils/user'
 import './Home.css'
 import { GOAL_POINTS } from '../constants/progress'
 import ProgressSummary from '../components/ProgressSummary'
+import AdventureProgress from '../components/ui/AdventureProgress'
+import { ADVENTURE_GAMES, getAdventureStep } from '../utils/adventure'
 
 /**
  * Home page listing available games.
@@ -14,6 +16,8 @@ import ProgressSummary from '../components/ProgressSummary'
 export default function Home() {
   const { user } = useContext(UserContext) as UserContextType
   const navigate = useNavigate()
+  const step = getAdventureStep(user.points)
+  const nextGame = ADVENTURE_GAMES[step]
 
   // Redirect to the age form if age hasn't been provided yet
   // Temporarily disabled so the home page loads without requiring age
@@ -55,10 +59,15 @@ export default function Home() {
         />
         <p className="tagline">Play engaging games and sharpen your skills.</p>
 
-        <button onClick={() => navigate('/games/tone')} className="btn-primary" aria-label="Play Tone Puzzle">
-
-          Play Now
-        </button>
+        {nextGame && (
+          <button
+            onClick={() => navigate(nextGame.path)}
+            className="btn-primary"
+            aria-label="Play next game"
+          >
+            Play
+          </button>
+        )}
         <button
           onClick={() => navigate('/community')}
           className="btn-primary"
@@ -77,6 +86,8 @@ export default function Home() {
         </button>
       </section>
 
+      <AdventureProgress step={step} />
+
 
       {/* greeting - temporarily disabled per UX review */}
       {/**
@@ -87,58 +98,32 @@ export default function Home() {
       )}
       */}
 
+
       {/* game list */}
       <div className="game-grid reveal">
-        <Link className="game-card" to="/games/tone">
-          <img
-            src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3V3YmcybDA1YTExbGhzcDJ4OXFpNGlnMmlkbWt3dGI2dWRraTh2eSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Z9EX1jzpulWOyM43uG/giphy.gif"
-            alt="Tone puzzle preview"
-            className="game-icon"
-          />
-          <span className="game-title">Tone Puzzle</span>
-        </Link>
-        <Link className="game-card" to="/games/quiz">
-          <img
-            src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTZoaHpxY3AwbmN1OTMwN3dkY3c5eXI1eXB3cDJ5ajNudDdkcnJ6cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9dg/SR6WK6jz0rRWf2QK0t/giphy.gif"
-            alt="Hallucinations preview"
-            className="game-icon"
-          />
-          <span className="game-title">Hallucinations</span>
-        </Link>
-        <Link className="game-card" to="/games/escape">
-          <img
-            src="https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGxwaGF2eGNmcW1mZzFqNWJhOGs2bmcxZm9scHN4a21ka2ttanhrdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vZFZFVYQvtdidWZltF/giphy.gif"
-            alt="Escape room preview"
-            className="game-icon"
-          />
-          <span className="game-title">Escape Room</span>
-        </Link>
-        <Link className="game-card" to="/games/recipe">
-          <img
-            src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3h3cTR0cmEybWt0ZGM2Ymx0ZHB4ZjltbmR2dG55M3Y0MWh6dnRjZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ll22OhMLAlVDbDS3Mo/giphy.gif"
-            alt="Prompt recipe preview"
-
-            className="game-icon"
-          />
-          <span className="game-title">Prompt Builder</span>
-        </Link>        <Link className="game-card" to="/games/darts">
-          <img
-            src="https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMW0xZHBmOTl3bWo3bmx6NDNmcjBkamo2a3prd242NjVmZzJvOTlkZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SvhOn6vnGXp0BiqlEc/giphy.gif"
-            alt="Prompt darts preview"
-            className="game-icon"
-          />
-          <span className="game-title">Prompt Darts</span>
-        </Link>
-        <Link className="game-card" to="/games/chain">
-          <img
-            src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeW1waDgxcTJjZms2bGZvZjFxZzBwMGgzcGRvNWVob2R0dWo0aGQybiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o7abKhOpu0NwenH3O/giphy.gif"
-            alt="Prompt chain challenge preview"
-            className="game-icon"
-          />
-          <span className="game-title">Prompt Chain</span>
-        </Link>
+        {ADVENTURE_GAMES.map((g, idx) => (
+          <Link
+            key={g.key}
+            className={`game-card${idx > step ? ' locked' : ''}`}
+            to={g.path}
+          >
+            <img
+              src={
+                g.key === 'tone'
+                  ? 'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3V3YmcybDA1YTexbGhzcDJ4OXFpNGlnMmlkbWt3dGI2dWRraTh2eSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Z9EX1jzpulWOyM43uG/giphy.gif'
+                  : g.key === 'quiz'
+                  ? 'https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTZoaHpxY3AwbmN1OTMwN3dkY3c5eXI1eXB3cDJ5ajNudDdkcnJ6cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9dg/SR6WK6jz0rRWf2QK0t/giphy.gif'
+                  : g.key === 'recipe'
+                  ? 'https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3h3cTR0cmEybWt0ZGM2Ymx0ZHB4ZjltbmR2dG55M3Y0MWh6dnRjZCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Ll22OhMLAlVDbDS3Mo/giphy.gif'
+                  : 'https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGxwaGF2eGNmcW1mZzFqNWJhOGs2bmcxZm9scHN4a21ka2ttanhrdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vZFZFVYQvtdidWZltF/giphy.gif'
+              }
+              alt={`${g.title} preview`}
+              className="game-icon"
+            />
+            <span className="game-title">{g.title}</span>
+          </Link>
+        ))}
       </div>
-
       {/* navigation */}
       <p className="reveal">
         <Link to="/leaderboard">View Progress</Link>

--- a/learning-games/src/pages/Match3Game.tsx
+++ b/learning-games/src/pages/Match3Game.tsx
@@ -9,6 +9,8 @@ import type { UserContextType } from "../../../shared/types/user";
 import RobotChat from "../components/RobotChat";
 import InstructionBanner from "../components/ui/InstructionBanner";
 import WhyCard from "../components/layout/WhyCard";
+import AdventureProgress from "../components/ui/AdventureProgress";
+import { getAdventureStep, getNextGame, pointsToStars } from "../utils/adventure";
 
 const quotes = [
   "Prompting is like seasoning \u2013 a single word changes the flavor.",
@@ -169,6 +171,16 @@ export default function Match3Game() {
       tips[Math.floor(Math.random() * tips.length)],
   )
   const [showComplete, setShowComplete] = useState(false)
+  const [finalScore, setFinalScore] = useState(0)
+  const step = getAdventureStep(user.points)
+  const next = getNextGame(user.points)
+
+  useEffect(() => {
+    if (showComplete && next) {
+      const id = setTimeout(() => navigate(next.path), 2000)
+      return () => clearTimeout(id)
+    }
+  }, [showComplete, next, navigate])
 
   function handleComplete(score: number) {
     const earned: string[] = [];
@@ -191,12 +203,14 @@ export default function Match3Game() {
       confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
     }
     notify(msg);
+    setFinalScore(score)
     setShowComplete(true);
   }
 
   if (showComplete) {
     return (
       <div id="main-content" className="match3-page">
+        <AdventureProgress step={step} />
         <div className="congrats-overlay">
           <div className="congrats-modal" role="dialog" aria-modal="true">
             <img
@@ -204,14 +218,17 @@ export default function Match3Game() {
               alt="Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble."
               style={{ width: '200px', display: 'block', margin: '0 auto' }}
             />
-            <p>Great job matching tones! Ready for a quick quiz?</p>
-            <button
-              className="btn-primary"
-              onClick={() => navigate('/games/quiz')}
-              style={{ display: 'block', marginTop: '0.5rem' }}
-            >
-              Start Quiz
-            </button>
+            <p>Great job matching tones!</p>
+            <p>Stars earned: {'{'}'⭐'.repeat(pointsToStars(finalScore)){'}'}</p>
+            {next && (
+              <button
+                className="btn-primary"
+                onClick={() => navigate(next.path)}
+                style={{ display: 'block', marginTop: '0.5rem' }}
+              >
+                Next Game
+              </button>
+            )}
             <a
               className="coffee-link"
               href="https://coff.ee/strawberrytech"
@@ -229,6 +246,7 @@ export default function Match3Game() {
 
   return (
     <div id="main-content" className="match3-page">
+      <AdventureProgress step={step} />
       <InstructionBanner>
         Match adjectives to explore how tone changes the meaning of a message.
       </InstructionBanner>

--- a/learning-games/src/pages/PromptRecipeGame.tsx
+++ b/learning-games/src/pages/PromptRecipeGame.tsx
@@ -12,6 +12,8 @@ import Tooltip from '../components/ui/Tooltip'
 import TimerBar from '../components/ui/TimerBar'
 import { UserContext } from '../shared/UserContext'
 import { getTimeLimit } from '../utils/time'
+import AdventureProgress from '../components/ui/AdventureProgress'
+import { getAdventureStep, getNextGame, pointsToStars } from '../utils/adventure'
 import './PromptRecipeGame.css'
 import {
   type Slot,
@@ -51,6 +53,9 @@ export default function PromptRecipeGame() {
   const [selectedCard, setSelectedCard] = useState<Card | null>(null)
   const [round, setRound] = useState(0)
   const [finished, setFinished] = useState(false)
+  const [finalScore, setFinalScore] = useState(0)
+  const step = getAdventureStep(user.points)
+  const next = getNextGame(user.points)
   const [feedback, setFeedback] = useState<Record<Slot, 'correct' | 'wrong' | null>>({
     Action: null,
     Context: null,
@@ -100,6 +105,13 @@ export default function PromptRecipeGame() {
     }, 1000)
     return () => clearInterval(id)
   }, [showPrompt])
+
+  useEffect(() => {
+    if (finished && next) {
+      const id = setTimeout(() => navigate(next.path), 2000)
+      return () => clearTimeout(id)
+    }
+  }, [finished, next, navigate])
 
   useEffect(() => {
     if (showPrompt) {
@@ -181,6 +193,7 @@ export default function PromptRecipeGame() {
     if (round + 1 < TOTAL_ROUNDS) {
       setRound(r => r + 1)
     } else {
+      setFinalScore(points)
       setFinished(true)
       setPoints('recipe', points)
     }
@@ -284,11 +297,12 @@ export default function PromptRecipeGame() {
     return (
       <CompletionModal
         imageSrc="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png"
-        buttonHref="/games/darts"
-        buttonLabel="Play Prompt Darts"
+        buttonHref={next ? next.path : '/'}
+        buttonLabel="Next Game"
       >
+        <AdventureProgress step={step} />
         <h3>You finished Prompt Builder!</h3>
-        <p className="final-score">Your points: {points}</p>
+        <p className="final-score">Stars earned: {'{'}'⭐'.repeat(pointsToStars(finalScore)){'}'}</p>
       </CompletionModal>
     )
   }
@@ -298,6 +312,7 @@ export default function PromptRecipeGame() {
 
   return (
     <div id="main-content" className="recipe-page">
+      <AdventureProgress step={step} />
       <InstructionBanner>
         Drag each card to the category it best fits to build a clear AI prompt.
       </InstructionBanner>

--- a/learning-games/src/utils/adventure.ts
+++ b/learning-games/src/utils/adventure.ts
@@ -1,0 +1,24 @@
+export const ADVENTURE_GAMES = [
+  { key: 'tone', path: '/games/tone', title: 'Tone Puzzle' },
+  { key: 'quiz', path: '/games/quiz', title: 'Hallucinations' },
+  { key: 'recipe', path: '/games/recipe', title: 'Prompt Builder' },
+  { key: 'escape', path: '/games/escape', title: 'Escape Room' },
+] as const
+
+export type AdventureGameKey = typeof ADVENTURE_GAMES[number]['key']
+
+export function getAdventureStep(points: Record<string, number>): number {
+  for (let i = 0; i < ADVENTURE_GAMES.length; i++) {
+    if (!points[ADVENTURE_GAMES[i].key]) return i
+  }
+  return ADVENTURE_GAMES.length
+}
+
+export function getNextGame(points: Record<string, number>) {
+  const step = getAdventureStep(points)
+  return ADVENTURE_GAMES[step] ?? null
+}
+
+export function pointsToStars(points: number): number {
+  return Math.max(1, Math.round(points / 50))
+}


### PR DESCRIPTION
## Summary
- add `adventure.ts` helpers for the new game sequence
- show progress with `AdventureProgress` component
- lock upcoming games on the home screen
- display stars earned and auto-advance after each game
- update home and game pages for the streamlined adventure

## Testing
- `USE_LOCAL_STORE=true npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687eab5e9788832f92fe5c791d906da5